### PR TITLE
Test all-tombstone full compaction

### DIFF
--- a/mini-lsm-mvcc/src/compact.rs
+++ b/mini-lsm-mvcc/src/compact.rs
@@ -212,16 +212,16 @@ impl LsmStorageInner {
 
             iter.next()?;
         }
-        if let Some(builder) = builder {
-            if entries_in_builder > 0 {
-                let sst_id = self.next_sst_id(); // lock dropped here
-                let sst = Arc::new(builder.build(
-                    sst_id,
-                    Some(self.block_cache.clone()),
-                    self.path_of_sst(sst_id),
-                )?);
-                new_sst.push(sst);
-            }
+        if let Some(builder) = builder
+            && entries_in_builder > 0
+        {
+            let sst_id = self.next_sst_id(); // lock dropped here
+            let sst = Arc::new(builder.build(
+                sst_id,
+                Some(self.block_cache.clone()),
+                self.path_of_sst(sst_id),
+            )?);
+            new_sst.push(sst);
         }
         Ok(new_sst)
     }

--- a/mini-lsm/src/compact.rs
+++ b/mini-lsm/src/compact.rs
@@ -166,16 +166,16 @@ impl LsmStorageInner {
                 entries_in_builder = 0;
             }
         }
-        if let Some(builder) = builder {
-            if entries_in_builder > 0 {
-                let sst_id = self.next_sst_id(); // lock dropped here
-                let sst = Arc::new(builder.build(
-                    sst_id,
-                    Some(self.block_cache.clone()),
-                    self.path_of_sst(sst_id),
-                )?);
-                new_sst.push(sst);
-            }
+        if let Some(builder) = builder
+            && entries_in_builder > 0
+        {
+            let sst_id = self.next_sst_id(); // lock dropped here
+            let sst = Arc::new(builder.build(
+                sst_id,
+                Some(self.block_cache.clone()),
+                self.path_of_sst(sst_id),
+            )?);
+            new_sst.push(sst);
         }
         Ok(new_sst)
     }

--- a/mini-lsm/src/tests/week2_day1.rs
+++ b/mini-lsm/src/tests/week2_day1.rs
@@ -28,6 +28,23 @@ use crate::{
 };
 
 #[test]
+fn test_task1_full_compaction_all_tombstones() {
+    let dir = tempdir().unwrap();
+    let storage =
+        Arc::new(LsmStorageInner::open(&dir, LsmStorageOptions::default_for_week1_test()).unwrap());
+
+    storage.delete(b"key").unwrap();
+    sync(&storage);
+
+    assert_eq!(storage.state.read().l0_sstables.len(), 1);
+    storage.force_full_compaction().unwrap();
+
+    let state = storage.state.read();
+    assert!(state.l0_sstables.is_empty());
+    assert!(state.levels[0].1.is_empty());
+}
+
+#[test]
 fn test_task1_full_compaction() {
     // We do not use LSM iterator in this test because it's implemented as part of task 3
     let dir = tempdir().unwrap();


### PR DESCRIPTION
## Summary

- add a regression test for full compaction when the input contains only tombstones
- exercise both the non-MVCC and MVCC implementations through the shared test file
- collapse the merged builder checks so Clippy remains clean

## Why

PR #182 fixed a panic caused by building an empty SST after bottom-level compaction filtered every tombstone, but the reported reproduction was not covered by a regression test. This test deletes a nonexistent key, flushes the tombstone, runs full compaction, and verifies that no output SST is produced.

## Validation

- `cargo x ci`
- 132 tests passed
- formatting, all-target checks, Clippy, and mdBook build passed
