### PR TITLE
Refactor local iterator handling in txn.rs, removing duplicate logic

### DIFF
--- a/mini-lsm-mvcc/src/mvcc/txn.rs
+++ b/mini-lsm-mvcc/src/mvcc/txn.rs
@@ -74,8 +74,7 @@ impl Transaction {
             item: (Bytes::new(), Bytes::new()),
         }
         .build();
-        let entry = local_iter.with_iter_mut(|iter| TxnLocalIterator::entry_to_item(iter.next()));
-        local_iter.with_mut(|x| *x.item = entry);
+        local_iter.next()?;
 
         TxnIterator::create(
             self.clone(),


### PR DESCRIPTION
Removed unused entry assignment and streamlined local iterator usage.