### PR TITLE
Added print functionality to iters to allow simpler debugging

### DIFF
--- a/mini-lsm-mvcc/src/iterators.rs
+++ b/mini-lsm-mvcc/src/iterators.rs
@@ -23,4 +23,9 @@ pub trait StorageIterator {
     fn num_active_iterators(&self) -> usize {
         1
     }
+
+    /// Print the current state of the iterator to the console
+    fn print(&self) {
+        println!("Print functionality not implemented for this iterator");
+    }
 }

--- a/mini-lsm/src/block/iterator.rs
+++ b/mini-lsm/src/block/iterator.rs
@@ -134,4 +134,44 @@ impl BlockIterator {
         }
         self.seek_to(low);
     }
+
+    pub fn print(&self) {
+        let separator = "-".repeat(10); // Ensure a consistent separator length
+        println!(
+            "{} {} {}",
+            separator,
+            format!("{:^25}", "Block Iterator"),
+            separator
+        );
+
+        if self.is_valid() {
+            // Ensuring that the spaces between descriptions and values are consistent
+            println!(
+                "{:<20}: {:?}",
+                "First Key",
+                String::from_utf8_lossy(&self.first_key.raw_ref())
+            );
+            println!(
+                "{:<20}: {:?}",
+                "Current Key",
+                String::from_utf8_lossy(&self.key.raw_ref())
+            );
+            println!(
+                "{:<20}: {:?}",
+                "Current Value",
+                String::from_utf8_lossy(&self.value())
+            );
+            println!("{:<20}: {}", "Key Index", self.idx);
+            // Print block details if needed
+            self.block.print();
+        } else {
+            println!("{:<20}", "This block iterator is not valid");
+        }
+        println!(
+            "{} {} {}",
+            separator,
+            format!("{:^25}", "Block Iterator End"),
+            separator
+        );
+    }
 }

--- a/mini-lsm/src/iterators.rs
+++ b/mini-lsm/src/iterators.rs
@@ -23,4 +23,9 @@ pub trait StorageIterator {
     fn num_active_iterators(&self) -> usize {
         1
     }
+
+    /// Print the current state of the iterator to the console
+    fn print(&self) {
+        println!("Print functionality not implemented for this iterator");
+    }
 }

--- a/mini-lsm/src/iterators/merge_iterator.rs
+++ b/mini-lsm/src/iterators/merge_iterator.rs
@@ -152,4 +152,42 @@ impl<I: 'static + for<'a> StorageIterator<KeyType<'a> = KeySlice<'a>>> StorageIt
                 .map(|x| x.1.num_active_iterators())
                 .unwrap_or(0)
     }
+
+    /// Prints the current state of the MergeIterator, including the active iterator and the state of iterators in the heap.
+    fn print(&self) {
+        let sep = "-".repeat(10);
+        println!("{} {} {}\n", sep, format!("{:^25}", "Merge Iterator"), sep);
+
+        // Print the current active iterator's state
+        if let Some(current) = &self.current {
+            if current.1.is_valid() {
+                println!("Current Iterator (Index {}):", current.0);
+                current.1.print();
+            } else {
+                println!("Active Iterator (Index {}) is invalid", current.0);
+            }
+        } else {
+            println!("No active iterator");
+        }
+
+        // Print the state of iterators in the heap
+        println!();
+        println!("Iterators in Heap:");
+        for heap_wrapper in self.iters.iter() {
+            let valid_status = if heap_wrapper.1.is_valid() {
+                "Valid"
+            } else {
+                "Invalid"
+            };
+            println!("Iterator Index {}: {}", heap_wrapper.0, valid_status);
+            heap_wrapper.1.print();
+        }
+
+        println!(
+            "{} {} {}",
+            sep,
+            format!("{:^25}", "End Merge Iterator"),
+            sep
+        );
+    }
 }

--- a/mini-lsm/src/iterators/merge_iterator.rs
+++ b/mini-lsm/src/iterators/merge_iterator.rs
@@ -172,7 +172,7 @@ impl<I: 'static + for<'a> StorageIterator<KeyType<'a> = KeySlice<'a>>> StorageIt
 
         // Print the state of iterators in the heap
         println!();
