### PR TITLE
update rustc version

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.66"
+channel = "1.70.0"
 components = [ "rustfmt", "clippy" ]
 profile = "minimal"


### PR DESCRIPTION
run command `cargo x install-tools` will get this error:

```
package `anstream v0.6.5` cannot be built because it requires rustc 1.70.0 or newer, while the currently active rustc version is 1.66.1
Either upgrade to rustc 1.70.0 or newer, or use
cargo update -p anstream@0.6.5 --precise ver
where `ver` is the latest version of `anstream` supporting rustc 1.66.1
```

I update my rustc version, it turns out that this file use older rustc version.
I prefer to use latest stable version which is `1.74.1`, but `1.70.0` is enough to solve this problem.