### PR TITLE
Fix: scan upper bound leak

### DIFF
--- a/mini-lsm-mvcc/src/lsm_iterator.rs
+++ b/mini-lsm-mvcc/src/lsm_iterator.rs
@@ -51,8 +51,20 @@ impl LsmIterator {
             read_ts,
             prev_key: Vec::new(),
         };
+        iter.check_end_bound();
         iter.move_to_key()?;
         Ok(iter)
+    }
+
+    fn check_end_bound(&mut self) {
+        if !self.is_valid {
+            return;
+        }
+        match self.end_bound.as_ref() {
+            Bound::Unbounded => {}
+            Bound::Included(key) => self.is_valid = self.inner.key().key_ref() <= key.as_ref(),
+            Bound::Excluded(key) => self.is_valid = self.inner.key().key_ref() < key.as_ref(),
+        }
     }
 
     fn next_inner(&mut self) -> Result<()> {
@@ -61,11 +73,7 @@ impl LsmIterator {
             self.is_valid = false;
             return Ok(());
         }
-        match self.end_bound.as_ref() {
-            Bound::Unbounded => {}
-            Bound::Included(key) => self.is_valid = self.inner.key().key_ref() <= key.as_ref(),
-            Bound::Excluded(key) => self.is_valid = self.inner.key().key_ref() < key.as_ref(),
-        }
+        self.check_end_bound();
         Ok(())
     }
 

--- a/mini-lsm/src/lsm_iterator.rs
+++ b/mini-lsm/src/lsm_iterator.rs
@@ -43,8 +43,20 @@ impl LsmIterator {
             inner: iter,
             end_bound,
         };
+        iter.check_end_bound();
         iter.move_to_non_delete()?;
         Ok(iter)
+    }
+
+    fn check_end_bound(&mut self) {
+        if !self.is_valid {
+            return;
+        }
+        match self.end_bound.as_ref() {
+            Bound::Unbounded => {}
+            Bound::Included(key) => self.is_valid = self.inner.key().raw_ref() <= key.as_ref(),
+            Bound::Excluded(key) => self.is_valid = self.inner.key().raw_ref() < key.as_ref(),
+        }
     }
 
     fn next_inner(&mut self) -> Result<()> {
@@ -53,11 +65,7 @@ impl LsmIterator {
             self.is_valid = false;
             return Ok(());
         }
-        match self.end_bound.as_ref() {
-            Bound::Unbounded => {}
-            Bound::Included(key) => self.is_valid = self.inner.key().raw_ref() <= key.as_ref(),
-            Bound::Excluded(key) => self.is_valid = self.inner.key().raw_ref() < key.as_ref(),
-        }
+        self.check_end_bound();
         Ok(())
     }
 

--- a/mini-lsm/src/tests/week1_day5.rs
+++ b/mini-lsm/src/tests/week1_day5.rs
@@ -219,6 +219,47 @@ fn test_task2_storage_scan() {
 }
 
 #[test]
+fn test_task2_storage_scan_end_bound_at_seek_position() {
+    let dir = tempdir().unwrap();
+    let storage =
+        Arc::new(LsmStorageInner::open(&dir, LsmStorageOptions::default_for_week1_test()).unwrap());
+    let sst1 = generate_sst(
+        10,
+        dir.path().join("10.sst"),
+        vec![
+            (Bytes::from_static(b"key00"), Bytes::from_static(b"233")),
+            (Bytes::from_static(b"key11"), Bytes::from_static(b"2333")),
+        ],
+        Some(storage.block_cache.clone()),
+    );
+    {
+        let mut state = storage.state.write();
+        let mut snapshot = state.as_ref().clone();
+        snapshot.l0_sstables.push(sst1.sst_id());
+        snapshot.sstables.insert(sst1.sst_id(), sst1.into());
+        *state = snapshot.into();
+    }
+    check_lsm_iter_result_by_key(
+        &mut storage
+            .scan(Bound::Included(b"key01"), Bound::Included(b"key01"))
+            .unwrap(),
+        vec![],
+    );
+    check_lsm_iter_result_by_key(
+        &mut storage
+            .scan(Bound::Included(b"key01"), Bound::Excluded(b"key11"))
+            .unwrap(),
+        vec![],
+    );
+    check_lsm_iter_result_by_key(
+        &mut storage
+            .scan(Bound::Included(b"key01"), Bound::Included(b"key11"))
+            .unwrap(),
+        vec![(Bytes::from("key11"), Bytes::from("2333"))],
+    );
+}
+
+#[test]
 fn test_task3_storage_get() {
     let dir = tempdir().unwrap();
     let storage =


### PR DESCRIPTION
RESOLVES #180 

Note for this one it might be worth rephrasing the book as well, since framing the bound as purely iteration logic is arguably what leads to the initial seek position being missed:

> You will then need to modify the `LsmIterator`'s iteration logic to ensure it stops
> when the keys from the inner iterator reach or exceed this specified `end_bound`.

