### PR TITLE
Refine preface and Week 1 book content

### DIFF
--- a/mini-lsm-book/src/00-get-started.md
+++ b/mini-lsm-book/src/00-get-started.md
@@ -4,19 +4,19 @@
 
 # Environment Setup
 
-The starter code and reference solution is available at [https://github.com/skyzh/mini-lsm](https://github.com/skyzh/mini-lsm).
+The starter code and reference solution are available in the [Mini-LSM repository](https://github.com/skyzh/mini-lsm).
 
 ## Install Rust
 
 See [https://rustup.rs](https://rustup.rs) for more information.
 
-## Clone the repo
+## Clone the Repository
 
 ```
 git clone https://github.com/skyzh/mini-lsm
 ```
 
-## Starter code
+## Open the Starter Code
 
 ```
 cd mini-lsm/mini-lsm-starter
@@ -25,19 +25,19 @@ code .
 
 ## Install Tools
 
-You will need the latest stable Rust to compile this project. The minimum requirement is `1.74`.
+The repository pins the required Rust toolchain in `rust-toolchain.toml`. If you use `rustup`, Cargo will select and install that toolchain automatically.
 
 ```
 cargo x install-tools
 ```
 
-## Run tests
+## Run the Tests
 
 ```
 cargo x copy-test --week 1 --day 1
 cargo x scheck
 ```
 
-Now, you can go ahead and start [Week 1: Mini-LSM](./week1-overview.md).
+You are now ready to begin [Week 1: Mini-LSM](./week1-overview.md).
 
 {{#include copyright.md}}

--- a/mini-lsm-book/src/00-overview.md
+++ b/mini-lsm-book/src/00-overview.md
@@ -8,57 +8,57 @@
 
 ![Course Overview](lsm-tutorial/00-full-overview.svg)
 
-We have three parts (weeks) for this course. In the first week, we will focus on the storage structure and the storage format of an LSM storage engine. In the second week, we will deeply dive into compactions and implement persistence support for the storage engine. In the third week, we will implement multi-version concurrency control.
+This course has three parts, or weeks. In the first week, you will focus on the structure and storage format of an LSM storage engine. In the second week, you will explore compaction in depth and add persistence to the storage engine. In the third week, you will implement multiversion concurrency control (MVCC).
 
 * [The First Week: Mini-LSM](./week1-overview.md)
 * [The Second Week: Compaction and Persistence](./week2-overview.md)
 * [The Third Week: Multi-Version Concurrency Control](./week3-overview.md)
 
-Please look at [Environment Setup](./00-get-started.md) to set up the environment.
+Follow [Environment Setup](./00-get-started.md) to prepare your development environment.
 
 ## Overview of LSM
 
-An LSM storage engine generally contains three parts:
+An LSM storage engine generally has three components:
 
-1. Write-ahead log to persist temporary data for recovery.
-2. SSTs on the disk to maintain an LSM-tree structure.
-3. Mem-tables in memory for batching small writes.
+1. A write-ahead log that persists recent data for recovery.
+2. SSTs on disk that form the LSM-tree structure.
+3. Memtables in memory that batch small writes.
 
 The storage engine generally provides the following interfaces:
 
-* `Put(key, value)`: store a key-value pair in the LSM tree.
-* `Delete(key)`: remove a key and its corresponding value.
-* `Get(key)`: get the value corresponding to a key.
-* `Scan(range)`: get a range of key-value pairs.
+* `Put(key, value)`: Stores a key-value pair in the LSM tree.
+* `Delete(key)`: Removes a key and its corresponding value.
+* `Get(key)`: Retrieves the value associated with a key.
+* `Scan(range)`: Retrieves a range of key-value pairs.
 
-To ensure persistence,
+It may also provide an operation that establishes a persistence boundary:
 
-* `Sync()`: ensure all the operations before `sync` are persisted to the disk.
+* `Sync()`: Ensures that all preceding operations have been persisted to disk.
 
-Some engines choose to combine `Put` and `Delete` into a single operation called `WriteBatch`, which accepts a batch of key-value pairs.
+Some engines combine `Put` and `Delete` into a single operation called `WriteBatch`, which accepts a batch of updates.
 
-In this course, we assume the LSM tree is using a leveled compaction algorithm, which is commonly used in real-world systems.
+The overview diagrams assume a leveled compaction layout, which is common in production systems. In Week 2, you will implement and compare several compaction strategies.
 
 ### Write Path
 
 ![Write Path](lsm-tutorial/00-lsm-write-flow.svg)
 
-The write path of LSM contains four steps:
+The LSM write path has four steps:
 
-1. Write the key-value pair to the write-ahead log so that it can be recovered after the storage engine crashes.
-2. Write the key-value pair to memtable. After (1) and (2) are completed, we can notify the user that the write operation is completed.
-3. (In the background) When a mem-table is full, we will freeze them into immutable mem-tables and flush them to the disk as SST files in the background.
-4. (In the background) The engine will compact some files in some levels into lower levels to maintain a good shape for the LSM tree so that the read amplification is low.
+1. Write the key-value pair to the write-ahead log so that it can be recovered after a crash.
+2. Write the key-value pair to the mutable memtable. After steps 1 and 2 are complete, the engine can report that the write has completed.
+3. In the background, freeze a full mutable memtable, making it immutable, and flush it to disk as an SST file.
+4. Also in the background, compact files from one or more levels into lower levels. This maintains the shape of the LSM tree and limits read amplification.
 
 ### Read Path
 
 ![Read Path](lsm-tutorial/00-lsm-read-flow.svg)
 
-When we want to read a key,
+To read a key, the engine:
 
-1. We will first probe all the mem-tables from the latest to the oldest.
-2. If the key is not found, we will then search the entire LSM tree containing SSTs to find the data.
+1. Probes the memtables from newest to oldest.
+2. If the memtables do not determine the result, searches the SSTs in the LSM tree.
 
-There are two types of read: lookup and scan. Lookup finds one key in the LSM tree, while scan iterates all keys within a range in the storage engine. We will cover both of them throughout the course.
+There are two types of reads: lookups and scans. A lookup finds one key in the LSM tree, whereas a scan iterates over all keys within a range. The course covers both.
 
 {{#include copyright.md}}

--- a/mini-lsm-book/src/00-preface.md
+++ b/mini-lsm-book/src/00-preface.md
@@ -6,65 +6,67 @@
 
 ![Banner](./mini-lsm-logo.png)
 
-This course teaches you how to build a simple LSM-Tree storage engine in Rust.
+This course teaches you how to build a simple LSM-tree storage engine in Rust.
 
-## What is LSM, and Why LSM?
+## What Is an LSM Tree, and Why Use One?
 
-Log-structured merge trees are data structures that maintain key-value pairs. This data structure is widely used in
-distributed database systems like [TiDB](https://www.pingcap.com) and [CockroachDB](https://www.cockroachlabs.com) as
-their underlying storage engine. [RocksDB](http://rocksdb.org), based on [LevelDB](https://github.com/google/leveldb),
-is an implementation of LSM-Tree storage engines. It provides many key-value access functionalities and is
-used in many production systems.
+Log-structured merge trees are data structures for maintaining key-value pairs. They are widely used as the underlying
+storage engines in distributed database systems such as [TiDB](https://www.pingcap.com) and
+[CockroachDB](https://www.cockroachlabs.com). [RocksDB](http://rocksdb.org), which is based on
+[LevelDB](https://github.com/google/leveldb), is an LSM-tree storage engine that provides a rich key-value interface and
+is used in many production systems.
 
-Generally speaking, LSM Tree is an append-friendly data structure. It is more intuitive to compare LSM to other
-key-value data structures like RB-Tree and B-Tree. For RB-Tree and B-Tree, all data operations are in place. That is to
-say, when you want to update the value corresponding to the key, the engine will overwrite its original memory or disk
-space with the new value. But in an LSM Tree, all write operations, i.e., insertions, updates, deletions, are lazily applied to the storage.
-The engine batches these operations into SST (sorted string table) files and writes them to the disk. Once written to the
-disk, the engine will not directly modify them. In a particular background task called compaction, the engine will merge these files to apply the updates and deletions.
+Generally speaking, an LSM tree is an append-friendly data structure. It is easiest to understand by comparing it with
+other key-value data structures, such as red-black trees and B-trees. In those structures, updates happen in place: when
+you update the value associated with a key, the engine overwrites the value in its original memory or disk location. In
+an LSM tree, however, writes—including insertions, updates, and deletions—are applied to persistent storage lazily. The
+engine batches these operations into sorted-string table (SST) files and writes them to disk. Once written, SST files are
+immutable. A background process called compaction merges these files and applies their updates and deletions.
 
 This architectural design makes LSM trees easy to work with.
 
-1. Data are immutable on persistent storage. Concurrency control is more straightforward. Offloading the background tasks (compaction) to remote servers is possible. Storing and serving data directly from cloud-native storage systems like S3 is also feasible.
-2. Changing the compaction algorithm allows the storage engine to balance between read, write, and space amplification. The data structure is versatile, and by adjusting the compaction parameters, we can optimize the LSM structure for different workloads.
+1. Data on persistent storage is immutable, which makes concurrency control more straightforward. Compaction can be offloaded to remote servers, and data can be stored and served directly from cloud-native storage systems such as S3.
+2. Changing the compaction algorithm lets the storage engine balance read, write, and space amplification. By tuning compaction parameters, we can optimize the LSM tree for different workloads.
 
 This course will teach you how to build an LSM-tree-based storage engine in the Rust programming language.
 
 ## Prerequisites
 
-* You should know the basics of the Rust programming language. Reading [the Rust book](https://doc.rust-lang.org/book/) is enough.
-* You should know the basic concepts of key-value storage engines, i.e., why we need a complex design to achieve persistence. If you have no experience with database systems and storage systems before, you can implement Bitcask in [PingCAP Talent Plan](https://github.com/pingcap/talent-plan/tree/master/courses/rust/projects/project-2).
-* Knowing the basics of an LSM tree is not a requirement, but we recommend you read something about it, e.g., the overall idea of LevelDB. Knowing them beforehand would familiarize you with concepts like mutable and immutable mem-tables, SST, compaction, WAL, etc.
+* You should know the basics of the Rust programming language. Reading [The Rust Programming Language](https://doc.rust-lang.org/book/) is sufficient.
+* You should understand the basic concepts behind key-value storage engines, including why persistence requires a more complex design. If you have no prior experience with database or storage systems, consider implementing Bitcask through the [PingCAP Talent Plan](https://github.com/pingcap/talent-plan/tree/master/courses/rust/projects/project-2).
+* You do not need to know how an LSM tree works, but we recommend reading an introduction, such as an overview of LevelDB. This background will familiarize you with concepts such as mutable and immutable memtables, SSTs, compaction, and write-ahead logs (WALs).
 
-## What should you expect from this course
+## What Should You Expect from This Course?
 
-After taking this course, you should deeply understand how an LSM-based storage system works, gain hands-on experience in designing such systems, and apply what you have learned in your study and career. You will understand the design tradeoffs in such storage systems and find optimal ways to design an LSM-based storage system to meet your workload requirements/goals. This very in-depth course covers all the essential implementation details and design choices of modern storage systems (i.e., RocksDB) based on the author's experience in several LSM-like storage systems, and you will be able to directly apply what you have learned in both industry and academia.
+After completing this course, you should have a deep understanding of how an LSM-based storage system works and hands-on experience designing one. You will learn the tradeoffs involved and how to choose a design that meets the requirements of a particular workload. Drawing on the author's experience with several LSM-based systems, the course covers the essential implementation details and design choices found in modern storage systems such as RocksDB. You can apply what you learn in both industry and academia.
 
 ### Structure
 
-The course is an extensive course with several parts (weeks). Each week has seven chapters; you can finish each within 2 to 3 hours. The first six chapters of each part will instruct you to build a working system, and the last chapter of each week will be a *snack time* chapter that implements some easy things over what you have built in the previous six days. Each chapter will have required tasks, *check your understanding* questions, and bonus tasks.
+The course consists of several parts, or weeks. Each week has seven chapters, and you can complete each chapter in two to three hours. The first six chapters of each week guide you through building a working system. The final chapter is a *snack time* chapter in which you implement a few approachable improvements to what you built over the previous six days. Each chapter includes required tasks, *Test Your Understanding* questions, and bonus tasks.
 
 ### Testing
 
-We provide a full test suite and some CLI tools for you to validate if your solution is correct. Note that the test suite is not exhaustive, and your solution might not be 100% correct after passing all test cases. You might need to fix earlier bugs when implementing later parts of the system. We recommend you think thoroughly about your implementation, especially when there are multi-thread operations and race conditions.
+We provide a comprehensive test suite and several command-line tools to help you validate your solution. The test suite is not exhaustive, so passing every test does not guarantee that your solution is completely correct. You might need to fix earlier bugs while implementing later parts of the system. Think carefully about your implementation, especially when it involves multithreaded operations and potential race conditions.
 
 ### Solution
 
-We have a solution that implements all the functionalities as required in the course in the mini-lsm main repo. At the same time, we also have a mini-lsm solution checkpoint repo where each commit corresponds to a chapter in the course. 
+The main Mini-LSM repository contains a reference solution that implements all functionality required by the course. We also maintain a solution-checkpoint repository in which each commit corresponds to a chapter.
 
-Keeping such a checkpoint repo up-to-date with the mini-lsm course is challenging because each bug fix or new feature must go through all commits (or checkpoints). Therefore, this repo might not use the latest starter code or incorporate the latest features from the mini-lsm course.
+Keeping the checkpoint repository synchronized with the Mini-LSM course is challenging because every bug fix or new feature must be applied to every relevant commit. Consequently, this repository might not use the latest starter code or include the course's latest features.
 
-**TL;DR: We do not guarantee the solution checkpoint repo contains a correct solution, passes all tests, or has the correct doc comments.** For a correct implementation and the solution after implementing everything, please look at the solution in the main repo instead. [https://github.com/skyzh/mini-lsm/tree/main/mini-lsm](https://github.com/skyzh/mini-lsm/tree/main/mini-lsm).
+**TL;DR: We do not guarantee that the solution-checkpoint repository contains a correct solution, passes every test, or has accurate documentation comments.** For the complete reference implementation, see the [`mini-lsm` crate in the main repository](https://github.com/skyzh/mini-lsm/tree/main/mini-lsm).
 
-If you are stuck at some part of the course or need help determining where to implement functionality, you can refer to this repo for help. You may compare the diff between commits to know what has been changed. You might need to modify some functions in the mini-lsm course multiple times throughout the chapters, and you can understand what exactly is expected to be implemented for each chapter in this repo.
+If you get stuck or need help determining where to implement functionality, you can consult the checkpoint repository. Compare adjacent commits to see what changed in each chapter. Because you will modify some functions several times during the course, these diffs can clarify exactly what each chapter expects you to implement.
 
 You may access the solution checkpoint repo at [https://github.com/skyzh/mini-lsm-solution-checkpoint](https://github.com/skyzh/mini-lsm-solution-checkpoint).
 
-### Feedbacks
+### Feedback
 
-Your feedback is greatly appreciated. We have rewritten the whole course from scratch in 2024 based on the feedback from the students. Please share your learning experience and help us continuously improve the course. Welcome to the [Discord community](https://skyzh.dev/join/discord) and share your experience.
+Your feedback is greatly appreciated. In 2024, we rewrote the entire course from scratch in response to student feedback. Please share your learning experience and help us continue improving the course in the [Discord community](https://skyzh.dev/join/discord).
 
-The long story of why we rewrote it: The course was originally planned as a general guidance that students start from an empty directory and implement whatever they want based on the specifications we had. We had minimal tests that checked if the behavior was correct. However, the original course was too open-ended, which caused huge obstacles to the learning experience. As students do not have an overview of the whole system beforehand and the instructions are vague, sometimes it is hard for them to know why a design decision is made and what they need to achieve a goal. Some parts of the course were so compact that delivering the expected contents within just one chapter was impossible. Therefore, we completely redesigned the course for an easier learning curve and clearer learning goals. The original one-week course is now split into two weeks (the first week on storage format and the second week on deep-dive compaction), with an extra part on MVCC. We hope you find this course interesting and helpful in your study and career. We want to thank everyone who commented in [Feedback after coding day 1](https://github.com/skyzh/mini-lsm/issues/11) and [Hello, when is the next update plan for the course?](https://github.com/skyzh/mini-lsm/issues/7) -- Your feedback greatly helped us improve the course.
+Here is the longer story behind the rewrite. The original course offered general guidance: students started with an empty directory and implemented their own designs from our specifications. A minimal test suite checked the resulting behavior. This approach proved too open-ended and created significant obstacles to learning. Without an overview of the complete system—and with instructions that were sometimes vague—students found it difficult to understand why a design decision was made or what they needed to accomplish. Some sections were also too dense to fit comfortably into a single chapter.
+
+We therefore redesigned the course to provide a gentler learning curve and clearer goals. The original one-week course is now split into two weeks: the first covers storage formats, and the second takes a deep dive into compaction. A third part covers MVCC. We hope you find the course interesting and useful in your studies and career. We thank everyone who commented on [Feedback after coding day 1](https://github.com/skyzh/mini-lsm/issues/11) and [Hello, when is the next update plan for the course?](https://github.com/skyzh/mini-lsm/issues/7)—your feedback greatly helped us improve the course.
 
 ### License
 
@@ -72,7 +74,7 @@ The source code of this course is licensed under Apache 2.0, while the book is l
 
 ### Will this course be free forever?
 
-Yes! Everything publicly available now will be free forever and receive lifetime updates and bug fixes. Meanwhile, we might provide paid code review and office hour services. For the DLC part (*rest of your life* chapters), we do not have plans to finish them as of 2024 and have yet to decide whether they will be publicly available.
+Yes! Everything that is publicly available now will remain free and receive ongoing updates and bug fixes. We might also provide paid code-review and office-hours services. As of 2024, we had no plans to finish the downloadable-content portion (the *rest of your life* chapters) and had not decided whether it would be publicly available.
 
 ## Community
 
@@ -82,11 +84,11 @@ You may join skyzh's Discord server and study with the mini-lsm community.
 
 ## Get Started
 
-Now, you can get an overview of the LSM structure in [Mini-LSM Course Overview](./00-overview.md).
+Next, read the [Mini-LSM Course Overview](./00-overview.md) for an introduction to the LSM structure.
 
 ## About the Author
 
-As of writing (at the beginning of 2024), Chi obtained his master's degree in Computer Science from Carnegie Mellon University and his bachelor's degree from Shanghai Jiao Tong University. He has been working on a variety of database systems, including [TiKV][db1], [AgateDB][db2], [TerarkDB][db3], [RisingWave][db4], and [Neon][db5]. Since 2022, he has worked as a teaching assistant for [CMU's Database Systems course](https://15445.courses.cs.cmu) for three semesters on the BusTub educational system, where he added a lot of new features and more challenges to the course (check out the redesigned [query execution](https://15445.courses.cs.cmu.edu/fall2022/project3/) project and the super challenging [multi-version concurrency control](https://15445.courses.cs.cmu.edu/fall2023/project4/) project). Besides working on the BusTub educational system, he also maintains the [RisingLight](https://github.com/risinglightdb/risinglight) educational database system. Chi is interested in exploring how the Rust programming language can fit into the database world. Check out his previous course on building a vectorized expression framework [type-exercise-in-rust](https://github.com/skyzh/type-exercise-in-rust) and on building a vector database [write-you-a-vector-db](https://github.com/skyzh/write-you-a-vector-db) if you are also interested in that topic.
+At the time of writing in early 2024, Chi held a master's degree in computer science from Carnegie Mellon University and a bachelor's degree from Shanghai Jiao Tong University. He had worked on several database systems, including [TiKV][db1], [AgateDB][db2], [TerarkDB][db3], [RisingWave][db4], and [Neon][db5]. Beginning in 2022, he served for three semesters as a teaching assistant for [CMU's Database Systems course](https://15445.courses.cs.cmu), working on the BusTub educational system. There, he added new features and challenges to the course, including the redesigned [query execution](https://15445.courses.cs.cmu.edu/fall2022/project3/) project and the demanding [multi-version concurrency control](https://15445.courses.cs.cmu.edu/fall2023/project4/) project. He also maintains the [RisingLight](https://github.com/risinglightdb/risinglight) educational database system. Chi is interested in exploring Rust's role in the database world. If you share that interest, see his earlier courses on building a vectorized expression framework, [type-exercise-in-rust](https://github.com/skyzh/type-exercise-in-rust), and a vector database, [write-you-a-vector-db](https://github.com/skyzh/write-you-a-vector-db).
 
 [db1]: https://github.com/tikv/tikv
 [db2]: https://github.com/tikv/agatedb

--- a/mini-lsm-book/src/week1-01-memtable.md
+++ b/mini-lsm-book/src/week1-01-memtable.md
@@ -9,10 +9,10 @@
 In this chapter, you will:
 
 * Implement memtables based on skiplists.
-* Implement freezing memtable logic.
-* Implement LSM read path `get` for memtables.
+* Implement the logic for freezing memtables.
+* Implement the memtable portion of the LSM `get` read path.
 
-To copy the test cases into the starter code and run them,
+To copy the test cases into the starter code and run them:
 
 ```
 cargo x copy-test --week 1 --day 1
@@ -27,15 +27,15 @@ In this task, you will need to modify:
 src/mem_table.rs
 ```
 
-Firstly, let us implement the in-memory structure of an LSM storage engine -- the memtable. We choose [crossbeam's skiplist implementation](https://docs.rs/crossbeam-skiplist/latest/crossbeam_skiplist/) as the data structure of the memtable as it supports lock-free concurrent read and write. We will not cover in-depth how a skiplist works, and in a nutshell, it is an ordered key-value map that easily allows concurrent read and write.
+First, let us implement the in-memory structure of an LSM storage engine: the memtable. We use [crossbeam-skiplist](https://docs.rs/crossbeam-skiplist/latest/crossbeam_skiplist/) because it supports lock-free concurrent reads and writes. We will not explore skiplists in depth. For this course, you can think of a skiplist as an ordered key-value map that supports concurrent access efficiently.
 
-crossbeam-skiplist provides similar interfaces to the Rust std's `BTreeMap`: insert, get, and iter. The only difference is that the modification interfaces (i.e., `insert`) only require an immutable reference to the skiplist, instead of a mutable one. Therefore, in your implementation, you should not take any mutex when implementing the memtable structure.
+`crossbeam-skiplist` provides methods similar to those on the Rust standard library's `BTreeMap`, including `insert`, `get`, and `iter`. The important difference is that mutating methods such as `insert` require only an immutable reference to the skiplist, rather than a mutable one. Your memtable implementation therefore does not need an additional mutex.
 
-You will also notice that the `MemTable` structure does not have a `delete` interface. In the mini-lsm implementation, deletion is represented as a key corresponding to an empty value.
+You will also notice that `MemTable` does not have a `delete` method. In Mini-LSM, a key associated with an empty value represents a deletion.
 
-In this task, you will need to implement `MemTable::get` and `MemTable::put` to enable modifications of the memtable. Note that `put` should always overwrite a key if it already exists. You won't have multiple entries of the same key in a single memtable.
+In this task, implement `MemTable::get` and `MemTable::put`. The `put` method should overwrite an existing entry with the same key, so a single memtable never contains multiple entries for one key.
 
-We use the `bytes` crate for storing the data in the memtable. `bytes::Byte` is similar to `Arc<[u8]>`. When you clone the `Bytes`, or get a slice of `Bytes`, the underlying data will not be copied, and therefore cloning it is cheap. Instead, it simply creates a new reference to the storage area and the storage area will be freed when there are no reference to that area.
+We use the `bytes` crate to store data in the memtable. `bytes::Bytes` is similar to `Arc<[u8]>`: cloning or slicing a `Bytes` value does not copy its underlying data, so both operations are inexpensive. Instead, each operation creates another reference to the same storage, which is freed when no references remain.
 
 ## Task 2: A Single Memtable in the Engine
 
@@ -45,17 +45,17 @@ In this task, you will need to modify:
 src/lsm_storage.rs
 ```
 
-Now, we will add our first data structure, the memtable, to the LSM state. In `LsmStorageState::create`, you will find that when a LSM structure is created, we will initialize a memtable of id 0. This is the **mutable memtable** in the initial state. At any point of the time, the engine will have only one single mutable memtable. A memtable usually has a size limit (i.e., 256MB), and it will be frozen to an immutable memtable when it reaches the size limit.
+Now, add the memtable to the LSM state. `LsmStorageState::create` initializes memtable 0, which is the initial **mutable memtable**. At any point in time, the engine has exactly one mutable memtable. A memtable usually has a size limit—for example, 256 MB—and is frozen into an immutable memtable when it reaches that limit.
 
-Taking a look at `lsm_storage.rs`, you will find there are two structures that represents a storage engine: `MiniLSM` and `LsmStorageInner`. `MiniLSM` is a thin wrapper for `LsmStorageInner`. You will implement most of the functionalities in `LsmStorageInner`, until week 2 compaction.
+In `lsm_storage.rs`, two structs represent the storage engine: `MiniLsm` and `LsmStorageInner`. `MiniLsm` is a thin wrapper around `LsmStorageInner`. Until you begin implementing compaction in Week 2, you will add most functionality to `LsmStorageInner`.
 
-`LsmStorageState` stores the current structure of the LSM storage engine. For now, we will only use the `memtable` field, which stores the current mutable memtable. In this task, you will need to implement `LsmStorageInner::get`, `LsmStorageInner::put`, and `LsmStorageInner::delete`. All of them should directly dispatch the request to the current memtable.
+`LsmStorageState` describes the current structure of the LSM storage engine. For now, you will use only its `memtable` field, which stores the current mutable memtable. Implement `LsmStorageInner::get`, `LsmStorageInner::put`, and `LsmStorageInner::delete`, dispatching each request directly to that memtable.
 
 ![one memtable LSM](./lsm-tutorial/week1-01-single.svg)
 
-Your `delete` implementation should simply put an empty slice for that key, and we call it a *delete tombstone*. Your `get` implementation should handle this case correspondingly.
+Your `delete` implementation should store an empty slice for the key. This entry is called a *deletion tombstone*. Your `get` implementation should recognize the tombstone and report that the key does not exist.
 
-To access the memtable, you will need to take the `state` lock. As our memtable implementation only requires an immutable reference for `put`, you ONLY need to take the read lock on `state` in order to modify the memtable. This allows concurrent access to the memtable from multiple threads.
+To access the memtable, acquire the `state` lock. Because `MemTable::put` requires only an immutable reference, you need only a read lock on `state`, even when writing to the memtable. This design allows multiple threads to access the memtable concurrently.
 
 ## Task 3: Write Path - Freezing a Memtable
 
@@ -68,98 +68,109 @@ src/mem_table.rs
 
 ![one memtable LSM](./lsm-tutorial/week1-01-frozen.svg)
 
-A memtable cannot continuously grow in size, and we will need to freeze them (and later flush to the disk) when it reaches the size limit. You may find the memtable size limit, which is **equal to the SST size limit** (not `num_memtables_limit`), in the `LsmStorageOptions`. This is not a hard limit and you should freeze the memtable at best effort.
+A memtable cannot grow indefinitely, so you must freeze it—and later flush it to disk—when it reaches its size limit. `LsmStorageOptions::target_sst_size` serves as both the target SST size and the approximate memtable capacity. Do not confuse it with `num_memtable_limit`. This capacity is a soft limit, so freezing is a best-effort operation.
 
-In this task, you will need to compute the approximate memtable size when put/delete a key in the memtable. This can be computed by simply adding the total number of bytes of keys and values when `put` is called. If a key is put twice, though the skiplist only contains the latest value, you may count it twice in the approximate memtable size. Once a memtable reaches the limit, you should call `force_freeze_memtable` to freeze the memtable and create a new one.
+In this task, track the approximate memtable size whenever you put or delete a key. You can estimate it by adding the key and value lengths on every call to `put`. If a key is written twice, you may count both writes even though the skiplist retains only the latest value. Once the memtable reaches the limit, call `force_freeze_memtable` to freeze it and create a new mutable memtable.
 
-The `state: Arc<RwLock<Arc<LsmStorageState>>>` field in `LsmStorageInner` is structured this way to manage the LSM tree's overall state concurrently and safely, primarily using a Copy-on-Write (CoW) strategy:
+The `state: Arc<RwLock<Arc<LsmStorageState>>>` field in `LsmStorageInner` uses a copy-on-write (CoW) strategy to manage the LSM tree's structural state safely and concurrently:
 
-1. Inner `Arc<LsmStorageState>`: This holds an **immutable snapshot** of the actual `LsmStorageState` (which contains memtable lists, SST references, etc.). Cloning this `Arc` is very cheap (just an atomic reference count increment) and gives any reader a consistent, unchanging view of the state for the duration of their operation.
+1. Inner `Arc<LsmStorageState>`: This holds a structurally **immutable snapshot** of `LsmStorageState`, including the memtable lists and SST references. Cloning the `Arc` is inexpensive—it only increments an atomic reference count—and gives a reader a consistent view of the structure for the duration of an operation.
 
-2. `RwLock<Arc<LsmStorageState>>`: This read-write lock protects the *pointer* to the current `Arc<LsmStorageState>` (the active snapshot).
-    * **Readers** acquire a read lock, clone the `Arc<LsmStorageState>` (getting their own reference to the current snapshot), and then quickly release the read lock. They can then work with their snapshot without further locking.
-    * **Writers** (when modifying the state, e.g., freezing a memtable) will:
-        * Create a *new* `LsmStorageState` instance, often by cloning the data from the current snapshot and then applying modifications.
-        * Wrap this new state in a new `Arc<LsmStorageState>`.
-        * Acquire the write lock on the `RwLock`.
-        * Replace the old `Arc<LsmStorageState>` with the new one.
-        * Release the write lock.
+2. `RwLock<Arc<LsmStorageState>>`: This read-write lock protects the pointer to the active snapshot.
+    * **Readers** acquire a read lock, clone the `Arc<LsmStorageState>`, and promptly release the lock. They can then work from their snapshot without holding the global state lock.
+    * **Writers** acquire the write lock, clone the underlying `LsmStorageState`, apply structural changes to the clone, wrap it in a new `Arc`, and replace the active snapshot.
 
-3. Outer `Arc<RwLock<...>>`: This allows the `RwLock` itself (and thus the mechanism for accessing and updating the state) to be shared safely across multiple threads or parts of your application that might need to interact with `LsmStorageInner`.
+3. Outer `Arc<RwLock<...>>`: This lets multiple threads safely share the lock and, through it, access and update the active snapshot.
 
-This CoW approach ensures that readers always see a valid, consistent state snapshot and experience minimal blocking. Writers update the state atomically by swapping out the entire state snapshot, reducing the time critical locks are held and thus improving concurrency.
+This CoW approach gives readers a valid, consistent snapshot with minimal blocking. Writers atomically replace the entire structural snapshot, which keeps critical sections short and improves concurrency.
 
-Because there could be multiple threads getting data into the storage engine, `force_freeze_memtable` might be called concurrently from multiple threads. You will need to think about how to avoid race conditions in this case.
+Because multiple threads can write to the storage engine, they might call `force_freeze_memtable` concurrently. You must prevent races between those calls.
 
-There are multiple places where you may want to modify the LSM state: freeze a mutable memtable, flush memtable to SST, and GC/compaction. During all of these modifications, there could be I/O operations. An intuitive way to structure the locking strategy is to:
+Several operations modify the LSM state: freezing a mutable memtable, flushing a memtable to an SST, and performing garbage collection or compaction. These operations can involve I/O. One intuitive locking strategy is to perform the entire state change under the write lock:
 
 ```rust,no_run
 fn freeze_memtable(&self) {
-    let state = self.state.write();
-    state.immutable_memtable.push(/* something */);
-    state.memtable = MemTable::create();
+    let mut guard = self.state.write();
+    let mut snapshot = guard.as_ref().clone();
+    let old_memtable = std::mem::replace(
+        &mut snapshot.memtable,
+        Arc::new(MemTable::create(self.next_sst_id())),
+    );
+    snapshot.imm_memtables.insert(0, old_memtable);
+    *guard = Arc::new(snapshot);
 }
 ```
 
-...that you modify everything in LSM state's write lock.
-
-This works fine for now. However, consider the case where you want to create a write-ahead log file for every memtables you have created.
+This approach works for now. However, consider creating a write-ahead log file for every memtable:
 
 ```rust,no_run
-fn freeze_memtable(&self) {
-    let state = self.state.write();
-    state.immutable_memtable.push(/* something */);
-    state.memtable = MemTable::create_with_wal()?; // <- could take several milliseconds
+fn freeze_memtable(&self) -> Result<()> {
+    let mut guard = self.state.write();
+    let id = self.next_sst_id();
+    let memtable = Arc::new(MemTable::create_with_wal(
+        id,
+        self.path_of_wal(id),
+    )?); // <- Could take several milliseconds.
+    // Clone and update the structural snapshot here.
+    // ...
+    Ok(())
 }
 ```
 
-Now when we freeze the memtable, no other threads could have access to the LSM state for several milliseconds, which creates a spike of latency.
+While the memtable is being frozen, no other thread can access the LSM state for several milliseconds, creating a latency spike.
 
-To solve this problem, we can put I/O operations outside of the lock region.
+To avoid this problem, perform I/O outside the critical section:
 
 ```rust,no_run
-fn freeze_memtable(&self) {
-    let memtable = MemTable::create_with_wal()?; // <- could take several milliseconds
+fn freeze_memtable(&self) -> Result<()> {
+    let id = self.next_sst_id();
+    let memtable = Arc::new(MemTable::create_with_wal(
+        id,
+        self.path_of_wal(id),
+    )?); // <- Could take several milliseconds.
     {
-        let state = self.state.write();
-        state.immutable_memtable.push(/* something */);
-        state.memtable = memtable;
+        let mut guard = self.state.write();
+        let mut snapshot = guard.as_ref().clone();
+        let old_memtable = std::mem::replace(&mut snapshot.memtable, memtable);
+        snapshot.imm_memtables.insert(0, old_memtable);
+        *guard = Arc::new(snapshot);
     }
+    Ok(())
 }
 ```
 
-Then, we do not have costly operations within the state write lock region. Now, consider the case that the memtable is about to reach the capacity limit and two threads successfully put two keys into the memtable, both of them discovering the memtable reaches capacity limit after putting the two keys. They will both do a size check on the memtable and decide to freeze it. In this case, we might create one empty memtable which is then immediately frozen.
+The state write lock now contains no expensive operations. Next, suppose that a memtable is about to reach its capacity and two threads each add a key. Both threads observe that the memtable has reached its capacity and decide to freeze it. Without additional synchronization, one of them might freeze the newly created empty memtable immediately after the other thread installs it.
 
-To solve the problem, all state modification should be synchronized through the state lock.
+To prevent this race, serialize all state modifications with `state_lock` and recheck the condition after acquiring it:
 
 ```rust,no_run
 fn put(&self, key: &[u8], value: &[u8]) {
-    // put things into the memtable, checks capacity, and drop the read lock on LSM state
+    // Write to the memtable, check its capacity, and release the state read lock.
     if memtable_reaches_capacity_on_put {
         let state_lock = self.state_lock.lock();
-        if /* check again current memtable reaches capacity */ {
+        if /* the current memtable still exceeds its capacity */ {
             self.freeze_memtable(&state_lock)?;
         }
     }
 }
 ```
 
-You will notice this kind of pattern very often in future chapters. For example, for L0 flush,
+You will see this pattern often in later chapters. For example, an L0 flush follows this outline:
 
 ```rust,no_run
 fn force_flush_next_imm_memtable(&self) {
     let state_lock = self.state_lock.lock();
-    // get the oldest memtable and drop the read lock on LSM state
-    // write the contents to the disk
-    // get the write lock on LSM state and update the state
+    // Get the oldest memtable, then release the state read lock.
+    // Write the contents to disk.
+    // Acquire the state write lock and install the updated snapshot.
 }
 ```
 
-This ensures only one thread will be able to modify the LSM state while still allowing concurrent access to the LSM storage.
+This approach ensures that only one thread modifies the LSM state at a time while still allowing concurrent access to the storage engine.
 
-In this task, you will need to modify `put` and `delete` to respect the soft capacity limit on the memtable. When it reaches the limit, call `force_freeze_memtable` to freeze the memtable. Note that we do not have test cases over this concurrent scenario, and you will need to think about all possible race conditions on your own. Also, remember to check lock regions to ensure the critical sections are the minimum required.
+Modify `put` and `delete` to respect the memtable's soft capacity limit. When the memtable reaches that limit, call `force_freeze_memtable`. The test suite does not cover this concurrent scenario, so consider the possible races carefully. Keep each critical section as small as possible.
 
-You can simply assign the next memtable id as `self.next_sst_id()`. Note that the `imm_memtables` stores the memtables from the latest one to the earliest one. That is to say, `imm_memtables.first()` should be the last frozen memtable.
+Assign the next memtable ID with `self.next_sst_id()`. The `imm_memtables` vector stores memtables from newest to oldest, so `imm_memtables.first()` is the most recently frozen memtable.
 
 ## Task 4: Read Path - Get
 
@@ -169,24 +180,24 @@ In this task, you will need to modify:
 src/lsm_storage.rs
 ```
 
-Now that you have multiple memtables, you may modify your read path `get` function to get the latest version of a key. Ensure that you probe the memtables from the latest one to the earliest one.
+Now that you have multiple memtables, update the read-path `get` method to retrieve the latest version of a key. Probe the memtables from newest to oldest.
 
 ## Test Your Understanding
 
 * Why doesn't the memtable provide a `delete` API?
-* Does it make sense for the memtable to store all write operations instead of only the latest version of a key? For example, the user puts a->1, a->2, and a->3 into the same memtable.
-* Is it possible to use other data structures as the memtable in LSM? What are the pros/cons of using the skiplist?
+* Does it make sense for a memtable to store every write instead of only the latest version of a key? For example, suppose a user writes `a -> 1`, `a -> 2`, and `a -> 3` to the same memtable.
+* Could an LSM tree use other data structures for its memtable? What are the advantages and disadvantages of a skiplist?
 * Why do we need a combination of `state` and `state_lock`? Can we only use `state.read()` and `state.write()`?
-* Why does the order to store and to probe the memtables matter? If a key appears in multiple memtables, which version should you return to the user?
-* Is the memory layout of the memtable efficient / does it have good data locality? (Think of how `Byte` is implemented and stored in the skiplist...) What are the possible optimizations to make the memtable more efficient?
-* So we are using `parking_lot` locks in this course. Is its read-write lock a fair lock? What might happen to the readers trying to acquire the lock if there is one writer waiting for existing readers to stop?
-* After freezing the memtable, is it possible that some threads still hold the old LSM state and wrote into these immutable memtables? How does your solution prevent it from happening?
-* There are several places that you might first acquire a read lock on state, then drop it and acquire a write lock (these two operations might be in different functions but they happened sequentially due to one function calls the other). How does it differ from directly upgrading the read lock to a write lock? Is it necessary to upgrade instead of acquiring and dropping and what is the cost of doing the upgrade?
+* Why does the order in which you store and probe memtables matter? If a key appears in multiple memtables, which version should you return?
+* Is the memtable's memory layout efficient? Does it have good data locality? Consider how `Bytes` is implemented and stored in the skiplist. How could you optimize the memtable's layout?
+* This course uses `parking_lot` locks. Is its read-write lock fair? What might happen to readers waiting to acquire the lock when a writer is already waiting for the current readers to release it?
+* After a memtable is frozen, could a thread that still holds an old LSM-state snapshot write to that now-immutable memtable? How does your solution prevent this?
+* In several places, you might acquire a state read lock, release it, and then acquire a write lock. The two operations may occur in different functions that call one another. How does this differ from directly upgrading a read lock to a write lock? Is an upgrade necessary, and what does it cost?
 
-We do not provide reference answers to the questions, and feel free to discuss about them in the Discord community.
+We do not provide reference answers to these questions, so feel free to discuss them in the Discord community.
 
 ## Bonus Tasks
 
-* **More Memtable Formats.** You may implement other memtable formats. For example, BTree memtable, vector memtable, and ART memtable.
+* **More Memtable Formats.** Implement other memtable formats, such as B-tree, vector, or adaptive radix tree (ART) memtables.
 
 {{#include copyright.md}}

--- a/mini-lsm-book/src/week1-02-merge-iterator.md
+++ b/mini-lsm-book/src/week1-02-merge-iterator.md
@@ -8,11 +8,11 @@
 
 In this chapter, you will:
 
-* Implement memtable iterator.
-* Implement merge iterator.
-* Implement LSM read path `scan` for memtables.
+* Implement a memtable iterator.
+* Implement a merge iterator.
+* Implement the memtable portion of the LSM `scan` read path.
 
-To copy the test cases into the starter code and run them,
+To copy the test cases into the starter code and run them:
 
 ```
 cargo x copy-test --week 1 --day 2
@@ -21,7 +21,7 @@ cargo x scheck
 
 ## Task 1: Memtable Iterator
 
-In this chapter, we will implement the LSM `scan` interface. `scan` returns a range of key-value pairs in order using an iterator API. In the previous chapter, you have implemented the `get` API and the logic to create immutable memtables, and your LSM state should now have multiple memtables. You will need to first create iterators on a single memtable, then create a merge iterator on all memtables, and finally implement the range limit for the iterators.
+In this chapter, you will implement the LSM `scan` interface, which uses an iterator to return an ordered range of key-value pairs. In the previous chapter, you implemented `get` and the logic for creating immutable memtables, so your LSM state can now contain several memtables. You will first create an iterator over one memtable, then merge iterators from all memtables, and finally enforce the requested key range.
 
 In this task, you will need to modify:
 
@@ -29,9 +29,9 @@ In this task, you will need to modify:
 src/mem_table.rs
 ```
 
-All LSM iterators implement the `StorageIterator` trait. It has 4 functions: `key`, `value`, `next`, and `is_valid`. If you're familiar with Rust's standard library `Iterator` trait, you might find `StorageIterator` a bit different. Instead, `StorageIterator` employs a cursor-based API, a design pattern common in database systems and notably inspired by RocksDB's iterators (see [`iterator_base.h`](https://github.com/facebook/rocksdb/blob/main/include/rocksdb/iterator_base.h) and [`iterator.h`](https://github.com/facebook/rocksdb/blob/main/include/rocksdb/iterator.h) for reference).
+All LSM iterators implement the `StorageIterator` trait. Its four core methods are `key`, `value`, `next`, and `is_valid`. If you are familiar with Rust's standard-library `Iterator` trait, you will notice that `StorageIterator` works differently. It uses a cursor-based API, a pattern common in database systems and inspired by RocksDB's iterators. See [`iterator_base.h`](https://github.com/facebook/rocksdb/blob/main/include/rocksdb/iterator_base.h) and [`iterator.h`](https://github.com/facebook/rocksdb/blob/main/include/rocksdb/iterator.h) for reference.
 
-When the iterator is created, its cursor will stop on some element, and `key` / `value` will return the first key in the memtable/block/SST satisfying the start condition (i.e., start key). These two interfaces will return a `&[u8]` to avoid copy.
+When an iterator is created, its cursor points to the first entry in the memtable, block, or SST that satisfies the lower bound. The `value` method returns `&[u8]`, while `key` returns the iterator's associated borrowed key type—for example, `KeySlice`. These borrowed return values avoid copying key and value data.
 
 From the caller's perspective, the typical usage pattern is:
 
@@ -45,18 +45,18 @@ while iter.is_valid() {
 }
 ```
 
-The semantics of `StorageIterator` are distinct for its core methods:
+The core `StorageIterator` methods have distinct responsibilities:
 
-* `next()`: This method is solely responsible for attempting to move the cursor to the next element. It returns a `Result` to report any errors encountered during this advancement (e.g., I/O issues). It does *not* inherently guarantee that the new position is valid, only that the attempt to move was made.
-* `is_valid()`: This method indicates whether the iterator's current cursor points to a valid data element. It does *not* advance the iterator.
+* `next()`: Attempts to move the cursor to the next element. It returns a `Result` so that it can report errors such as I/O failures. A successful call does not guarantee that the new position is valid; the cursor may have reached the end.
+* `is_valid()`: Reports whether the current cursor points to a valid data element. It does *not* advance the iterator.
 
-Therefore, as an implementer of `StorageIterator`, after each call to `next()` (even if it succeeds without an error from the `next()` operation itself), you are responsible for updating the internal state so that `is_valid()` correctly reflects whether the new cursor position actually points to a valid item.
+After every call to `next()`, including a successful one, your implementation must update its internal state so that `is_valid()` accurately reports whether the new cursor position contains an item.
 
-In summary, `next` moves the cursor to the next place. `is_valid` returns if the iterator has reached the end or errored. You can assume `next` will only be called when `is_valid` returns true. There will be a `FusedIterator` wrapper for iterators that block calls to `next` when the iterator is not valid to avoid users from misusing the iterators.
+In summary, `next` advances the cursor, and `is_valid` reports whether that cursor still identifies an item. You may assume that callers invoke `next` only while `is_valid` returns `true`. Later, you will implement a `FusedIterator` wrapper that normalizes behavior after an iterator becomes invalid or returns an error.
 
-Back to the memtable iterator. You should have found out that the iterator does not have any lifetime associated with that. Imagine that you create a `Vec<u64>` and call `vec.iter()`, the iterator type will be something like `VecIterator<'a>`, where `'a` is the lifetime of the `vec` object. The same applies to `SkipMap`, where its `iter` API returns an iterator with a lifetime. However, in our case, we do not want to have such lifetimes on our iterators to avoid making the system overcomplicated (and hard to compile...).
+Now return to the memtable iterator. You may have noticed that its public type has no lifetime parameter. If you create a `Vec<u64>` and call `vec.iter()`, the iterator's type contains a lifetime such as `VecIterator<'a>`, where `'a` is tied to the vector. The same is true of `SkipMap::iter`. For Mini-LSM, however, we avoid exposing such lifetimes on storage iterators because doing so would complicate the entire system.
 
-If the iterator does not have a lifetime generics parameter, we should ensure that *whenever the iterator is being used, the underlying skiplist object is not freed*. The only way to achieve that is to put the `Arc<SkipMap>` object into the iterator itself. To define such a structure,
+Because the iterator has no lifetime parameter, it must ensure that *the underlying skiplist remains alive for as long as the iterator is in use*. We do this by storing an `Arc<SkipMap>` inside the iterator itself. A first attempt might look like this:
 
 ```rust,no_run
 pub struct MemtableIterator {
@@ -65,9 +65,9 @@ pub struct MemtableIterator {
 }
 ```
 
-Okay, here is the problem: we want to express that the lifetime of the iterator is the same as the `map` in the structure. How can we do that?
+The problem is that we need to express that `iter` borrows `map`, another field in the same struct. How can we represent that relationship?
 
-This is the first and most tricky Rust language thing that you will ever meet in this course -- self-referential structure. If it is possible to write something like:
+This is the first particularly tricky Rust concept in the course: a self-referential struct. If Rust allowed us to write the following, the problem would be solved:
 
 ```rust,no_run
 pub struct MemtableIterator { // <- with lifetime 'this
@@ -76,9 +76,9 @@ pub struct MemtableIterator { // <- with lifetime 'this
 }
 ```
 
-Then the problem is solved! You can do this with the help of some third-party libraries like `ouroboros`. It provides an easy way to define self-referential structure. It is also possible to do this with unsafe Rust (and indeed, `ouroboros` itself uses unsafe Rust internally...)
+Third-party crates such as `ouroboros` provide a safe interface for defining this kind of self-referential struct. You could also implement it with unsafe Rust; in fact, `ouroboros` uses unsafe Rust internally.
 
-We have leveraged [`ouroboros`](https://docs.rs/ouroboros/latest/ouroboros/attr.self_referencing.html) to define the self-referential `MemtableIterator` fields for you. You will need to implement the `MemtableIterator` logic and the `Memtable::scan` API based on this provided structure.
+We have used [`ouroboros`](https://docs.rs/ouroboros/latest/ouroboros/attr.self_referencing.html) to define the self-referential fields of `MemTableIterator` for you. Implement its iterator logic and the `MemTable::scan` API using the provided structure.
 
 ## Task 2: Merge Iterator
 
@@ -88,9 +88,9 @@ In this task, you will need to modify:
 src/iterators/merge_iterator.rs
 ```
 
-Now that you have multiple memtables and you will create multiple memtable iterators. You will need to merge the results from the memtables and return the latest version of each key to the user.
+Because the LSM state can contain multiple memtables, a scan creates multiple memtable iterators. Merge their results and return only the latest version of each key.
 
-`MergeIterator` maintains a binary heap internally. Consider the challenge of merging `n` sorted sequences (our iterators) into a single sorted output; a binary heap is a natural fit here, as it efficiently helps identify which sequence currently holds the overall smallest element. You'll see that the ordering of the binary heap is such that the iterator with the lowest head key value is first. When multiple iterators have the same head key value, the newest one is first. Note that you will need to handle errors (i.e., when an iterator is not valid) and ensure that the latest version of a key-value pair comes out.
+`MergeIterator` maintains a binary heap internally. A binary heap is a natural way to merge `n` sorted iterators because it efficiently identifies the iterator whose current key is smallest. The heap orders the iterator with the smallest current key first. When several iterators have the same current key, it orders the newest one first. Handle errors and exhausted iterators carefully, and ensure that the merge emits only the latest version of each key-value pair.
 
 For example, if we have the following data:
 
@@ -100,40 +100,40 @@ iter2: a->1, b->2, c->3
 iter3: e->4
 ```
 
-The sequence that the merge iterator outputs should be:
+The merge iterator should produce:
 
 ```
 a->1, b->del, c->4, d->5, e->4
 ```
 
-The constructor of the merge iterator takes a vector of iterators. We assume the one with a lower index (i.e., the first one) has the latest data.
+The merge iterator's constructor accepts a vector of iterators. An iterator with a lower index—closer to the front of the vector—contains newer data.
 
-When using the Rust binary heap, you may find the `peek_mut` function useful.
+When using Rust's binary heap, you may find `peek_mut` useful:
 
 ```rust,no_run
 let Some(mut inner) = heap.peek_mut() {
-    *inner += 1; // <- do some modifications to the inner item
+    *inner += 1; // Modify the top item.
 }
-// When the PeekMut reference gets dropped, the binary heap gets reordered automatically.
+// When PeekMut is dropped, the binary heap is reordered automatically.
 
 let Some(mut inner) = heap.peek_mut() {
-    PeekMut::pop(inner) // <- pop it out from the heap
+    PeekMut::pop(inner) // Remove the top item from the heap.
 }
 ```
 
-One common pitfall is on error handling. For example,
+A common pitfall involves error handling. For example:
 
 ```rust,no_run
 let Some(mut inner_iter) = self.iters.peek_mut() {
-    inner_iter.next()?; // <- will cause problem
+    inner_iter.next()?; // Problematic.
 }
 ```
 
-If `next` returns an error (i.e., due to disk failure, network failure, checksum error, etc.), it is no longer valid. However, when we go out of the if condition and return the error to the caller, `PeekMut`'s drop will try move the element within the heap, which causes an access to an invalid iterator. Therefore, you will need to do all error handling by yourself instead of using `?` within the scope of `PeekMut`.
+If `next` returns an error—for example, because of a disk, network, or checksum failure—the iterator must no longer remain in the heap. When the scope exits, however, `PeekMut::drop` attempts to restore the heap order and may access that invalid iterator. Handle the error explicitly and remove the iterator instead of using `?` while the `PeekMut` guard is alive.
 
-We want to avoid dynamic dispatch as much as possible, and therefore we do not use `Box<dyn StorageIterator>` in the system. Instead, we prefer static dispatch using generics. Also note that `StorageIterator` uses generic associated type (GAT), so that it can support both `KeySlice` and `&[u8]` as the key type. We will change `KeySlice` to include the timestamp in week 3 and using a separate type for it now can make the transition more smooth.
+We avoid dynamic dispatch where practical, so the system does not use `Box<dyn StorageIterator>`. Instead, it uses generics and static dispatch. `StorageIterator` also uses a generic associated type (GAT) for its borrowed key type, allowing different iterators to return types such as `KeySlice` or `&[u8]`. In Week 3, `KeySlice` will include a timestamp; introducing the key abstraction now makes that transition smoother.
 
-Starting this section, we will use `Key<T>` to represent LSM key types and distinguish them from values in the type system. You should use provided APIs of `Key<T>` instead of directly accessing the inner value. We will add timestamp to this key type in part 3, and using the key abstraction will make the transition more smooth. For now, `KeySlice` is equivalent to `&[u8]`, `KeyVec` is equivalent to `Vec<u8>`, and `KeyBytes` is equivalent to `Bytes`.
+From this section onward, use `Key<T>` for LSM keys so that the type system can distinguish keys from values. Use the provided `Key<T>` methods instead of accessing the wrapped value directly. In Week 3, you will add a timestamp to this type, and the abstraction will make that transition smoother. For now, `KeySlice` wraps `&[u8]`, `KeyVec` wraps `Vec<u8>`, and `KeyBytes` wraps `Bytes`.
 
 ## Task 3: LSM Iterator + Fused Iterator
 
@@ -143,17 +143,17 @@ In this task, you will need to modify:
 src/lsm_iterator.rs
 ```
 
-We use the `LsmIterator` structure to represent the internal LSM iterators. You will need to modify this structure multiple times throughout the course when more iterators are added into the system. For now, because we only have multiple memtables, it should be defined as:
+`LsmIterator` represents the storage engine's internal iterator. You will modify it several times as you add more iterator types. For now, the engine contains only memtables, so its inner type should be:
 
 ```rust,no_run
 type LsmIteratorInner = MergeIterator<MemTableIterator>;
 ```
 
-You may go ahead and implement the `LsmIterator` structure, which calls the corresponding inner iterator, and also skip deleted keys.
+Implement `LsmIterator` by delegating to the inner iterator and skipping deletion tombstones.
 
-We do not test `LsmIterator` in this task. There will be an integration test in task 4.
+This task does not test `LsmIterator` directly; Task 4 includes an integration test.
 
-Then, we want to provide extra safety on the iterator to avoid users from misusing them. Users should not call `key`, `value`, or `next` when the iterator is not valid. At the same time, they should not use the iterator anymore if `next` returns an error. `FusedIterator` is a wrapper around an iterator to normalize the behaviors across all iterators. You can go ahead and implement it by yourself.
+Next, add safeguards against iterator misuse. Callers must not invoke `key` or `value` while an iterator is invalid, and they must not continue using it after `next` returns an error. `FusedIterator` wraps another iterator to normalize these behaviors. Implement it using the contract documented in the starter code.
 
 ## Task 4: Read Path - Scan
 
@@ -163,26 +163,26 @@ In this task, you will need to modify:
 src/lsm_storage.rs
 ```
 
-We are finally there -- with all iterators you have implemented, you can finally implement the `scan` interface of the LSM engine. You can simply construct an LSM iterator with the memtable iterators (remember to put the latest memtable at the front of the merge iterator), and your storage engine will be able to handle the scan request.
+With these iterators in place, you can implement the LSM engine's `scan` interface. Construct an `LsmIterator` from the memtable iterators, placing the newest memtable first in the merge iterator. The storage engine will then be able to serve scan requests.
 
 ## Test Your Understanding
 
 * What is the time/space complexity of using your merge iterator?
-* Why do we need a self-referential structure for memtable iterator?
+* Why do we need a self-referential struct for the memtable iterator?
 * If a key is removed (there is a delete tombstone), do you need to return it to the user? Where did you handle this logic?
 * If a key has multiple versions, will the user see all of them? Where did you handle this logic?
-* If we want to get rid of self-referential structure and have a lifetime on the memtable iterator (i.e., `MemtableIterator<'a>`, where `'a` = memtable or `LsmStorageInner` lifetime), is it still possible to implement the `scan` functionality?
-* What happens if (1) we create an iterator on the skiplist memtable (2) someone inserts new keys into the memtable (3) will the iterator see the new key?
+* If we replace the self-referential struct with a lifetime on the memtable iterator—for example, `MemTableIterator<'a>`, where `'a` is tied to a memtable or `LsmStorageInner`—can we still implement `scan`?
+* Suppose that (1) you create an iterator over the skiplist memtable and (2) another thread inserts keys into that memtable. Will the iterator see the new keys?
 * What happens if your key comparator cannot give the binary heap implementation a stable order?
-* Why do we need to ensure the merge iterator returns data in the iterator construction order?
-* Is it possible to implement a Rust-style iterator (i.e., `next(&self) -> (Key, Value)`) for LSM iterators? What are the pros/cons?
-* The scan interface is like `fn scan(&self, lower: Bound<&[u8]>, upper: Bound<&[u8]>)`. How to make this API compatible with Rust-style range (i.e., `key_a..key_b`)? If you implement this, try to pass a full range `..` to the interface and see what will happen.
+* Why must the merge iterator resolve duplicate keys according to iterator construction order?
+* Could you implement a Rust-style iterator—for example, one with `next(&mut self) -> Option<(Key, Value)>`—for LSM iterators? What are the advantages and disadvantages?
+* The scan interface resembles `fn scan(&self, lower: Bound<&[u8]>, upper: Bound<&[u8]>)`. How could you make it accept Rust range syntax such as `key_a..key_b`? If you implement this API, try passing the full range `..` and observe what happens.
 * The starter code provides the merge iterator interface to store `Box<I>` instead of `I`. What might be the reason behind that?
 
-We do not provide reference answers to the questions, and feel free to discuss about them in the Discord community.
+We do not provide reference answers to these questions, so feel free to discuss them in the Discord community.
 
 ## Bonus Tasks
 
-* **Foreground Iterator.** In this course we assumed that all operations are short, so that we can hold reference to mem-table in the iterator. If an iterator is held by users for a long time, the whole mem-table (which might be 256MB) will stay in the memory even if it has been flushed to disk. To solve this, we can provide a `ForegroundIterator` / `LongIterator` to our user. The iterator will periodically create new underlying storage iterator so as to allow garbage collection of the resources.
+* **Foreground Iterator.** This course assumes that all operations are short, so an iterator can retain a reference to a memtable. If a user holds an iterator for a long time, the entire memtable—which might occupy 256 MB—remains in memory even after it has been flushed to disk. To address this issue, provide a `ForegroundIterator` or `LongIterator` that periodically creates a new underlying storage iterator, allowing the old resources to be reclaimed.
 
 {{#include copyright.md}}

--- a/mini-lsm-book/src/week1-03-block.md
+++ b/mini-lsm-book/src/week1-03-block.md
@@ -9,10 +9,10 @@
 In this chapter, you will:
 
 * Implement SST block encoding.
-* Implement SST block decoding and block iterator.
+* Implement SST block decoding and a block iterator.
 
 
-To copy the test cases into the starter code and run them,
+To copy the test cases into the starter code and run them:
 
 ```
 cargo x copy-test --week 1 --day 3
@@ -21,7 +21,7 @@ cargo x scheck
 
 ## Task 1: Block Builder
 
-You have already implemented all in-memory structures for an LSM storage engine in the previous two chapters. Now it's time to build the on-disk structures. The basic unit of the on-disk structure is blocks. Blocks are usually of 4-KB size (the size may vary depending on the storage medium), which is equivalent to the page size in the operating system and the page size on an SSD. A block stores ordered key-value pairs. An SST is composed of multiple blocks. When the number of memtables exceed the system limit, it will flush the memtable as an SST. In this chapter, you will implement the encoding and decoding of a block.
+In the previous two chapters, you implemented the in-memory structures for an LSM storage engine. Now it is time to build the on-disk structures. Their basic unit is the block, which stores sorted key-value pairs. Blocks are often 4 KiB—the typical size of an operating-system page and an SSD page—although the ideal size depends on the storage medium. An SST consists of multiple blocks. When the number of memtables exceeds the configured limit, the engine flushes a memtable to an SST. In this chapter, you will implement block encoding and decoding.
 
 In this task, you will need to modify:
 
@@ -50,12 +50,11 @@ Each entry is a key-value pair.
 -----------------------------------------------------------------------
 ```
 
-Key length and value length are both 2 bytes, which means their maximum lengths are 65535. (Internally stored as `u16`)
+The key and value lengths are each encoded in 2 bytes as `u16` values, so their maximum encoded length is 65,535 bytes.
 
-We assume that keys will never be empty, and values can be empty. An empty value means that the corresponding key has been deleted in the view of other parts of the system. For the `BlockBuilder` and `BlockIterator`, we just treat the empty value as-is.
+We assume that keys are never empty, but values may be. Other parts of the system interpret an empty value as a deletion marker, or tombstone. `BlockBuilder` and `BlockIterator` simply preserve the empty value.
 
-At the end of each block, we will store the offsets of each entry and the total number of entries. For example, if
-the first entry is at 0th position of the block, and the second entry is at 12th position of the block.
+At the end of each block, we store the offset of every entry followed by the total number of entries. For example, suppose the first entry starts at byte 0 and the second starts at byte 12:
 
 ```
 -------------------------------
@@ -65,13 +64,13 @@ the first entry is at 0th position of the block, and the second entry is at 12th
 -------------------------------
 ```
 
-The footer of the block will be as above. Each of the number is stored as `u16`.
+The block footer then has the layout shown above. Every number in the footer is stored as a `u16`.
 
-The block has a size limit, which is `target_size`. Unless the first key-value pair exceeds the target block size, you should ensure that the encoded block size is always less than or equal to `target_size`. (In the provided code, the `target_size` here is essentially the `block_size`)
+Each block has a size limit, `target_size`, which corresponds to `block_size` in the provided code. Unless the first key-value pair alone exceeds this limit, ensure that the encoded block is no larger than `target_size`.
 
-The `BlockBuilder` will produce the data part and unencoded entry offsets when `build` is called. The information will be stored in the `Block` structure. As key-value entries are stored in raw format and offsets are stored in a separate vector, this reduces unnecessary memory allocations and processing overhead when decoding data —— what you need to do is to simply copy the raw block data to the `data` vector and decode the entry offsets every 2 bytes, *instead of* creating something like `Vec<(Vec<u8>, Vec<u8>)>` to store all the key-value pairs in one block in memory. This compact memory layout is very efficient.
+When `BlockBuilder::build` is called, it produces the raw data section and the unencoded entry offsets, which are stored in a `Block`. Keeping raw key-value data contiguous and storing offsets separately avoids unnecessary allocations and decoding work. Copy the raw block data into the `data` vector and decode one entry offset every 2 bytes, rather than materializing all entries as a structure such as `Vec<(Vec<u8>, Vec<u8>)>`. This compact layout is efficient.
 
-In `Block::encode` and `Block::decode`, you will need to encode/decode the block in the format as indicated above.
+Implement `Block::encode` and `Block::decode` according to the format above.
 
 ## Task 2: Block Iterator
 
@@ -81,37 +80,37 @@ In this task, you will need to modify:
 src/block/iterator.rs
 ```
 
-Now that we have an encoded block, we will need to implement the `BlockIterator` interface, so that the user can lookup/scan keys in the block.
+Now that you have an encoded block, implement `BlockIterator` so that callers can look up and scan keys within it.
 
-`BlockIterator` can be created with an `Arc<Block>`. If `create_and_seek_to_first` is called, it will be positioned at the first key in the block. If `create_and_seek_to_key` is called, the iterator will be positioned at the first key that is `>=` the provided key. For example, if `1, 3, 5` is in a block.
+Create a `BlockIterator` from an `Arc<Block>`. `create_and_seek_to_first` positions it at the first key in the block. `create_and_seek_to_key` positions it at the first key greater than or equal to the requested key. For example, suppose a block contains `1`, `3`, and `5`:
 
 ```rust,no_run
 let mut iter = BlockIterator::create_and_seek_to_key(block, b"2");
 assert_eq!(iter.key(), b"3");
 ```
 
-The above `seek 2` will make the iterator to be positioned at the next available key of `2`, which in this case is `3`.
+Seeking to `2` positions the iterator at the next available key, which is `3`.
 
-The iterator should copy `key` from the block and store them inside the iterator (we will have key compression in the future and you will have to do so). For the value, you should only store the begin/end offset in the iterator without copying them.
+The iterator should copy the current key from the block and store it internally; this will be necessary when you add key compression. For the value, store only its start and end offsets instead of copying its bytes.
 
-When `next` is called, the iterator will move to the next position. If we reach the end of the block, we can set `key` to empty and return `false` from `is_valid`, so that the caller can switch to another block if possible.
+When `next` is called, advance the iterator by one entry. At the end of the block, set `key` to empty so that `is_valid` returns `false`; the caller can then move to another block if one is available.
 
 ## Test Your Understanding
 
 * What is the time complexity of seeking a key in the block?
 * Where does the cursor stop when you seek a non-existent key in your implementation?
-* So `Block` is simply a vector of raw data and a vector of offsets. Can we change them to `Byte` and `Arc<[u16]>`, and change all the iterator interfaces to return `Byte` instead of `&[u8]`? (Assume that we use `Byte::slice` to return a slice of the block without copying.) What are the pros/cons?
-* What is the endian of the numbers written into the blocks in your implementation?
-* Is your implementation prune to a maliciously-built block? Will there be invalid memory access, or OOMs, if a user deliberately construct an invalid block?
+* `Block` is simply a vector of raw data and a vector of offsets. Could we change them to `Bytes` and `Arc<[u16]>`, then change the iterator interfaces to return `Bytes` instead of `&[u8]`? Assume that we use `Bytes::slice` to return a slice without copying. What are the advantages and disadvantages?
+* What endianness does your implementation use for numbers written to blocks?
+* Is your implementation vulnerable to a maliciously constructed block? Could invalid input cause an out-of-bounds access or an out-of-memory condition?
 * Can a block contain duplicated keys?
 * What happens if the user adds a key larger than the target block size?
-* Consider the case that the LSM engine is built on object store services (S3). How would you optimize/change the block format and parameters to make it suitable for such services?
+* Suppose the LSM engine uses an object-storage service such as S3. How would you adapt the block format and its parameters to suit that environment?
 * Do you love bubble tea? Why or why not?
 
-We do not provide reference answers to the questions, and feel free to discuss about them in the Discord community.
+We do not provide reference answers to these questions. Feel free to discuss them in the Discord community.
 
 ## Bonus Tasks
 
-* **Backward Iterators.** You may implement `prev` for your `BlockIterator` so that you will be able to iterate the key-value pairs reversely. You may also have a variant of backward merge iterator and backward SST iterator (in the next chapter) so that your storage engine can do a reverse scan.
+* **Backward Iterators.** Implement `prev` for `BlockIterator` to iterate over key-value pairs in reverse. You can also implement backward variants of the merge iterator and, in the next chapter, the SST iterator so that the storage engine can perform reverse scans.
 
 {{#include copyright.md}}

--- a/mini-lsm-book/src/week1-04-sst.md
+++ b/mini-lsm-book/src/week1-04-sst.md
@@ -9,9 +9,9 @@
 In this chapter, you will:
 
 * Implement SST encoding and metadata encoding.
-* Implement SST decoding and iterator.
+* Implement SST decoding and an SST iterator.
   
-To copy the test cases into the starter code and run them,
+To copy the test cases into the starter code and run them:
 
 ```
 cargo x copy-test --week 1 --day 4
@@ -27,11 +27,11 @@ src/table/builder.rs
 src/table.rs
 ```
 
-SSTs are composed of data blocks and index blocks stored on the disk. Usually, data blocks are lazily loaded -- they will not be loaded into the memory until a user requests it. Index blocks can also be loaded on-demand, but in this course, we make simple assumptions that all SST index blocks (meta blocks) can fit in memory (actually we do not have a designated index block implementation.) Generally, an SST file is of 256MB size.
+SSTs consist of data blocks and index information stored on disk. Data blocks are usually loaded lazily: they remain on disk until a read requires them. Index blocks can also be loaded on demand, but this course assumes that the metadata for every SST fits in memory; we do not implement separate index blocks. An SST file is commonly around 256 MB.
 
-The SST builder is similar to block builder -- users will call `add` on the builder. You should maintain a `BlockBuilder` inside SST builder and split blocks when necessary. Also, you will need to maintain block metadata `BlockMeta`, which includes the first/last keys in each block and the offsets of each block. The `build` function will encode the SST, write everything to disk using `FileObject::create`, and return an `SsTable` object.
+The SST builder resembles the block builder: callers add entries through `add`. Maintain a `BlockBuilder` within `SsTableBuilder` and finish the current block when necessary. You must also maintain `BlockMeta` for each block, including its offset and its first and last keys. The `build` function encodes the SST, writes it to disk with `FileObject::create`, and returns an `SsTable`.
 
-The encoding of SST is like:
+The SST encoding has the following layout:
 
 ```plaintext
 -------------------------------------------------------------------------------------------
@@ -41,9 +41,9 @@ The encoding of SST is like:
 -------------------------------------------------------------------------------------------
 ```
 
-You also need to implement `estimated_size` function of `SsTableBuilder`, so that the caller can know when can it start a new SST to write data. The function doesn't need to be very accurate. Given the assumption that data blocks contain much more data than meta block, we can simply return the size of data blocks for `estimated_size`.
+Implement `SsTableBuilder::estimated_size` so that callers can decide when to begin a new SST. The estimate does not need to be exact. Because the data blocks are much larger than the metadata, returning the size of the encoded data blocks is sufficient.
 
-Besides SST builder, you will also need to complete the encoding/decoding of block metadata, so that `SsTableBuilder::build` can produce a valid SST file.
+You must also implement block-metadata encoding and decoding so that `SsTableBuilder::build` can produce a valid SST file.
 
 ## Task 2: SST Iterator
 
@@ -54,11 +54,11 @@ src/table/iterator.rs
 src/table.rs
 ```
 
-Like `BlockIterator`, you will need to implement an iterator over an SST. Note that you should load data on demand. For example, if your iterator is at block 1, it should not hold any other block content in memory until it reaches the next block.
+As with `BlockIterator`, implement an iterator over an SST. Load data blocks on demand: while the iterator is in block 1, for example, it should not retain any other block's contents.
 
 `SsTableIterator` should implement the `StorageIterator` trait, so that it can be composed with other iterators in the future.
 
-One thing to note is `seek_to_key` function. Basically, you will need to do binary search on block metadata to find which block might possibly contain the key. It is possible that the key does not exist in the LSM tree so that the block iterator will be invalid immediately after a seek. For example,
+Pay particular attention to `seek_to_key`. Use a binary search over block metadata to find the block that may contain the requested key. Because the key might not exist, the block iterator may become invalid immediately after the seek. For example:
 
 ```plaintext
 --------------------------------------
@@ -68,9 +68,9 @@ One thing to note is `seek_to_key` function. Basically, you will need to do bina
 --------------------------------------
 ```
 
-We recommend only using the first key of each block to do the binary search so as to reduce the complexity of your implementation. If we do `seek(b)` in this SST, it is quite simple -- using binary search, we can know block 1 contains keys `a <= keys < e`. Therefore, we load block 1 and seek the block iterator to the corresponding position.
+To keep the implementation simple, we recommend using only the first key of each block in the binary search. For `seek(b)`, the search shows that block 1 covers the candidate range `a <= key < e`. Load block 1 and seek its iterator to the appropriate position.
 
-But if we do `seek(d)`, we will position to block 1, if we only use first key as the binary search criteria, but seeking `d` in block 1 will reach the end of the block. Therefore, we should check if the iterator is invalid after the seek, and switch to the next block if necessary. Or you can leverage the last key metadata to directly position to a correct block, it is up to you.
+For `seek(d)`, however, searching only the first keys also selects block 1, and seeking within that block reaches its end. After a seek, check whether the iterator is invalid and advance to the next block if necessary. Alternatively, use the last-key metadata to select the correct block directly.
 
 ## Task 3: Block Cache
 
@@ -81,32 +81,32 @@ src/table/iterator.rs
 src/table.rs
 ```
 
-You can implement a new `read_block_cached` function on `SsTable` .
+Implement a new `read_block_cached` function on `SsTable`.
 
-We use [`moka-rs`](https://docs.rs/moka/latest/moka/) as our block cache implementation. Blocks are cached by `(sst_id, block_id)` as the cache key. You may use `try_get_with` to get the block from cache if it hits the cache / populate the cache if it misses the cache. If there are multiple requests reading the same block and cache misses, `try_get_with` will only issue a single read request to the disk and broadcast the result to all requests.
+We use [`moka-rs`](https://docs.rs/moka/latest/moka/) for the block cache, with `(sst_id, block_id)` as the cache key. Use `try_get_with` to return a cached block on a hit or load and cache it on a miss. If concurrent requests miss on the same block, `try_get_with` performs one disk read and shares the result among the requests.
 
-At this point, you may change your table iterator to use `read_block_cached` instead of `read_block` to leverage the block cache.
+Update the table iterator to call `read_block_cached` instead of `read_block`.
 
 ## Test Your Understanding
 
 * What is the time complexity of seeking a key in the SST?
 * Where does the cursor stop when you seek a non-existent key in your implementation?
 * Is it possible (or necessary) to do in-place updates of SST files?
-* An SST is usually large (i.e., 256MB). In this case, the cost of copying/expanding the `Vec` would be significant. Does your implementation allocate enough space for your SST builder in advance? How did you implement it?
+* An SST is usually large—for example, 256 MB—so repeatedly copying or growing its `Vec` can be expensive. Does your implementation reserve enough space for the SST builder in advance? How?
 * Looking at the `moka` block cache, why does it return `Arc<Error>` instead of the original `Error`?
 * Does the usage of a block cache guarantee that there will be at most a fixed number of blocks in memory? For example, if you have a `moka` block cache of 4GB and block size of 4KB, will there be more than 4GB/4KB number of blocks in memory at the same time?
-* Is it possible to store columnar data (i.e., a table of 100 integer columns) in an LSM engine? Is the current SST format still a good choice?
-* Consider the case that the LSM engine is built on object store services (i.e., S3). How would you optimize/change the SST format/parameters and the block cache to make it suitable for such services?
-* For now, we load the index of all SSTs into the memory. Assume you have a 16GB memory reserved for the indexes, can you estimate the maximum size of the database your LSM system can support? (That's why you need an index cache!)
+* Can an LSM engine store columnar data, such as a table with 100 integer columns? Would the current SST format still be a good choice?
+* Suppose the LSM engine uses an object-storage service such as S3. How would you adapt the SST format, its parameters, and the block cache to suit that environment?
+* For now, we load the metadata for every SST into memory. If 16 GB of memory is reserved for this metadata, can you estimate the maximum database size the LSM system could support? This limitation motivates an index cache.
 
-We do not provide reference answers to the questions, and feel free to discuss about them in the Discord community.
+We do not provide reference answers to these questions. Feel free to discuss them in the Discord community.
 
 ## Bonus Tasks
 
-* **Explore different SST encoding and layout.** For example, in the [Lethe: Enabling Efficient Deletes in LSMs](https://disc-projects.bu.edu/lethe/) paper, where the author adds secondary key support to SST.
-  * Or you can use B+ Tree as the SST format instead of sorted blocks.
+* **Explore Different SST Encodings and Layouts.** For example, the authors of [Lethe: Enabling Efficient Deletes in LSMs](https://disc-projects.bu.edu/lethe/) add secondary-key support to SSTs.
+  * Alternatively, use a B+ tree rather than sorted blocks as the SST format.
 * **Index Blocks.** Split block indexes and block metadata into index blocks, and load them on-demand.
 * **Index Cache.** Use a separate cache for indexes apart from the data block cache.
-* **I/O Optimizations.** Align blocks to 4KB boundary and use direct I/O to bypass the system page cache.
+* **I/O Optimizations.** Align blocks to 4 KiB boundaries and use direct I/O to bypass the system page cache.
 
 {{#include copyright.md}}

--- a/mini-lsm-book/src/week1-05-read-path.md
+++ b/mini-lsm-book/src/week1-05-read-path.md
@@ -12,7 +12,7 @@ In this chapter, you will:
 * Implement LSM read path `get` with SSTs.
 * Implement LSM read path `scan` with SSTs.
 
-To copy the test cases into the starter code and run them,
+To copy the test cases into the starter code and run them:
 
 ```
 cargo x copy-test --week 1 --day 5
@@ -27,9 +27,9 @@ In this task, you will need to modify:
 src/iterators/two_merge_iterator.rs
 ```
 
-You have already implemented a merge iterator that merges iterators of the same type (i.e., memtable iterators). Now that we have implemented the SST formats, we have both on-disk SST structures and in-memory memtables. When we scan from the storage engine, we will need to merge data from both memtable iterators and SST iterators into a single one. In this case, we need a `TwoMergeIterator<X, Y>` that merges two different types of iterators.
+You have already implemented a merge iterator for iterators of the same type, such as memtable iterators. Now that the SST format is implemented, the engine has both in-memory memtables and on-disk SSTs. A scan must merge memtable and SST iterators into a single stream. For this purpose, implement `TwoMergeIterator<X, Y>`, which can merge two different iterator types.
 
-You can implement `TwoMergeIterator` in `two_merge_iterator.rs`. As we only have two iterators here, we do not need to maintain a binary heap. Instead, we can simply use a flag to indicate which iterator to read. Similar to `MergeIterator`, if the same key is found in both of the iterator, the first iterator takes the precedence.
+Because there are only two iterators, `TwoMergeIterator` does not need a binary heap. A flag can indicate which iterator currently has precedence. As in `MergeIterator`, when both iterators contain the same key, the first iterator takes precedence.
 
 ## Task 2: Read Path - Scan
 
@@ -47,19 +47,19 @@ type LsmIteratorInner =
     TwoMergeIterator<MergeIterator<MemTableIterator>, MergeIterator<SsTableIterator>>;
 ```
 
-So that our internal iterator of the LSM storage engine will be an iterator combining both data from the memtables and the SSTs.
+This type combines data from memtables and SSTs into the storage engine's internal iterator.
 
-Currently, our SST iterator doesn't support an end bound for scans. To address this, you'll need to implement this boundary check within the `LsmIterator` itself. This involves updating the `LsmIterator::new` constructor to accept an `end_bound` parameter:
+The SST iterator does not support an end bound for scans. Enforce that bound in `LsmIterator` by updating its constructor to accept an `end_bound`:
 
 ```rust,no_run
 pub(crate) fn new(iter: LsmIteratorInner, end_bound: Bound<Bytes>) -> Result<Self> {}
 ```
 
-You will then need to modify the `LsmIterator`'s iteration logic to ensure it stops when the keys from the inner iterator reach or exceed this specified `end_bound`.
+Then update the iteration logic to stop according to the bound's semantics: before an excluded end key, or after an included end key.
 
-Our test cases will generate some memtables and SSTs in `l0_sstables`, and you will need to scan all of these data out correctly in this task. You do not need to flush SSTs until next chapter. Therefore, you can go ahead and modify your `LsmStorageInner::scan` interface to create a merge iterator over all memtables and SSTs, so as to finish the read path of your storage engine.
+The tests create memtables and SSTs referenced by `l0_sstables`; your scan must return their combined contents correctly. You do not need to implement flushing until the next chapter. For now, update `LsmStorageInner::scan` to create a merge iterator over all memtables and L0 SSTs, completing the engine's scan path.
 
-Because `SsTableIterator::create` involves I/O operations and might be slow, we do not want to do this in the `state` critical section. Therefore, you should firstly take read the `state` and clone the `Arc` of the LSM state snapshot. Then, you should drop the lock. After that, you can go through all L0 SSTs and create iterators for each of them, then create a merge iterator to retrieve the data.
+Creating and initially seeking an `SsTableIterator` may perform I/O, so do not do it while holding the `state` lock. First acquire the read lock and clone the `Arc` containing the state snapshot. Release the lock, then create an iterator for each L0 SST and merge the resulting streams.
 
 ```rust,no_run
 fn scan(&self) {
@@ -71,7 +71,7 @@ fn scan(&self) {
 }
 ```
 
-In the LSM storage state, we only store the SST ids in the `l0_sstables` vector. You will need to retrieve the actual SST object from the `sstables` hash map.
+The `l0_sstables` vector stores only SST IDs. Retrieve the corresponding `SsTable` objects from the `sstables` map.
 
 ## Task 3: Read Path - Get
 
@@ -81,18 +81,18 @@ In this task, you will need to modify:
 src/lsm_storage.rs
 ```
 
-For get requests, it will be processed as lookups in the memtables, and then scans on the SSTs. You can create a merge iterator over all SSTs after probing all memtables. You can seek to the key that the user wants to lookup. There are two possibilities of the seek: the key is the same as what the user probes, and the key is not the same / does not exist. You should only return the value to the user when the key exists and is the same as probed. You should also reduce the critical section of the state lock as in the previous section. Also remember to handle deleted keys.
+Process a `get` as direct lookups in the memtables followed, if necessary, by a seek over a merge iterator of the SSTs. A seek may land on the requested key or on the next greater key, so return a value only if the iterator's key exactly matches the requested key. As in the scan path, minimize the `state` lock's critical section. Preserve newest-to-oldest precedence, and treat an empty value as a tombstone rather than continuing to older data.
 
 ## Test Your Understanding
 
-* Consider the case that a user has an iterator that iterates the whole storage engine, and the storage engine is 1TB large, so that it takes ~1 hour to scan all the data. What would be the problems if the user does so? (This is a good question and we will ask it several times at different points of the course...)
-* Another popular interface provided by some LSM-tree storage engines is multi-get (or vectored get). The user can pass a list of keys that they want to retrieve. The interface returns the value of each of the key. For example, `multi_get(vec!["a", "b", "c", "d"]) -> a=1,b=2,c=3,d=4`. Obviously, an easy implementation is to simply doing a single get for each of the key. How will you implement the multi-get interface, and what optimizations you can do to make it more efficient? (Hint: some operations during the get process will only need to be done once for all keys, and besides that, you can think of an improved disk I/O interface to better support this multi-get interface).
+* Suppose a user creates an iterator over the entire 1 TB storage engine, and the scan takes about an hour. What problems could this cause? We will revisit this question at several points in the course.
+* Some LSM-tree storage engines provide a multi-get, or vectored-get, interface. The caller supplies a list of keys and receives a value for each one; for example, `multi_get(vec!["a", "b", "c", "d"]) -> a=1,b=2,c=3,d=4`. The simplest implementation performs one `get` per key. How would you implement multi-get, and what could you optimize? Hint: some work in the get path needs to be performed only once for the entire batch. You can also consider an improved disk-I/O interface designed for multi-get.
 
-We do not provide reference answers to the questions, and feel free to discuss about them in the Discord community.
+We do not provide reference answers to these questions. Feel free to discuss them in the Discord community.
 
 ## Bonus Tasks
 
 * **The Cost of Dynamic Dispatch.** Implement a `Box<dyn StorageIterator>` version of merge iterators and benchmark to see the performance differences.
-* **Parallel Seek.** Creating a merge iterator requires loading the first block of all underlying SSTs (when you create `SSTIterator`). You may parallelize the process of creating iterators.
+* **Parallel Seek.** Creating a merge iterator requires loading the first relevant block from every underlying SST when you create each `SsTableIterator`. Consider creating these iterators in parallel.
 
 {{#include copyright.md}}

--- a/mini-lsm-book/src/week1-06-write-path.md
+++ b/mini-lsm-book/src/week1-06-write-path.md
@@ -12,7 +12,7 @@ In this chapter, you will:
 * Implement the logic to correctly update the LSM state.
 
 
-To copy the test cases into the starter code and run them,
+To copy the test cases into the starter code and run them:
 
 ```
 cargo x copy-test --week 1 --day 6
@@ -21,7 +21,7 @@ cargo x scheck
 
 ## Task 1: Flush Memtable to SST
 
-At this point, we have all in-memory things and on-disk files ready, and the storage engine is able to read and merge the data from all these structures. Now, we are going to implement the logic to move things from memory to the disk (so-called flush), and complete the Mini-LSM week 1 course.
+At this point, the in-memory and on-disk structures are ready, and the storage engine can read and merge data from them. You will now implement flushing—the process of moving data from memory to disk—and complete Week 1 of Mini-LSM.
 
 In this task, you will need to modify:
 
@@ -30,40 +30,45 @@ src/lsm_storage.rs
 src/mem_table.rs
 ```
 
-You will need to modify `LSMStorageInner::force_flush_next_imm_memtable` and `MemTable::flush`. In `LSMStorageInner::open`, you will need to create the LSM database directory if it does not exist. To flush a memtable to the disk, we will need to do three things:
+Modify `LsmStorageInner::force_flush_next_imm_memtable` and `MemTable::flush`. In `LsmStorageInner::open`, create the database directory if it does not exist. Flushing a memtable requires three steps:
 
 * Select a memtable to flush.
-* Create an SST file corresponding to a memtable.
-* Remove the memtable from the immutable memtable list and add the SST file to L0 SSTs.
+* Create an SST file from that memtable.
+* Remove the memtable from the immutable-memtable list and add the new SST to L0.
 
-We have not explained what is L0 (level-0) SSTs for now. In general, they are the set of SSTs files directly created as a result of memtable flush. In week 1 of this course, we will only have L0 SSTs on the disk. We will dive into how to organize them efficiently using leveled or tiered structure on the disk in week 2.
+We have not yet discussed level 0 (L0). It contains SST files produced directly by memtable flushes, so their key ranges may overlap. During Week 1, all on-disk SSTs remain in L0. In Week 2, you will explore how leveled and tiered compaction strategies organize SSTs efficiently.
 
-Note that creating an SST file is a compute-heavy and a costly operation. Again, we do not want to hold the `state` read/write lock for a long time, as it might block other operations and create huge latency spikes in the LSM operations. Also, we use the `state_lock` mutex to serialize state modification operations in the LSM tree. In this task, you will need to think carefully how to use these locks to make the LSM state modification race-condition free while minimizing critical sections.
+Creating an SST is computationally expensive and involves I/O. Do not hold the `state` read-write lock throughout this work: doing so could block other operations and cause large latency spikes. The `state_lock` mutex serializes operations that modify the LSM-tree state. Use both locks carefully to prevent races while keeping critical sections short.
 
-We do not have concurrent test cases and you will need to think carefully about your implementation. Also, remember that the last memtable in the immutable memtable list is the earliest one, and is the one that you should flush.
+The test suite does not exercise all concurrent cases, so reason carefully about synchronization. The last memtable in `imm_memtables` is the oldest and therefore the one to flush.
 
 <details>
 
-<summary>Spoilers: Flush L0 Pseudo Code</summary>
+<summary>Spoiler: L0 Flush Pseudocode</summary>
 
 ```rust,no_run
-fn flush_l0(&self) {
+fn force_flush_next_imm_memtable(&self) -> Result<()> {
     let _state_lock = self.state_lock.lock();
 
-    let memtable_to_flush;
-    let snapshot = {
+    let memtable_to_flush = {
         let guard = self.state.read();
-        memtable_to_flush = guard.imm_memtables.last();
+        guard.imm_memtables.last().unwrap().clone()
     };
 
-    let sst = memtable_to_flush.flush()?;
+    let sst_id = memtable_to_flush.id();
+    let sst = build_sst_from_memtable(&memtable_to_flush, sst_id)?;
 
     {
-        let guard = self.state.write();
-        guard.imm_memtables.pop();
-        guard.l0_sstables.insert(0, sst);
-    };
+        let mut guard = self.state.write();
+        let mut snapshot = guard.as_ref().clone();
+        let removed = snapshot.imm_memtables.pop().unwrap();
+        assert_eq!(removed.id(), sst_id);
+        snapshot.l0_sstables.insert(0, sst_id);
+        snapshot.sstables.insert(sst_id, sst);
+        *guard = Arc::new(snapshot);
+    }
 
+    Ok(())
 }
 ```
 
@@ -78,19 +83,19 @@ src/lsm_storage.rs
 src/compact.rs
 ```
 
-When the number of memtables (immutable + mutable) in memory exceeds the `num_memtable_limit` in LSM storage options, you should flush the earliest memtable to the disk. This is done by a flush thread in the background. The flush thread will be started with the `MiniLSM` structure. We have already implemented necessary code to start the thread and properly stop the thread.
+When the number of immutable memtables reaches the `num_memtable_limit` configured in the storage options, flush the oldest one to disk. A background flush thread performs this work. The `MiniLsm` wrapper already contains the code needed to start the thread and signal it to stop.
 
-In this task, you will need to implement `LsmStorageInner::trigger_flush` in `compact.rs`, and `MiniLsm::close` in `lsm_storage.rs`. `trigger_flush` will be executed every 50 milliseconds. If the number of memtables exceed the limit, you should call `force_flush_next_imm_memtable` to flush a memtable. When the user calls the `close` function, you should wait until the flush thread (and the compaction thread in week 2) to finish.
+Implement `LsmStorageInner::trigger_flush` in `compact.rs` and `MiniLsm::close` in `lsm_storage.rs`. The background thread calls `trigger_flush` every 50 milliseconds. When the number of memtables reaches the limit, call `force_flush_next_imm_memtable`. When the user calls `close`, signal the background threads to stop and wait for the flush thread—and, in Week 2, the compaction thread—to finish.
 
 ## Task 3: Filter the SSTs
 
-Now that you have a fully working storage engine, and you can use the mini-lsm-cli to interact with your storage engine.
+Now that you have a working storage engine, use `mini-lsm-cli` to interact with it:
 
 ```shell
 cargo run --bin mini-lsm-cli -- --compaction none
 ```
 
-And then,
+At the prompt, run:
 
 ```
 fill 1000 3000
@@ -103,9 +108,9 @@ get 2333
 scan 2000 2333
 ```
 
-If you fill more data, you can see your flush thread working and automatically flushing the L0 SSTs without using the `flush` command.
+If you insert more data, you can observe the background thread automatically flushing memtables to L0 without an explicit `flush` command.
 
-And lastly, let us implement a simple optimization on filtering the SSTs before we end this week. Based on the key range that the user provides, we can easily filter out some SSTs that do not contain the key range, so that we do not need to read them in the merge iterator.
+Finally, implement a simple SST-filtering optimization. Using the requested key or key range and each SST's first and last keys, exclude SSTs that cannot contribute any results. The merge iterator then avoids reading those files.
 
 In this task, you will need to modify:
 
@@ -115,7 +120,7 @@ src/iterators/*
 src/lsm_iterator.rs
 ```
 
-You will need to change your read path functions to skip the SSTs that is impossible to contain the key/key range. You will need to implement `num_active_iterators` for your iterators so that the test cases can do the check on whether your implementation is correct or not. For `MergeIterator` and `TwoMergeIterator`, it is the sum of `num_active_iterators` of all children iterators. Note that if you did not modify the fields in the starter code of `MergeIterator`, remember to also take `MergeIterator::current` into account. For `LsmIterator` and `FusedIterator`, simply return the number of active iterators from the inner iterator.
+Update the read path to skip SSTs that cannot contain the requested key or overlap the requested range. Also implement `num_active_iterators` so the tests can verify the optimization. For `MergeIterator` and `TwoMergeIterator`, return the sum of their children's active-iterator counts. If you retained the starter code's `MergeIterator` fields, remember to include `MergeIterator::current`. For `LsmIterator` and `FusedIterator`, delegate to the inner iterator.
 
 You can implement helper functions like `range_overlap` and `key_within` to simplify your code.
 
@@ -123,15 +128,15 @@ You can implement helper functions like `range_overlap` and `key_within` to simp
 
 * What happens if a user requests to delete a key twice?
 * How much memory (or number of blocks) will be loaded into memory at the same time when the iterator is initialized?
-* Some crazy users want to *fork* their LSM tree. They want to start the engine to ingest some data, and then fork it, so that they get two identical dataset and then operate on them separately. An easy but not efficient way to implement is to simply copy all SSTs and the in-memory structures to a new directory and start the engine. However, note that we never modify the on-disk files, and we can actually reuse the SST files from the parent engine. How do you think you can implement this fork functionality efficiently without copying data? (Check out [Neon Branching](https://neon.tech/docs/introduction/branching)).
-* Imagine you are building a multi-tenant LSM system where you host 10k databases on a single 128GB memory machine. The memtable size limit is set to 256MB. How much memory for memtable do you need for this setup?
-  * Obviously, you don't have enough memory for all these memtables. Assume each user still has their own memtable, how can you design the memtable flush policy to make it work? Does it make sense to make all these users share the same memtable (i.e., by encoding a tenant ID as the key prefix)?
+* Suppose users want to *fork* an LSM tree: after ingesting data, they create two identical datasets and modify them independently. A simple but inefficient implementation copies every SST and in-memory structure to a new directory. Because on-disk SSTs are immutable, the fork can instead reuse its parent's files. How could you implement this efficiently without copying data? See [Neon Branching](https://neon.tech/docs/introduction/branching).
+* Imagine a multitenant LSM system hosting 10,000 databases on one machine with 128 GB of memory. If each memtable has a 256 MB size limit, how much memory would all memtables require?
+  * You clearly do not have enough memory for all of them to reach that limit simultaneously. If each tenant still has a separate memtable, how could you design the flush policy to fit within the global memory budget? Would sharing one memtable among tenants—for example, by encoding a tenant ID in each key prefix—make sense?
 
-We do not provide reference answers to the questions, and feel free to discuss about them in the Discord community.
+We do not provide reference answers to these questions. Feel free to discuss them in the Discord community.
 
 ## Bonus Tasks
 
-* **Implement Write/L0 Stall.** When the number of memtables exceed the maximum number too much, you can stop users from writing to the storage engine. You may also implement write stall for L0 tables in week 2 after you have implemented compactions.
+* **Implement Write/L0 Stalls.** When the number of memtables grows too far beyond the limit, pause user writes. After implementing compaction in Week 2, you can also add write stalls based on the number of L0 SSTs.
 * **Prefix Scan.** You may filter more SSTs by implementing the prefix scan interface and using the prefix information.
 
 {{#include copyright.md}}

--- a/mini-lsm-book/src/week1-07-sst-optimizations.md
+++ b/mini-lsm-book/src/week1-07-sst-optimizations.md
@@ -6,15 +6,15 @@
 
 ![Chapter Overview](./lsm-tutorial/week1-07-overview.svg)
 
-In the previous chapter, you already built a storage engine with get/scan/put support. At the end of this week, we will implement some easy but important optimizations of SST formats. Welcome to Mini-LSM's week 1 snack time!
+In the previous chapter, you completed a storage engine that supports `get`, `scan`, and `put`. To finish the week, you will implement two approachable but important SST-format optimizations. Welcome to Week 1's snack-time chapter!
 
 In this chapter, you will:
 
-* Implement bloom filter on SSTs and integrate into the LSM read path `get`.
-* Implement key compression in SST block format.
+* Implement Bloom filters for SSTs and integrate them into the `get` path.
+* Implement key-prefix compression in the SST block format.
 
 
-To copy the test cases into the starter code and run them,
+To copy the test cases into the starter code and run them:
 
 ```
 cargo x copy-test --week 1 --day 7
@@ -23,11 +23,11 @@ cargo x scheck
 
 ## Task 1: Bloom Filters
 
-Bloom filters are probabilistic data structures that maintains a set of keys. You can add keys to a bloom filter, and you can know what key may exist / must not exist in the set of keys being added to the bloom filter.
+A Bloom filter is a probabilistic data structure that represents set membership. After adding keys, you can ask whether a key may belong to the set or definitely does not belong to it. False positives are possible; false negatives are not.
 
-You usually need to have a hash function in order to construct a bloom filter, and a key can have multiple hashes. Let us take a look at the below example. Assume that we already have hashes of some keys and the bloom filter has 7 bits.
+Constructing a Bloom filter requires hashing each key, usually to several bit positions. Consider the following example, in which each key has two hashes and the filter contains 7 bits:
 
-[Note: If you want to understand bloom filters better, look [here](https://samwho.dev/bloom-filters/)]
+For a more detailed introduction, see [Bloom Filters by Example](https://samwho.dev/bloom-filters/).
 
 ```plaintext 
 hash1 = ((character - a) * 13) % 7
@@ -40,7 +40,7 @@ g -> 1 3
 h -> 0 0
 ```
 
-If we insert b, c, d into the 7-bit bloom filter, we will get:
+Inserting `b`, `c`, and `d` produces this filter:
 
 ```
     bit  0123456
@@ -50,9 +50,9 @@ insert d     11
 result   0101111
 ```
 
-When probing the bloom filter, we generate the hashes for a key, and see if the corresponding bit has been set. If all of them are set to true, then the key may exist in the bloom filter. Otherwise, the key must NOT exist in the bloom filter.
+To probe the filter, hash the key and inspect the corresponding bits. If every bit is set, the key may belong to the original set. If any bit is clear, the key definitely does not belong to the set.
 
-For `e -> 3 2`, as the bit 2 is not set, it should not be in the original set. For `g -> 1 3`, because two bits are all set, it may or may not exist in the set. For `h -> 0 0`, both of the bits (actually it's one bit) are not set, and therefore it should not be in the original set.
+For `e -> 3 2`, bit 2 is clear, so `e` is definitely absent. For `g -> 1 3`, both bits are set, so `g` may or may not be present. For `h -> 0 0`, the single referenced bit is clear, so `h` is definitely absent.
 
 ```
 b -> maybe (actual: yes)
@@ -63,7 +63,7 @@ g -> maybe (actual: no)
 h -> MUST not (actual: no)
 ```
 
-Remember that at the end of last chapter, we implemented SST filtering based on key range. Now, on the `get` read path, we can also use the bloom filter to ignore SSTs that do not contain the key that the user wants to lookup, therefore reducing the number of files to be read from the disk.
+In the previous chapter, you filtered SSTs by key range. On the `get` path, a Bloom filter can additionally exclude SSTs that definitely do not contain the requested key, reducing disk reads.
 
 In this task, you will need to modify:
 
@@ -71,7 +71,7 @@ In this task, you will need to modify:
 src/table/bloom.rs
 ```
 
-In the implementation, you will build a bloom filter from key hashes (which are u32 numbers). For each of the hash, you will need to set `k` bits. The bits are computed by:
+Build the Bloom filter from `u32` key hashes. For each hash, set `k` bits using the following sequence:
 
 ```rust,no_run
 let delta = (h >> 17) | (h << 15); // h is the key hash
@@ -81,7 +81,7 @@ for _ in 0..k {
 }
 ```
 
-We provide all the skeleton code for doing the magic mathematics. You only need to implement the procedure of building a bloom filter and probing a bloom filter.
+The starter code provides the remaining calculations. Implement the procedures for building and probing the filter.
 
 ## Task 2: Integrate Bloom Filter on the Read Path
 
@@ -93,7 +93,7 @@ src/table.rs
 src/lsm_storage.rs
 ```
 
-For the bloom filter encoding, you can append the bloom filter to the end of your SST file. You will need to store the bloom filter offset at the end of the file, and compute meta offsets accordingly.
+Append the encoded Bloom filter to the SST file and store its offset at the end. Account for that new section when reading the metadata offset.
 
 ```plaintext
 -----------------------------------------------------------------------------------------------------
@@ -104,11 +104,11 @@ For the bloom filter encoding, you can append the bloom filter to the end of you
 -----------------------------------------------------------------------------------------------------
 ```
 
-We use the `farmhash` crate to compute the hashes of the keys. When building the SST, you will need also to build the bloom filter by computing the key hash using `farmhash::fingerprint32`. You will need to encode/decode the bloom filters with the block meta. You can choose false positive rate 0.01 for your bloom filter. You may need to add new fields to the structures apart from the ones provided in the starter code as necessary.
+Use the `farmhash` crate to hash keys. While building the SST, compute each key's hash with `farmhash::fingerprint32`, then build and encode the Bloom filter. When opening an SST, decode both its block metadata and its Bloom filter. Use a false-positive rate of 0.01. Add fields to the provided structures as needed.
 
-After that, you can modify the `get` read path to filter SSTs based on bloom filters.
+Then update the `get` path to filter SSTs with their Bloom filters.
 
-We do not have integration test for this part and you will need to ensure that your implementation still pass all previous chapter tests.
+There is no integration test specifically for this optimization, so ensure that all tests from earlier chapters still pass.
 
 ## Task 3: Key Prefix Encoding + Decoding
 
@@ -119,25 +119,25 @@ src/block/builder.rs
 src/block/iterator.rs
 ```
 
-As the SST file stores keys in order, it is possible that the user stores keys of the same prefix, and we can compress the prefix in the SST encoding so as to save space.
+Because an SST stores keys in sorted order, nearby keys often share a prefix. Encoding that prefix only once can save space.
 
-We compare the current key with the first key in the block. We store the key as follows:
+Compare each key with the first key in its block, and encode it as follows:
 
 ```
 key_overlap_len (u16) | rest_key_len (u16) | key (rest_key_len)
 ```
 
-The `key_overlap_len` indicates how many bytes are the same as the first key in the block. For example, if we see a record: `5|3|LSM`, where the first key in the block is `mini-something`, we can recover the current key to `mini-LSM`.
+`key_overlap_len` is the length of the shared prefix, in bytes. For example, if the first key is `mini-something`, the record `5|3|LSM` reconstructs the key `mini-LSM`.
 
-After you finish the encoding, you will also need to implement decoding in the block iterator. You may need to add new fields to the structures apart from the ones provided in the starter code as necessary.
+After implementing the encoding, update the block iterator to reconstruct keys while decoding. Add fields to the provided structures as needed.
 
 ## Test Your Understanding
 
-* How does the bloom filter help with the SST filtering process? What kind of information can it tell you about a key? (may not exist/may exist/must exist/must not exist)
-* Consider the case that we need a backward iterator. Does our key compression affect backward iterators?
-* Can you use bloom filters on scan?
-* What might be the pros/cons of doing key-prefix encoding over adjacent keys instead of with the first key in the block?
+* How does a Bloom filter help filter SSTs? Which claims can it make about a key: may not exist, may exist, must exist, or must not exist?
+* If we need a backward iterator, how does this key compression affect it?
+* Can Bloom filters help with scans?
+* What are the advantages and disadvantages of prefix-encoding each key relative to the previous key rather than the first key in the block?
 
-We do not provide reference answers to the questions, and feel free to discuss about them in the Discord community.
+We do not provide reference answers to these questions. Feel free to discuss them in the Discord community.
 
 {{#include copyright.md}}

--- a/mini-lsm-book/src/week1-overview.md
+++ b/mini-lsm-book/src/week1-overview.md
@@ -6,16 +6,16 @@
 
 ![Chapter Overview](./lsm-tutorial/week1-overview.svg)
 
-In the first week of the course, you will build necessary storage formats for the storage engine, the read path and the write path of the system, and have a working implementation of an LSM-based key-value store. There are 7 chapters (days) for this part.
+In the first week, you will build the storage engine's core formats, read path, and write path. By the end of its seven chapters, you will have a working LSM-based key-value store.
 
-* [Day 1: Memtable](./week1-01-memtable.md). You will implement the in-memory read and write path of the system.
-* [Day 2: Merge Iterator](./week1-02-merge-iterator.md). You will extend what you have built in day 1 and implement a `scan` interface for your system.
-* [Day 3: Block Encoding](./week1-03-block.md). Now we start the first step of the on-disk structure and build the encoding/decoding of the blocks.
-* [Day 4: SST Encoding](./week1-04-sst.md). SSTs are composed of blocks and at the end of the day, you will have the basic building blocks of the LSM on-disk structure.
-* [Day 5: Read Path](./week1-05-read-path.md). Now that we have both in-memory and on-disk structures, we can combine them together and have a fully-working read path for the storage engine.
-* [Day 6: Write Path](./week1-06-write-path.md). In day 5, the test harness generates the structures, and in day 6, you will control the SST flushes by yourself. You will implement flush to level-0 SST and the storage engine is complete.
-* [Day 7: SST Optimizations](./week1-07-sst-optimizations.md). We will implement several SST format optimizations and improve the performance of the system.
+* [Day 1: Memtable](./week1-01-memtable.md). Implement the system's in-memory read and write paths.
+* [Day 2: Merge Iterator](./week1-02-merge-iterator.md). Extend what you built on Day 1 and implement the system's `scan` interface.
+* [Day 3: Block Encoding](./week1-03-block.md). Take the first step toward an on-disk representation by implementing block encoding and decoding.
+* [Day 4: SST Encoding](./week1-04-sst.md). Compose blocks into SSTs to create the basic building blocks of the LSM tree's on-disk structure.
+* [Day 5: Read Path](./week1-05-read-path.md). Combine the in-memory and on-disk structures into a complete read path.
+* [Day 6: Write Path](./week1-06-write-path.md). Take over the SST creation that the Day 5 test harness performed for you. Flush memtables to level-0 SSTs to complete the storage engine.
+* [Day 7: SST Optimizations](./week1-07-sst-optimizations.md). Implement several SST-format optimizations to improve system performance.
 
-At the end of the week, your storage engine should be able to handle all get/scan/put requests. The only missing parts are persisting the LSM state to disk and a more efficient way of organizing the SSTs on the disk. You will have a working **Mini-LSM** storage engine.
+At the end of the week, your storage engine should be able to handle `get`, `scan`, and `put` requests. The remaining work is to persist the LSM state across restarts and organize SSTs on disk more efficiently. You will have a working **Mini-LSM** storage engine.
 
 {{#include copyright.md}}


### PR DESCRIPTION
## Summary

- copyedit the Mini-LSM preface, overview, environment setup, and all Week 1 chapters for flow, clarity, grammar, and consistent terminology
- align identifiers, task descriptions, iterator semantics, and storage-engine behavior with the starter and reference implementations
- correct the L0 flush pseudocode and document the actual immutable-memtable flush threshold

## Impact

The introductory course material is clearer and more consistent while preserving its original meaning. Students should also encounter fewer discrepancies between the book and the code they are asked to implement.

## Validation

- `mdbook build mini-lsm-book`
- `typos` across all 11 edited chapters
- `git diff --check`
- `cargo test -p mini-lsm --tests` (58 passed)
