### PR TITLE
Allow dead code in harness to eliminate warnings

### DIFF
--- a/mini-lsm/src/tests/harness.rs
+++ b/mini-lsm/src/tests/harness.rs
@@ -1,3 +1,4 @@
+#![allow(dead_code)] // REMOVE THIS LINE once all modules are complete
 use std::{
     collections::BTreeMap, ops::Bound, os::unix::fs::MetadataExt, path::Path, sync::Arc,
     time::Duration,


### PR DESCRIPTION
Without this, warnings are emitted until users get late in week 2.
```
warning: function `compaction_bench` is never used
   --> mini-lsm-starter/src/tests/harness.rs:221:8
    |
221 | pub fn compaction_bench(storage: Arc<MiniLsm>) {
    |        ^^^^^^^^^^^^^^^^
    |
    = note: `#[warn(dead_code)]` on by default

warning: function `check_compaction_ratio` is never used
   --> mini-lsm-starter/src/tests/harness.rs:283:8
    |
283 | pub fn check_compaction_ratio(storage: Arc<MiniLsm>) {
    |        ^^^^^^^^^^^^^^^^^^^^^^

warning: function `dump_files_in_dir` is never used
   --> mini-lsm-starter/src/tests/harness.rs:413:8
    |
413 | pub fn dump_files_in_dir(path: impl AsRef<Path>) {
    |        ^^^^^^^^^^^^^^^^^

warning: `mini-lsm-starter` (lib test) generated 3 warnings
```