### PR TITLE
Fix W1D6 test

### DIFF
--- a/mini-lsm/src/tests/week1_day6.rs
+++ b/mini-lsm/src/tests/week1_day6.rs
@@ -193,5 +193,5 @@ fn test_task3_sst_filter() {
             Bound::Excluded(format!("{:05}", 6000).as_bytes()),
         )
         .unwrap();
-    assert!(min_num < iter.num_active_iterators() && iter.num_active_iterators() < max_num);
+    assert!(min_num <= iter.num_active_iterators() && iter.num_active_iterators() < max_num);
 }


### PR DESCRIPTION
The assert is changed to: `assert!(min_num <= iter.num_active_iterators() && iter.num_active_iterators() < max_num);`


Reasoning:
The sstables should look like the following (format: (id, first_key, last_key)):
```
[(0, b"00001", b"00999"), 
(1, b"01000", b"01999"), 
(2, b"02000", b"02999"), 
(3, b"03000", b"03999"), 
(4, b"04000", b"04999"), 
(5, b"05000", b"05999"), 
(6, b"06000", b"06999"), 
(7, b"07000", b"07999"), 
(8, b"08000", b"08999"), 
(9, b"09000", b"09999")]
```
Given query 
```rust
let iter = storage
        .scan(
            Bound::Included(format!("{:05}", 5000).as_bytes()),
            Bound::Excluded(format!("{:05}", 6000).as_bytes()),
        )
        .unwrap();
```
it's correct for the filter to only return the Sstable with id=5, and thus `min_num <= iter.num_active_iterators()`.