### PR TITLE
chore: fix many clippy warnings

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,8 +15,15 @@ jobs:
       - uses: actions/checkout@v2
       - name: setup rust toolchain
         run: rustup update && rustup toolchain install
-      - uses: taiki-e/install-action@nextest
-      - uses: taiki-e/install-action@mdbook
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: nextest
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: mdbook
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: mdbook-toc
       - name: patch for gh-pages build
         run: mv mini-lsm-book/theme/head.hbs._ mini-lsm-book/theme/head.hbs
       - name: check and build

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -15,7 +15,14 @@ jobs:
       - uses: actions/checkout@v2
       - name: setup rust toolchain
         run: rustup update && rustup toolchain install
-      - uses: taiki-e/install-action@nextest
-      - uses: taiki-e/install-action@mdbook
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: nextest
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: mdbook
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: mdbook-toc
       - name: check and build
         run: cargo x ci

--- a/mini-lsm-book/book.toml
+++ b/mini-lsm-book/book.toml
@@ -1,7 +1,6 @@
 [book]
 authors = ["Alex Chi Z"]
 language = "en"
-multilingual = false
 src = "src"
 title = "LSM in a Week"
 

--- a/mini-lsm-mvcc/src/block/iterator.rs
+++ b/mini-lsm-mvcc/src/block/iterator.rs
@@ -74,7 +74,7 @@ impl BlockIterator {
     }
 
     /// Returns the key of the current entry.
-    pub fn key(&self) -> KeySlice {
+    pub fn key(&self) -> KeySlice<'_> {
         debug_assert!(!self.key.is_empty(), "invalid iterator");
         self.key.as_key_slice()
     }

