### PR TITLE
fix: call lsm::close when closing the cli

### DIFF
--- a/mini-lsm-starter/src/bin/mini-lsm-cli.rs
+++ b/mini-lsm-starter/src/bin/mini-lsm-cli.rs
@@ -121,7 +121,10 @@ impl ReplHandler {
                 self.lsm.force_full_compaction()?;
                 println!("full compaction success");
             }
-            Command::Quit | Command::Close => std::process::exit(0),
+            Command::Quit | Command::Close => {
+                self.lsm.close()?;
+                std::process::exit(0);
+            }
         };
 
         self.epoch += 1;


### PR DESCRIPTION
When executing `close` command in cli repl, mini lsm should call its `close` function to update state and manifest.