### PR TITLE
[test]: Modify test_sst_build_all() to add checks for first_key and last_key of SST

### DIFF
--- a/mini-lsm/src/tests/week1_day4.rs
+++ b/mini-lsm/src/tests/week1_day4.rs
@@ -57,7 +57,10 @@ fn generate_sst() -> (TempDir, SsTable) {
 fn test_sst_build_all() {
     let (_, sst) = generate_sst();
     assert_eq!(sst.first_key().as_key_slice(), key_of(0).as_key_slice());
-    assert_eq!(sst.last_key().as_key_slice(), key_of(num_of_keys()-1).as_key_slice())
+    assert_eq!(
+        sst.last_key().as_key_slice(),
+        key_of(num_of_keys() - 1).as_key_slice()
+    )
 }
 
 #[test]

--- a/mini-lsm/src/tests/week1_day4.rs
+++ b/mini-lsm/src/tests/week1_day4.rs
@@ -55,7 +55,9 @@ fn generate_sst() -> (TempDir, SsTable) {
 
 #[test]
 fn test_sst_build_all() {
-    generate_sst();
+    let (_, sst) = generate_sst();
+    assert_eq!(sst.first_key().as_key_slice(), key_of(0).as_key_slice());
+    assert_eq!(sst.last_key().as_key_slice(), key_of(num_of_keys()-1).as_key_slice())
 }
 
 #[test]


### PR DESCRIPTION
Hi, when I implemented W1D5, I found that my code can not pass `test_task2_storage_scan()`. It is caused by wrong result returned by `sst.first_key()` and `sst.last_key()` because of my missing in `SsTableBuilder.build()`

I think it's better to add checks within `test_sst_build_all()` in week1_day4 so that we can ensure the correctness of the SST implementation. What do you think?