### PR TITLE
docs: specify the updated `LsmIterator::new` constructor signature

### DIFF
--- a/mini-lsm-book/src/week1-05-read-path.md
+++ b/mini-lsm-book/src/week1-05-read-path.md
@@ -12,7 +12,6 @@ In this chapter, you will:
 * Implement LSM read path `get` with SSTs.
 * Implement LSM read path `scan` with SSTs.
 
-
 To copy the test cases into the starter code and run them,
 
 ```
@@ -21,7 +20,6 @@ cargo x scheck
 ```
 
 ## Task 1: Two Merge Iterator
-
 
 In this task, you will need to modify:
 
@@ -51,7 +49,13 @@ type LsmIteratorInner =
 
 So that our internal iterator of the LSM storage engine will be an iterator combining both data from the memtables and the SSTs.
 
-Note that our SST iterator does not support passing an end bound to it. Therefore, you will need to handle the `end_bound` manually in `LsmIterator`. You will need to modify your `LsmIterator` logic to stop when the key from the inner iterator reaches the end boundary.
+Currently, our SST iterator doesn't support an end bound for scans. To address this, you'll need to implement this boundary check within the `LsmIterator` itself. This involves updating the `LsmIterator::new` constructor to accept an `end_bound` parameter:
+
+```rust,no_run
+pub(crate) fn new(iter: LsmIteratorInner, end_bound: Bound<Bytes>) -> Result<Self> {}
+```
+
+You will then need to modify the `LsmIterator`'s iteration logic to ensure it stops when the keys from the inner iterator reach or exceed this specified `end_bound`.
 
 Our test cases will generate some memtables and SSTs in `l0_sstables`, and you will need to scan all of these data out correctly in this task. You do not need to flush SSTs until next chapter. Therefore, you can go ahead and modify your `LsmStorageInner::scan` interface to create a merge iterator over all memtables and SSTs, so as to finish the read path of your storage engine.
 

--- a/mini-lsm-starter/src/block/builder.rs
+++ b/mini-lsm-starter/src/block/builder.rs
@@ -38,6 +38,7 @@ impl BlockBuilder {
     }
 
     /// Adds a key-value pair to the block. Returns false when the block is full.
+    /// You may find the `bytes::BufMut` trait useful for manipulating binary data.
     #[must_use]
     pub fn add(&mut self, key: KeySlice, value: &[u8]) -> bool {
         unimplemented!()

--- a/mini-lsm-starter/src/table/builder.rs
+++ b/mini-lsm-starter/src/table/builder.rs
@@ -57,7 +57,7 @@ impl SsTableBuilder {
 
     /// Builds the SSTable and writes it to the given path. Use the `FileObject` structure to manipulate the disk objects.
     pub fn build(
-        self,
+        mut self,
         id: usize,
         block_cache: Option<Arc<BlockCache>>,
         path: impl AsRef<Path>,


### PR DESCRIPTION
quality of life updates:

+ add a hint about using `bytes::BufMut` for manipulating binary data
+ specify the updated `LsmIterator::new()` constructor signature
+ change `self` to `mut self` in `SsTableBuilder::build()`
