### PR TITLE
book: ‎LsmStorageInner::write_batch ‎method should be modified to call MemTable::put_batch

### DIFF
--- a/mini-lsm-book/src/week3-05-txn-occ.md
+++ b/mini-lsm-book/src/week3-05-txn-occ.md
@@ -52,6 +52,7 @@ In this task, you will need to modify:
 ```
 src/wal.rs
 src/mem_table.rs
+src/lsm_storage.rs
 ```
 
 Note that `commit` involves producing a write batch, and for now, the write batch does not guarantee atomicity. You will need to change the WAL implementation to produce a header and a footer for the write batch.


### PR DESCRIPTION
If the LsmStorageInner::write_batch is not modified, the atomicity of the WAL cannot be guaranteed.