### PR TITLE
Add cfg(test) to mod tests in mem_table.rs.

### DIFF
--- a/mini-lsm-starter/src/mem_table.rs
+++ b/mini-lsm-starter/src/mem_table.rs
@@ -75,4 +75,5 @@ impl StorageIterator for MemTableIterator {
     }
 }
 
+#[cfg(test)]
 mod tests;


### PR DESCRIPTION
The tempfile dependency causes build failure due to being in dev-dependencies. Adding cfg(test) fixes the isseue.