--- a/mini-lsm-mvcc/src/iterators/concat_iterator.rs
+++ b/mini-lsm-mvcc/src/iterators/concat_iterator.rs
@@ -108,7 +108,7 @@ impl SstConcatIterator {
 impl StorageIterator for SstConcatIterator {
     type KeyType<'a> = KeySlice<'a>;
 
-    fn key(&self) -> KeySlice {
+    fn key(&self) -> KeySlice<'_> {
         self.current.as_ref().unwrap().key()
     }
 

--- a/mini-lsm-mvcc/src/iterators/merge_iterator.rs
+++ b/mini-lsm-mvcc/src/iterators/merge_iterator.rs
@@ -94,7 +94,7 @@ impl<I: 'static + for<'a> StorageIterator<KeyType<'a> = KeySlice<'a>>> StorageIt
 {
     type KeyType<'a> = KeySlice<'a>;
 
-    fn key(&self) -> KeySlice {
+    fn key(&self) -> KeySlice<'_> {
         self.current.as_ref().unwrap().1.key()
     }
 
@@ -144,10 +144,10 @@ impl<I: 'static + for<'a> StorageIterator<KeyType<'a> = KeySlice<'a>>> StorageIt
         }
 
         // Otherwise, compare with heap top and swap if necessary.
-        if let Some(mut inner_iter) = self.iters.peek_mut() {
-            if *current < *inner_iter {
-                std::mem::swap(&mut *inner_iter, current);
-            }
+        if let Some(mut inner_iter) = self.iters.peek_mut()
+            && *current < *inner_iter
+        {
+            std::mem::swap(&mut *inner_iter, current);
         }
 
         Ok(())

--- a/mini-lsm-mvcc/src/key.rs
+++ b/mini-lsm-mvcc/src/key.rs
@@ -86,7 +86,7 @@ impl Key<Vec<u8>> {
         self.1 = key_slice.1;
     }
 
-    pub fn as_key_slice(&self) -> KeySlice {
+    pub fn as_key_slice(&self) -> KeySlice<'_> {
         Key(self.0.as_slice(), self.1)
     }
 
@@ -116,7 +116,7 @@ impl Key<Bytes> {
         Self(Bytes::new(), TS_DEFAULT)
     }
 
-    pub fn as_key_slice(&self) -> KeySlice {
+    pub fn as_key_slice(&self) -> KeySlice<'_> {
         Key(&self.0, self.1)
     }
 

--- a/mini-lsm-mvcc/src/lsm_iterator.rs
+++ b/mini-lsm-mvcc/src/lsm_iterator.rs
@@ -171,11 +171,11 @@ impl<I: StorageIterator> StorageIterator for FusedIterator<I> {
         if self.has_errored {
             bail!("the iterator is tainted");
         }
-        if self.iter.is_valid() {
-            if let Err(e) = self.iter.next() {
-                self.has_errored = true;
-                return Err(e);
-            }
+        if self.iter.is_valid()
+            && let Err(e) = self.iter.next()
+        {
+            self.has_errored = true;
+            return Err(e);
         }
         Ok(())
     }

--- a/mini-lsm-mvcc/src/lsm_storage.rs
+++ b/mini-lsm-mvcc/src/lsm_storage.rs
@@ -784,11 +784,7 @@ impl LsmStorageInner {
     }
 
     /// Create an iterator over a range of keys.
-    pub fn scan<'a>(
-        self: &'a Arc<Self>,
-        lower: Bound<&[u8]>,
-        upper: Bound<&[u8]>,
-    ) -> Result<TxnIterator> {
+    pub fn scan(self: &Arc<Self>, lower: Bound<&[u8]>, upper: Bound<&[u8]>) -> Result<TxnIterator> {
         let txn = self.mvcc().new_txn(self.clone(), self.options.serializable);
         txn.scan(lower, upper)
     }

--- a/mini-lsm-mvcc/src/mem_table.rs
+++ b/mini-lsm-mvcc/src/mem_table.rs
@@ -257,7 +257,7 @@ impl StorageIterator for MemTableIterator {
         &self.borrow_item().1[..]
     }
 
-    fn key(&self) -> KeySlice {
+    fn key(&self) -> KeySlice<'_> {
         self.borrow_item().0.as_key_slice()
     }
 

--- a/mini-lsm-mvcc/src/table/bloom.rs
+++ b/mini-lsm-mvcc/src/table/bloom.rs
@@ -84,8 +84,7 @@ impl Bloom {
 
     /// Get bloom filter bits per key from entries count and FPR
     pub fn bloom_bits_per_key(entries: usize, false_positive_rate: f64) -> usize {
-        let size =
-            -(entries as f64) * false_positive_rate.ln() / std::f64::consts::LN_2.powi(2);
+        let size = -(entries as f64) * false_positive_rate.ln() / std::f64::consts::LN_2.powi(2);
         let locs = (size / (entries as f64)).ceil();
         locs as usize
     }

--- a/mini-lsm-mvcc/src/table/bloom.rs
+++ b/mini-lsm-mvcc/src/table/bloom.rs
@@ -85,7 +85,7 @@ impl Bloom {
     /// Get bloom filter bits per key from entries count and FPR
     pub fn bloom_bits_per_key(entries: usize, false_positive_rate: f64) -> usize {
         let size =
-            -1.0 * (entries as f64) * false_positive_rate.ln() / std::f64::consts::LN_2.powi(2);
+            -(entries as f64) * false_positive_rate.ln() / std::f64::consts::LN_2.powi(2);
         let locs = (size / (entries as f64)).ceil();
         locs as usize
     }
@@ -95,7 +95,7 @@ impl Bloom {
         let k = (bits_per_key as f64 * 0.69) as u32;
         let k = k.clamp(1, 30);
         let nbits = (keys.len() * bits_per_key).max(64);
-        let nbytes = (nbits + 7) / 8;
+        let nbytes = nbits.div_ceil(8);
         let nbits = nbytes * 8;
         let mut filter = BytesMut::with_capacity(nbytes);
         filter.resize(nbytes, 0);

--- a/mini-lsm-mvcc/src/table/iterator.rs
+++ b/mini-lsm-mvcc/src/table/iterator.rs
@@ -96,7 +96,7 @@ impl StorageIterator for SsTableIterator {
         self.blk_iter.value()
     }
 
-    fn key(&self) -> KeySlice {
+    fn key(&self) -> KeySlice<'_> {
         self.blk_iter.key()
     }
 

--- a/mini-lsm-starter/src/block/iterator.rs
+++ b/mini-lsm-starter/src/block/iterator.rs
@@ -57,7 +57,7 @@ impl BlockIterator {
     }
 
     /// Returns the key of the current entry.
-    pub fn key(&self) -> KeySlice {
+    pub fn key(&self) -> KeySlice<'_> {
         unimplemented!()
     }
 

--- a/mini-lsm-starter/src/iterators/concat_iterator.rs
+++ b/mini-lsm-starter/src/iterators/concat_iterator.rs
@@ -46,7 +46,7 @@ impl SstConcatIterator {
 impl StorageIterator for SstConcatIterator {
     type KeyType<'a> = KeySlice<'a>;
 
-    fn key(&self) -> KeySlice {
+    fn key(&self) -> KeySlice<'_> {
         unimplemented!()
     }
 

--- a/mini-lsm-starter/src/iterators/merge_iterator.rs
+++ b/mini-lsm-starter/src/iterators/merge_iterator.rs
@@ -68,7 +68,7 @@ impl<I: 'static + for<'a> StorageIterator<KeyType<'a> = KeySlice<'a>>> StorageIt
 {
     type KeyType<'a> = KeySlice<'a>;
 
-    fn key(&self) -> KeySlice {
+    fn key(&self) -> KeySlice<'_> {
         unimplemented!()
     }
 

--- a/mini-lsm-starter/src/key.rs
+++ b/mini-lsm-starter/src/key.rs
@@ -68,7 +68,7 @@ impl Key<Vec<u8>> {
         self.0.extend(key_slice.0);
     }
 
-    pub fn as_key_slice(&self) -> KeySlice {
+    pub fn as_key_slice(&self) -> KeySlice<'_> {
         Key(self.0.as_slice())
     }
 
@@ -91,7 +91,7 @@ impl Key<Vec<u8>> {
 }
 
 impl Key<Bytes> {
-    pub fn as_key_slice(&self) -> KeySlice {
+    pub fn as_key_slice(&self) -> KeySlice<'_> {
         Key(&self.0)
     }
 

--- a/mini-lsm-starter/src/mem_table.rs
+++ b/mini-lsm-starter/src/mem_table.rs
@@ -162,7 +162,7 @@ impl StorageIterator for MemTableIterator {
         unimplemented!()
     }
 
-    fn key(&self) -> KeySlice {
+    fn key(&self) -> KeySlice<'_> {
         unimplemented!()
     }
 

--- a/mini-lsm-starter/src/table/bloom.rs
+++ b/mini-lsm-starter/src/table/bloom.rs
@@ -77,8 +77,7 @@ impl Bloom {
 
     /// Get bloom filter bits per key from entries count and FPR
     pub fn bloom_bits_per_key(entries: usize, false_positive_rate: f64) -> usize {
-        let size =
-            -1.0 * (entries as f64) * false_positive_rate.ln() / std::f64::consts::LN_2.powi(2);
+        let size = -(entries as f64) * false_positive_rate.ln() / std::f64::consts::LN_2.powi(2);
         let locs = (size / (entries as f64)).ceil();
         locs as usize
     }
@@ -88,7 +87,7 @@ impl Bloom {
         let k = (bits_per_key as f64 * 0.69) as u32;
         let k = k.clamp(1, 30);
         let nbits = (keys.len() * bits_per_key).max(64);
-        let nbytes = (nbits + 7) / 8;
+        let nbytes = nbits.div_ceil(8);
         let nbits = nbytes * 8;
         let mut filter = BytesMut::with_capacity(nbytes);
         filter.resize(nbytes, 0);

--- a/mini-lsm-starter/src/table/iterator.rs
+++ b/mini-lsm-starter/src/table/iterator.rs
@@ -57,7 +57,7 @@ impl StorageIterator for SsTableIterator {
     type KeyType<'a> = KeySlice<'a>;
 
     /// Return the `key` that's held by the underlying block iterator.
-    fn key(&self) -> KeySlice {
+    fn key(&self) -> KeySlice<'_> {
         unimplemented!()
     }
 

--- a/mini-lsm/src/block/iterator.rs
+++ b/mini-lsm/src/block/iterator.rs
@@ -73,7 +73,7 @@ impl BlockIterator {
     }
 
     /// Returns the key of the current entry.
-    pub fn key(&self) -> KeySlice {
+    pub fn key(&self) -> KeySlice<'_> {
         debug_assert!(!self.key.is_empty(), "invalid iterator");
         self.key.as_key_slice()
     }

--- a/mini-lsm/src/iterators/concat_iterator.rs
+++ b/mini-lsm/src/iterators/concat_iterator.rs
@@ -108,7 +108,7 @@ impl SstConcatIterator {
 impl StorageIterator for SstConcatIterator {
     type KeyType<'a> = KeySlice<'a>;
 
-    fn key(&self) -> KeySlice {
+    fn key(&self) -> KeySlice<'_> {
         self.current.as_ref().unwrap().key()
     }
 

--- a/mini-lsm/src/iterators/merge_iterator.rs
+++ b/mini-lsm/src/iterators/merge_iterator.rs
@@ -94,7 +94,7 @@ impl<I: 'static + for<'a> StorageIterator<KeyType<'a> = KeySlice<'a>>> StorageIt
 {
     type KeyType<'a> = KeySlice<'a>;
 
-    fn key(&self) -> KeySlice {
+    fn key(&self) -> KeySlice<'_> {
         self.current.as_ref().unwrap().1.key()
     }
 
@@ -144,10 +144,10 @@ impl<I: 'static + for<'a> StorageIterator<KeyType<'a> = KeySlice<'a>>> StorageIt
         }
 
         // Otherwise, compare with heap top and swap if necessary.
-        if let Some(mut inner_iter) = self.iters.peek_mut() {
-            if *current < *inner_iter {
-                std::mem::swap(&mut *inner_iter, current);
-            }
+        if let Some(mut inner_iter) = self.iters.peek_mut()
+            && *current < *inner_iter
+        {
+            std::mem::swap(&mut *inner_iter, current);
         }
 
         Ok(())

--- a/mini-lsm/src/key.rs
+++ b/mini-lsm/src/key.rs
@@ -68,7 +68,7 @@ impl Key<Vec<u8>> {
         self.0.extend(key_slice.0);
     }
 
-    pub fn as_key_slice(&self) -> KeySlice {
+    pub fn as_key_slice(&self) -> KeySlice<'_> {
         Key(self.0.as_slice())
     }
 
@@ -91,7 +91,7 @@ impl Key<Vec<u8>> {
 }
 
 impl Key<Bytes> {
-    pub fn as_key_slice(&self) -> KeySlice {
+    pub fn as_key_slice(&self) -> KeySlice<'_> {
         Key(&self.0)
     }
 

--- a/mini-lsm/src/lsm_iterator.rs
+++ b/mini-lsm/src/lsm_iterator.rs
@@ -141,11 +141,11 @@ impl<I: StorageIterator> StorageIterator for FusedIterator<I> {
         if self.has_errored {
             bail!("the iterator is tainted");
         }
-        if self.iter.is_valid() {
-            if let Err(e) = self.iter.next() {
-                self.has_errored = true;
-                return Err(e);
-            }
+        if self.iter.is_valid()
+            && let Err(e) = self.iter.next()
+        {
+            self.has_errored = true;
+            return Err(e);
         }
         Ok(())
     }

--- a/mini-lsm/src/mem_table.rs
+++ b/mini-lsm/src/mem_table.rs
@@ -203,7 +203,7 @@ impl StorageIterator for MemTableIterator {
         &self.borrow_item().1[..]
     }
 
-    fn key(&self) -> KeySlice {
+    fn key(&self) -> KeySlice<'_> {
         KeySlice::from_slice(&self.borrow_item().0[..])
     }
 

--- a/mini-lsm/src/table/bloom.rs
+++ b/mini-lsm/src/table/bloom.rs
@@ -84,8 +84,7 @@ impl Bloom {
 
     /// Get bloom filter bits per key from entries count and FPR
     pub fn bloom_bits_per_key(entries: usize, false_positive_rate: f64) -> usize {
-        let size =
-            -(entries as f64) * false_positive_rate.ln() / std::f64::consts::LN_2.powi(2);
+        let size = -(entries as f64) * false_positive_rate.ln() / std::f64::consts::LN_2.powi(2);
         let locs = (size / (entries as f64)).ceil();
         locs as usize
     }

--- a/mini-lsm/src/table/bloom.rs
+++ b/mini-lsm/src/table/bloom.rs
@@ -85,7 +85,7 @@ impl Bloom {
     /// Get bloom filter bits per key from entries count and FPR
     pub fn bloom_bits_per_key(entries: usize, false_positive_rate: f64) -> usize {
         let size =
-            -1.0 * (entries as f64) * false_positive_rate.ln() / std::f64::consts::LN_2.powi(2);
+            -(entries as f64) * false_positive_rate.ln() / std::f64::consts::LN_2.powi(2);
         let locs = (size / (entries as f64)).ceil();
         locs as usize
     }
@@ -95,7 +95,7 @@ impl Bloom {
         let k = (bits_per_key as f64 * 0.69) as u32;
         let k = k.clamp(1, 30);
         let nbits = (keys.len() * bits_per_key).max(64);
-        let nbytes = (nbits + 7) / 8;
+        let nbytes = nbits.div_ceil(8);
         let nbits = nbytes * 8;
         let mut filter = BytesMut::with_capacity(nbytes);
         filter.resize(nbytes, 0);

--- a/mini-lsm/src/table/iterator.rs
+++ b/mini-lsm/src/table/iterator.rs
@@ -96,7 +96,7 @@ impl StorageIterator for SsTableIterator {
         self.blk_iter.value()
     }
 
-    fn key(&self) -> KeySlice {
+    fn key(&self) -> KeySlice<'_> {
         self.blk_iter.key()
     }
 

--- a/mini-lsm/src/tests/harness.rs
+++ b/mini-lsm/src/tests/harness.rs
@@ -65,37 +65,37 @@ impl StorageIterator for MockIterator {
         if self.index < self.data.len() {
             self.index += 1;
         }
-        if let Some(error_when) = self.error_when {
-            if self.index == error_when {
-                bail!("fake error!");
-            }
+        if let Some(error_when) = self.error_when
+            && self.index == error_when
+        {
+            bail!("fake error!");
         }
         Ok(())
     }
 
-    fn key(&self) -> KeySlice {
-        if let Some(error_when) = self.error_when {
-            if self.index >= error_when {
-                panic!("invalid access after next returns an error!");
-            }
+    fn key(&self) -> KeySlice<'_> {
+        if let Some(error_when) = self.error_when
+            && self.index >= error_when
+        {
+            panic!("invalid access after next returns an error!");
         }
         KeySlice::for_testing_from_slice_no_ts(self.data[self.index].0.as_ref())
     }
 
     fn value(&self) -> &[u8] {
-        if let Some(error_when) = self.error_when {
-            if self.index >= error_when {
-                panic!("invalid access after next returns an error!");
-            }
+        if let Some(error_when) = self.error_when
+            && self.index >= error_when
+        {
+            panic!("invalid access after next returns an error!");
         }
         self.data[self.index].1.as_ref()
     }
 
     fn is_valid(&self) -> bool {
-        if let Some(error_when) = self.error_when {
-            if self.index >= error_when {
-                panic!("invalid access after next returns an error!");
-            }
+        if let Some(error_when) = self.error_when
+            && self.index >= error_when
+        {
+            panic!("invalid access after next returns an error!");
         }
         self.index < self.data.len()
     }


### PR DESCRIPTION
- fix many clippy warnings
```
warning: `mini-lsm` (lib test) generated 16 warnings (11 duplicates) (run `cargo clippy --fix --lib -p mini-lsm --tests` to apply 5 suggestions)
warning: hiding a lifetime that's elided elsewhere is confusing
  --> mini-lsm-mvcc/src/tests/harness.rs:76:12
   |
76 |     fn key(&self) -> KeySlice {
   |            ^^^^^     ^^^^^^^^ the same lifetime is hidden here
   |            |
   |            the lifetime is elided here
   |
   = help: the same lifetime is referred to in inconsistent ways, making the signature confusing
help: use `'_` for type paths
   |
76 |     fn key(&self) -> KeySlice<'_> {
   |                              ++++

warning: `mini-lsm-mvcc` (lib test) generated 17 warnings (12 duplicates) (run `cargo clippy --fix --lib -p mini-lsm-mvcc --tests` to apply 5 suggestions)
```