### PR TITLE
sync: synchronize the methods used in the w3d4 test to mini-lsm-starter

### DIFF
--- a/mini-lsm-starter/src/lsm_storage.rs
+++ b/mini-lsm-starter/src/lsm_storage.rs
@@ -248,6 +248,10 @@ impl LsmStorageInner {
             .fetch_add(1, std::sync::atomic::Ordering::SeqCst)
     }
 
+    pub(crate) fn mvcc(&self) -> &LsmMvccInner {
+        self.mvcc.as_ref().unwrap()
+    }
+
     /// Start the storage engine by either loading an existing directory or creating a new one if the directory does
     /// not exist.
     pub(crate) fn open(path: impl AsRef<Path>, options: LsmStorageOptions) -> Result<Self> {

--- a/mini-lsm-starter/src/mvcc.rs
+++ b/mini-lsm-starter/src/mvcc.rs
@@ -16,7 +16,7 @@
 #![allow(dead_code)] // TODO(you): remove this lint after implementing this mod
 
 pub mod txn;
-mod watermark;
+pub mod watermark;
 
 use std::{
     collections::{BTreeMap, HashSet},

--- a/mini-lsm-starter/src/mvcc/watermark.rs
+++ b/mini-lsm-starter/src/mvcc/watermark.rs
@@ -32,6 +32,10 @@ impl Watermark {
 
     pub fn remove_reader(&mut self, ts: u64) {}
 
+    pub fn num_retained_snapshots(&self) -> usize {
+        unimplemented!()
+    }
+
     pub fn watermark(&self) -> Option<u64> {
         Some(0)
     }


### PR DESCRIPTION
The test of w3d4 uses methods that do not exist in mini-lsm-starter.