### PR TITLE
explain copy-on-write strategy

### DIFF
--- a/mini-lsm-book/src/week1-01-memtable.md
+++ b/mini-lsm-book/src/week1-01-memtable.md
@@ -33,7 +33,7 @@ crossbeam-skiplist provides similar interfaces to the Rust std's `BTreeMap`: ins
 
 You will also notice that the `MemTable` structure does not have a `delete` interface. In the mini-lsm implementation, deletion is represented as a key corresponding to an empty value.
 
-In this task, you will need to implement `MemTable::get` and `MemTable::put` to enable modifications of the memtable. Note that `put` should always overwrite a key if it already exists. You won't have mutiple entries of the same key in a single memtable.
+In this task, you will need to implement `MemTable::get` and `MemTable::put` to enable modifications of the memtable. Note that `put` should always overwrite a key if it already exists. You won't have multiple entries of the same key in a single memtable.
 
 We use the `bytes` crate for storing the data in the memtable. `bytes::Byte` is similar to `Arc<[u8]>`. When you clone the `Bytes`, or get a slice of `Bytes`, the underlying data will not be copied, and therefore cloning it is cheap. Instead, it simply creates a new reference to the storage area and the storage area will be freed when there are no reference to that area.
 


### PR DESCRIPTION
I've added a short explanation for the `state: Arc<RwLock<Arc<LsmStorageState>>>` structure within `LsmStorageInner`, specifically outlining its Copy-on-Write (CoW) nature and how the nested `Arc`s and `RwLock` work together.

From a beginner's perspective, this particular nested type can look a bit daunting at first glance. My thinking was that a brief, friendly breakdown of *why* it's structured this way and what each part does could really help newcomers grasp the state management concepts more easily and make their learning journey smoother as they go through the material.
