### PR TITLE
fix: typo in md (iter->tier)

### DIFF
--- a/mini-lsm-book/src/week2-03-tiered.md
+++ b/mini-lsm-book/src/week2-03-tiered.md
@@ -76,7 +76,7 @@ L67 (1): [67]
 L40 (27): [39, 38, 37, 36, 35, 34, 33, 32, 31, 30, 29, 28, 27, 26, 25, 24, 23, 22, 13, 14, 15, 16, 17, 18, 19, 20, 21]
 ```
 
-The `num_iters` in the compaction simulator is set to 3. However, there are far more than 3 iters in the LSM state, which incurs large read amplification.
+The `num_tiers` in the compaction simulator is set to 3. However, there are far more than 3 tiers in the LSM state, which incurs large read amplification.
 
 The current trigger only reduces space amplification. We will need to add new triggers to the compaction algorithm to reduce read amplification.
 


### PR DESCRIPTION
I think the description in md:

https://github.com/skyzh/mini-lsm/blob/2015ee17032b551d964b5f9fbb8d1ff2165673de/mini-lsm-book/src/week2-03-tiered.md?plain=1#L79

"num_iter" and "iter" should be "num_tier" and "tier" 

as in the code:

https://github.com/skyzh/mini-lsm/blob/2015ee17032b551d964b5f9fbb8d1ff2165673de/mini-lsm-starter/src/bin/mini-lsm-cli.rs#L330