### PR TITLE
[fix]: Fix typo in w1d6

### DIFF
--- a/mini-lsm-book/src/week1-06-write-path.md
+++ b/mini-lsm-book/src/week1-06-write-path.md
@@ -26,7 +26,7 @@ src/lsm_storage.rs
 src/mem_table.rs
 ```
 
-You will need to modify `LSMStorageInner::force_flush_next_imm_memtable` and `MemTable::flush`. In `LSMStorageInner::open`, you will need to create the LSM database directory if it does not exist. To flush a memtable to the disk, we will need to do two things:
+You will need to modify `LSMStorageInner::force_flush_next_imm_memtable` and `MemTable::flush`. In `LSMStorageInner::open`, you will need to create the LSM database directory if it does not exist. To flush a memtable to the disk, we will need to do three things:
 
 * Select a memtable to flush.
 * Create an SST file corresponding to a memtable.


### PR DESCRIPTION
"two" things -> "three" things

https://github.com/skyzh/mini-lsm/blob/bcaab6f706cb33ebaea6a1f00c444f84d924f309/mini-lsm-book/src/week1-06-write-path.md?plain=1#L29-L33