### PR TITLE
Fixed typo: varlen -> keylen

### DIFF
--- a/mini-lsm-book/src/01-block.md
+++ b/mini-lsm-book/src/01-block.md
@@ -30,7 +30,7 @@ When user adds a key-value pair to a block (which is an entry), we will need to 
 
 ```
 |                             entry1                            |
-| key_len (2B) | key (varlen) | value_len (2B) | value (varlen) | ... |
+| key_len (2B) | key (keylen) | value_len (2B) | value (varlen) | ... |
 ```
 
 Key length and value length are 2B, which means their maximum length is 65536.


### PR DESCRIPTION
fix(docs): typo in part 1