### PR TITLE
chore: remove a duplicate attribute

### DIFF
--- a/mini-lsm-starter/src/wal.rs
+++ b/mini-lsm-starter/src/wal.rs
@@ -1,4 +1,3 @@
-#![allow(dead_code)]
 // REMOVE THIS LINE after fully implementing this functionality
 // Copyright (c) 2022-2025 Alex Chi Z
 //


### PR DESCRIPTION
Removes a duplicate attribute, as reported by Clippy.