-        println!("Iterators in Heap:");
+        println!("Iterators in Heap: {}", self.iters.len());
         for heap_wrapper in self.iters.iter() {
             let valid_status = if heap_wrapper.1.is_valid() {
                 "Valid"

--- a/mini-lsm/src/iterators/two_merge_iterator.rs
+++ b/mini-lsm/src/iterators/two_merge_iterator.rs
@@ -89,4 +89,47 @@ impl<
     fn num_active_iterators(&self) -> usize {
         self.a.num_active_iterators() + self.b.num_active_iterators()
     }
+
+    fn print(&self) {
+        let x_separator = "x".repeat(10);
+        let dash_separator = "-".repeat(10);
+        println!(
+            "{} {} {}",
+            x_separator,
+            format!("{:^25}", "TWO_MERGE_ITERATOR"),
+            x_separator
+        );
+        println!(
+            "{} {} {}",
+            dash_separator,
+            format!("{:^25}", "ITERATOR A"),
+            dash_separator
+        );
+        self.a.print();
+        println!(
+            "{} {} {}\n",
+            dash_separator,
+            format!("{:^25}", "END ITERATOR A"),
+            dash_separator
+        );
+        println!(
+            "{} {} {}",
+            dash_separator,
+            format!("{:^25}", "ITERATOR B"),
+            dash_separator
+        );
+        self.b.print();
+        println!(
+            "{} {} {}",
+            dash_separator,
+            format!("{:^25}", "END ITERATOR B"),
+            dash_separator
+        );
+        println!(
+            "{} {} {}\n",
+            x_separator,
+            format!("{:^25}", "END TWO_MERGE_ITERATOR"),
+            x_separator
+        );
+    }
 }

--- a/mini-lsm/src/lsm_iterator.rs
+++ b/mini-lsm/src/lsm_iterator.rs
@@ -79,6 +79,10 @@ impl StorageIterator for LsmIterator {
     fn num_active_iterators(&self) -> usize {
         self.inner.num_active_iterators()
     }
+
+    fn print(&self) {
+        self.inner.print();
+    }
 }
 
 /// A wrapper around existing iterator, will prevent users from calling `next` when the iterator is
@@ -135,5 +139,9 @@ impl<I: StorageIterator> StorageIterator for FusedIterator<I> {
 
     fn num_active_iterators(&self) -> usize {
         self.iter.num_active_iterators()
+    }
+
+    fn print(&self) {
+        self.iter.print();
     }
 }

--- a/mini-lsm/src/mem_table.rs
+++ b/mini-lsm/src/mem_table.rs
@@ -193,4 +193,35 @@ impl StorageIterator for MemTableIterator {
         self.with_mut(|x| *x.item = entry);
         Ok(())
     }
+
+    /// Prints the current key-value pair to the console.
+    fn print(&self) {
+        let sep = "-".repeat(10);
+        println!("{} {} {}", sep, format!("{:^25}", "Memtable Iterator"), sep);
+        if self.is_valid() {
+            let key = self.with_item(|item| &item.0);
+            let value = self.with_item(|item| &item.1);
+
+            // Attempt to convert both key and value to UTF-8 strings for readable printing.
+            let key_str = match std::str::from_utf8(key) {
+                Ok(s) => s.to_string(),
+                Err(_) => format!("{:X?}", key), // Fallback to hex representation if not valid UTF-8
+            };
+
+            let value_str = match std::str::from_utf8(value) {
+                Ok(s) => s.to_string(),
+                Err(_) => format!("{:X?}", value), // Fallback to hex representation if not valid UTF-8
+            };
+            println!("{:<10}: {:?}", "Key", key_str);
+            println!("{:<10}: {:?}", "Value", value_str);
+        } else {
+            println!("Invalid Iterator State");
+        }
+        println!(
+            "{} {} {}",
+            sep,
+            format!("{:^25}", "End Memtable Iterator"),
+            sep
+        );
+    }
 }

--- a/mini-lsm/src/table/iterator.rs
+++ b/mini-lsm/src/table/iterator.rs
@@ -102,4 +102,22 @@ impl StorageIterator for SsTableIterator {
         }
         Ok(())
     }
