### PR TITLE
test: test scan exclusive start on a sstable

### DIFF
--- a/mini-lsm/src/tests/week1_day5.rs
+++ b/mini-lsm/src/tests/week1_day5.rs
@@ -187,6 +187,21 @@ fn test_task2_storage_scan() {
             .unwrap(),
         vec![(Bytes::from("2"), Bytes::from("2333"))],
     );
+    check_lsm_iter_result_by_key(
+        &mut storage
+            .scan(Bound::Included(b"0"), Bound::Included(b"1"))
+            .unwrap(),
+        vec![
+            (Bytes::from_static(b"0"), Bytes::from_static(b"2333333")),
+            (Bytes::from("00"), Bytes::from("2333")),
+        ],
+    );
+    check_lsm_iter_result_by_key(
+        &mut storage
+            .scan(Bound::Excluded(b"0"), Bound::Included(b"1"))
+            .unwrap(),
+        vec![(Bytes::from("00"), Bytes::from("2333"))],
+    );
 }
 
 #[test]


### PR DESCRIPTION
Add a case when scan with an exclusive start where the start key locates on a sstable