### PR TITLE
Fix typos in W3D5 writeup and code

### DIFF
--- a/mini-lsm-book/src/week3-05-txn-occ.md
+++ b/mini-lsm-book/src/week3-05-txn-occ.md
@@ -27,7 +27,7 @@ In this task, you will need to modify:
 src/txn.rs
 ```
 
-For `get`, you should first probe the local storage. If a value is found, return the value or `None` depending on whether it is a deletion marker. For `scan`, you will need to implement a `TxnLocalIterator` for the skiplist as in chapter 1.1 when you implement the iterator for a memtable without key timestamp. You will need to store a `TwoMergeIterator<TxnLocalIterator, FusedIterator<LsmIterator>>` in the `TxnLocalIterator`. And, lastly, given that the `TwoMergeIterator` will retain the deletion markers in the child iterators, you will need to modify your `TxnIterator` implementation to correctly handle deletions.
+For `get`, you should first probe the local storage. If a value is found, return the value or `None` depending on whether it is a deletion marker. For `scan`, you will need to implement a `TxnLocalIterator` for the skiplist as in chapter 1.1 when you implement the iterator for a memtable without key timestamp. You will need to store a `TwoMergeIterator<TxnLocalIterator, FusedIterator<LsmIterator>>` in the `TxnIterator`. And, lastly, given that the `TwoMergeIterator` will retain the deletion markers in the child iterators, you will need to modify your `TxnIterator` implementation to correctly handle deletions.
 
 ## Task 3: Commit
 

--- a/mini-lsm-mvcc/src/mvcc/txn.rs
+++ b/mini-lsm-mvcc/src/mvcc/txn.rs
@@ -179,7 +179,7 @@ type SkipMapRangeIter<'a> =
 pub struct TxnLocalIterator {
     /// Stores a reference to the skipmap.
     map: Arc<SkipMap<Bytes, Bytes>>,
-    /// Stores a skipmap iterator that refers to the lifetime of `MemTableIterator` itself.
+    /// Stores a skipmap iterator that refers to the lifetime of `TxnLocalIterator` itself.
     #[borrows(map)]
     #[not_covariant]
     iter: SkipMapRangeIter<'this>,

--- a/mini-lsm-starter/src/mvcc/txn.rs
+++ b/mini-lsm-starter/src/mvcc/txn.rs
@@ -61,7 +61,7 @@ type SkipMapRangeIter<'a> =
 pub struct TxnLocalIterator {
     /// Stores a reference to the skipmap.
     map: Arc<SkipMap<Bytes, Bytes>>,
-    /// Stores a skipmap iterator that refers to the lifetime of `MemTableIterator` itself.
+    /// Stores a skipmap iterator that refers to the lifetime of `TxnLocalIterator` itself.
     #[borrows(map)]
     #[not_covariant]
     iter: SkipMapRangeIter<'this>,


### PR DESCRIPTION
Pretty trivial fixes of typos.