+
+    fn print(&self) {
+        let separator = "-".repeat(10);
+        println!(
+            "{} {} {}",
+            separator,
+            format!("{:^25}", "SST_ITERATOR"),
+            separator
+        );
+        println!("Current Block Index: {}", self.blk_idx);
+        self.blk_iter.print();
+        println!(
+            "{} {} {}",
+            separator,
+            format!("{:^25}", "SST_ITERATOR_END"),
+            separator
+        );
+    }
 }

--- a/mini-lsm/src/tests/harness.rs
+++ b/mini-lsm/src/tests/harness.rs
@@ -83,6 +83,40 @@ impl StorageIterator for MockIterator {
         }
         self.index < self.data.len()
     }
+
+    /// Prints the current state of the iterator, including the current key-value pair and the position.
+    fn print(&self) {
+        let separator = "-".repeat(10);
+        println!(
+            "{} {} {}",
+            separator,
+            format!("{:^25}", "MOCK_ITERATOR"),
+            separator
+        );
+        if self.is_valid() {
+            let (key, value) = &self.data[self.index];
+            let key_str = String::from_utf8_lossy(key);
+            let value_str = String::from_utf8_lossy(value);
+            println!(
+                "Index: {}, Key: {}, Value: {}",
+                self.index, key_str, value_str
+            );
+        } else {
+            println!("Index: {}, Iterator is not valid.", self.index);
+        }
+
+        if let Some(error_when) = self.error_when {
+            if self.index == error_when {
+                println!("An error is scheduled to occur at this index.");
+            }
+        }
+        println!(
+            "{} {} {}",
+            separator,
+            format!("{:^25}", "MOCK_ITERATOR_END"),
+            separator
+        );
+    }
 }
 
 pub fn as_bytes(x: &[u8]) -> Bytes {
@@ -165,6 +199,7 @@ where
             v,
             as_bytes(iter.value()),
         );
+        iter.print();
         iter.next().unwrap();
     }
     assert!(!iter.is_valid());


### PR DESCRIPTION
## What This PR Does

* Adds print functionality to all iterators
* Ensures proper formatting for each iterator

Sample output for a two merge iterator shown below

```
xxxxxxxxxx    TWO_MERGE_ITERATOR     xxxxxxxxxx
----------        ITERATOR A         ----------
----------      Merge Iterator       ----------

Current Iterator (Index 1):
----------     Memtable Iterator     ----------
Key       : "00"
Value     : "2333"
----------   End Memtable Iterator   ----------

Iterators in Heap: 1
Iterator Index 0: Valid
----------     Memtable Iterator     ----------
Key       : "1"
Value     : ""
----------   End Memtable Iterator   ----------
----------    End Merge Iterator     ----------
----------      END ITERATOR A       ----------

----------        ITERATOR B         ----------
----------      Merge Iterator       ----------

Current Iterator (Index 1):
----------       SST_ITERATOR        ----------
Current Block Index: 0
----------      Block Iterator       ----------
First Key           : "0"
Current Key         : "0"
Current Value       : "2333333"
Key Index           : 0
==========   Block    ==========
Index     : 0
Key       : 0
Value     : 2333333
--------------------
Index     : 1
Key       : 00
Value     : 2333333
--------------------
Index     : 2
Key       : 4
Value     : 23
--------------------
Offsets: [0, 14, 28]
========== End Block  ==========
----------    Block Iterator End     ----------
----------     SST_ITERATOR_END      ----------

Iterators in Heap: 1
Iterator Index 0: Valid
----------       SST_ITERATOR        ----------
Current Block Index: 0
----------      Block Iterator       ----------
First Key           : "4"
Current Key         : "4"
Current Value       : ""
Key Index           : 0
==========   Block    ==========
Index     : 0
Key       : 4
Value     : 
--------------------
Offsets: [0]
========== End Block  ==========
----------    Block Iterator End     ----------
----------     SST_ITERATOR_END      ----------
----------    End Merge Iterator     ----------
----------      END ITERATOR B       ----------
xxxxxxxxxx  END TWO_MERGE_ITERATOR   xxxxxxxxxx
```

## Questions
 - One point to note is that the decoding scheme used for a block is the compressed key format implemented on week 1 day 7. Should that be the decoding scheme while printing? 
 - Should this be left as an exercise for the student since they are expected to implement an encoding decoding scheme anyway?