### PR TITLE
strengthen Week 2 learning and persistence

### DIFF
--- a/mini-lsm-book/src/week2-01-compaction.md
+++ b/mini-lsm-book/src/week2-01-compaction.md
@@ -6,13 +6,14 @@
 
 ![Chapter Overview](./lsm-tutorial/week2-01-full.svg)
 
-In this chapter, you will:
+By the end of this chapter, you will be able to:
 
 * Implement the compaction logic that combines some files and produces new files.
-* Implement the logic to update the LSM states and manage SST files on the filesystem.
-* Update LSM read path to incorporate the LSM levels.
+* Install a compaction result without losing SSTs flushed concurrently.
+* Update the LSM read path to incorporate non-overlapping sorted runs.
+* Explain why iterator priority and the destination level determine whether a tombstone can be discarded.
 
-To copy the test cases into the starter code and run them,
+To copy the test cases into the starter code and run them:
 
 ```
 cargo x copy-test --week 2 --day 1
@@ -21,25 +22,39 @@ cargo x scheck
 
 <div class="warning">
 
-It might be helpful to take a look at [week 2 overview](./week2-overview.md) before reading this chapter to have a general overview of compactions.
+Read the [Week 2 overview](./week2-overview.md) before beginning this chapter for an introduction to compaction and amplification.
 
 </div>
 
+## Before You Begin
+
+At the end of Week 1, every flush creates a new L0 SST. L0 files can have overlapping key ranges and are stored from newest to oldest. This chapter introduces L1, one sorted run whose SSTs have non-overlapping key ranges and are ordered by their first keys.
+
+Keep these invariants in mind while implementing the tasks:
+
+1. When several inputs contain the same key, the iterator representing the newest source must win.
+2. L0 may overlap, but the SSTs produced for L1 must be ordered and non-overlapping.
+3. A tombstone may be discarded only when the compaction includes every possible older version of that key. In this chapter, full compaction targets the bottom level, so that condition holds.
+4. Merging and writing output SSTs happens outside `state_lock`. Installing the result happens while holding it, and must remove only the files named by the task. An L0 SST flushed after the task was created must remain in the new state.
+5. If every surviving entry is a tombstone, compaction produces no SST rather than building an empty one.
+
+> **Predict before coding:** A full-compaction task captures L0 files `[5, 4]` and L1 files `[1, 2]`. While it is writing output SSTs, file 6 is flushed to the front of L0. Which files should remain in L0 after the result is installed? If the newest value of `k` in file 5 is a tombstone and an older value is in file 1, should either entry appear in the output?
+
 ## Task 1: Compaction Implementation
 
-In this task, you will implement the core logic of doing a compaction -- merge sort a set of SST files into a sorted run. You will need to modify:
+In this task, implement the core compaction operation: merge a set of SSTs into a sorted run. You will need to modify:
 
 ```
 src/compact.rs
 ```
 
-Specifically, the `force_full_compaction` and `compact` function. `force_full_compaction` is the compaction trigger that decides which files to compact and update the LSM state. `compact` does the actual compaction job that merges some SST files and return a set of new SST files.
+Specifically, implement the `force_full_compaction` and `compact` functions. `force_full_compaction` chooses the files and installs the result in the LSM state. `compact` performs the merge and returns a set of new SSTs.
 
-Your compaction implementation should take all SSTs in the storage engine, do a merge over them by using `MergeIterator`, and then use the SST builder to write the result into new files. You will need to split the SST files if the file is too large. After compaction completes, you can update the LSM state to add all the new sorted run to the first level of the LSM tree. And, you will need to remove unused files in the LSM tree. In your implementation, your SSTs should only be stored in two places: the L0 SSTs and the L1 SSTs. That is to say, the `levels` structure in the LSM state should only have one vector. In `LsmStorageState`, we have already initialized the LSM to have L1 in `levels` field.
+Use `MergeIterator` to merge every SST captured by the task, then write the surviving entries through `SsTableBuilder`. Split the output when it reaches the target SST size. After the merge finishes, install the output as the L1 sorted run and remove the obsolete inputs from the state and filesystem. At this stage, SSTs appear only in L0 or L1, so `LsmStorageState::levels` contains one entry.
 
-Compaction should not block L0 flush, and therefore you should not take the state lock when merging the files. You should only take the state lock at the end of the compaction process when you update the LSM state, and release the lock right after finishing modifying the states.
+Compaction should not block L0 flushes. Do not hold `state_lock` while merging files and writing outputs. Acquire it only when installing the result, and release it immediately after the structural update and manifest record are complete.
 
-You can assume that the user will ensure there is only one compaction going on. `force_full_compaction` will be called in only one thread at any time. The SSTs being put in the level 1 should be sorted by their first key and should not have overlapping key ranges.
+You may assume that only one compaction runs at a time. The SSTs installed in L1 must be sorted by first key and have non-overlapping key ranges.
 
 <details>
 
@@ -64,28 +79,28 @@ fn force_full_compaction(&self) {
 
 </details>
 
-In your compaction implementation, you only need to handle `FullCompaction` for now, where the task information contains the SSTs that you will need to compact. You will also need to ensure the order of the SSTs are correct so that the latest version of a key will be put into the new SST.
+For now, `compact` needs to handle only `ForceFullCompaction`, whose task lists the input SSTs. Preserve source priority so that the newest version of each key reaches the output.
 
-Because we always compact all SSTs, if we find multiple version of a key, we can simply retain the latest one. If the latest version is a delete marker, we do not need to keep it in the produced SST files. This does not apply for the compaction strategies in the next few chapters.
+Because this task includes every SST, retain only the newest version of each key. If that version is a tombstone, omit it from the output. Later chapters compact only part of the tree, so they cannot always discard tombstones.
 
-There are some things that you might need to think about.
+Before moving on, account for these two cases:
 
-* How does your implementation handle L0 flush in parallel with compaction? (Not taking the state lock when doing the compaction, and also need to consider new L0 files produced when compaction is going on.)
-* If your implementation removes the original SST files immediately after the compaction completes, will it cause problems in your system? (Generally no on macOS/Linux because the OS will not actually remove the file until no file handle is being held.)
+* How does your implementation retain an L0 SST flushed while compaction is in progress?
+* Can a reader using an older state snapshot finish after the input filenames are unlinked? On Unix-like systems, an open file remains accessible until its final handle is closed.
 
 ## Task 2: Concat Iterator
 
-In this task, you will need to modify,
+In this task, you will need to modify:
 
 ```
 src/iterators/concat_iterator.rs
 ```
 
-Now that you have created sorted runs in your system, it is possible to do a simple optimization over the read path. You do not always need to create merge iterators for your SSTs. If SSTs belong to one sorted run, you can create a concat iterator that simply iterates the keys in each SST in order, because SSTs in one sorted run do not contain overlapping key ranges and they are sorted by their first key. We do not want to create all SST iterators in advance (because it will lead to one block read), and therefore we only store SST objects in this iterator.
+A sorted run does not need a merge iterator: its SSTs are ordered and have non-overlapping ranges, so a concat iterator can visit them sequentially. Store the SST objects and create only the active child iterator. Creating every child in advance would read the first block of every SST unnecessarily.
 
 ## Task 3: Integrate with the Read Path
 
-In this task, you will need to modify,
+In this task, you will need to modify:
 
 ```
 src/lsm_iterator.rs
@@ -93,13 +108,13 @@ src/lsm_storage.rs
 src/compact.rs
 ```
 
-Now that we have the two-level structure for your LSM tree, and you can change your read path to use the new concat iterator to optimize the read path.
+Now update the two-level read path to use the concat iterator for L1.
 
-You will need to change the inner iterator type of the `LsmStorageIterator`. After that, you can construct a two merge iterator that merges memtables and L0 SSTs, and another merge iterator that merges that iterator with the L1 concat iterator.
+Change the inner iterator type of `LsmStorageIterator`. Merge the memtable and L0 iterators first, then use `TwoMergeIterator` to combine that newer stream with the L1 concat iterator.
 
 You can also change your compaction implementation to leverage the concat iterator.
 
-You will need to implement `num_active_iterators` for concat iterator so that the test case can test if concat iterators are being used by your implementation, and it should always be 1.
+Implement `num_active_iterators` for the concat iterator. For this exercise, it should always report one active iterator.
 
 To test your implementation interactively,
 
@@ -123,16 +138,39 @@ get 2333
 scan 2000 2333
 ```
 
+## Chapter Checkpoint
+
+Your engine should now compact the captured L0 and L1 inputs into zero or more ordered L1 SSTs, retain L0 files created after the task snapshot, and serve `get` and `scan` through both overlapping and non-overlapping sources.
+
+In addition to passing the tests, verify three cases explicitly:
+
+1. Give two input SSTs the same key and confirm that reversing their merge priority changes the result.
+2. Compact an input containing only tombstones and confirm that no empty SST is created.
+3. Seek a concat iterator into the second or later SST and confirm that it opens only the active child iterator.
+
 ## Test Your Understanding
+
+Answer correctness questions with a concrete LSM state or execution. For amplification questions, state what you count in the numerator and denominator.
+
+### Correctness and Concurrency
+
+* Construct the smallest input in which reversing L0 iterator priority preserves a stale value. Then construct one in which it resurrects a deleted value.
+* Why is it safe to discard tombstones during this chapter's full compaction? Give a counterexample showing why the same rule is unsafe when compacting into a non-bottom level.
+* How does your implementation retain an L0 SST flushed while compaction is writing its output?
+* What should `apply_compaction_result` do when compaction produces no SSTs?
+* If your implementation removes the original SST files immediately after installing the new state, can a reader using an older state snapshot still finish? How does the answer depend on filesystem semantics?
+* What ordering and non-overlap properties must hold before `SstConcatIterator` is safe to use?
+
+### Performance and Design
 
 * What are the definitions of read/write/space amplifications? (This is covered in the overview chapter)
 * What are the ways to accurately compute the read/write/space amplifications, and what are the ways to estimate them?
 * Is it correct that a key will take some storage space even if a user requests to delete it?
-* Given that compaction takes a lot of write bandwidth and read bandwidth and may interfere with foreground operations, it is a good idea to postpone compaction when there are large write flow. It is even beneficial to stop/pause existing compaction tasks in this situation. What do you think of this idea? (Read the [SILK: Preventing Latency Spikes in Log-Structured Merge Key-Value Stores](https://www.usenix.org/conference/atc19/presentation/balmau) paper!)
+* Because compaction consumes read and write bandwidth, should the engine postpone or pause it during heavy foreground traffic? What new problem could that create? Read [SILK: Preventing Latency Spikes in Log-Structured Merge Key-Value Stores](https://www.usenix.org/conference/atc19/presentation/balmau).
 * Is it a good idea to use/fill the block cache for compactions? Or is it better to fully bypass the block cache when compaction?
 * Does it make sense to have a `struct ConcatIterator<I: StorageIterator>` in the system?
 * Some researchers/engineers propose to offload compaction to a remote server or a serverless lambda function. What are the benefits, and what might be the potential challenges and performance impacts of doing remote compaction? (Think of the point when a compaction completes and what happens to the block cache on the next read request...)
 
-We do not provide reference answers to the questions, and feel free to discuss about them in the Discord community.
+We do not provide reference answers to these questions, so feel free to discuss them in the Discord community.
 
 {{#include copyright.md}}

--- a/mini-lsm-book/src/week2-02-simple.md
+++ b/mini-lsm-book/src/week2-02-simple.md
@@ -6,12 +6,14 @@
 
 ![Chapter Overview](./lsm-tutorial/week2-02-simple.svg)
 
-In this chapter, you will:
+By the end of this chapter, you will be able to:
 
 * Implement a simple leveled compaction strategy and simulate it on the compaction simulator.
-* Start compaction as a background task and implement a compaction trigger in the system.
+* Run compaction as a background task and install its results safely.
+* Extend point reads and scans across multiple non-overlapping levels.
+* Explain how level ratios, merge priority, and bottom-level tombstone removal affect correctness and amplification.
 
-To copy the test cases into the starter code and run them,
+To copy the test cases into the starter code and run them:
 
 ```
 cargo x copy-test --week 2 --day 2
@@ -20,25 +22,39 @@ cargo x scheck
 
 <div class="warning">
 
-It might be helpful to take a look at [week 2 overview](./week2-overview.md) before reading this chapter to have a general overview of compactions.
+Read the [Week 2 overview](./week2-overview.md) before beginning this chapter for an introduction to compaction and amplification.
 
 </div>
 
+## Before You Begin
+
+Day 1 compacted the entire database into L1 on demand. Simple leveled compaction introduces a controller that chooses one adjacent pair of levels at a time and a background thread that repeatedly asks the controller for work.
+
+Keep these invariants in mind:
+
+1. L0 is ordered from newest to oldest and may overlap. Each level from L1 downward is one sorted, non-overlapping run.
+2. In a merge, the upper level contains newer versions than the lower level and must win on duplicate keys. For L0, individual files also need newest-to-oldest priority.
+3. `generate_compaction_task` must eventually return `None`; otherwise, the simulator and background worker cannot converge.
+4. Applying an L0 task removes exactly the captured L0 files, not files flushed after the task was generated.
+5. Tombstones are preserved until the task's lower level is the bottom-most level.
+
+> **Predict before coding:** With `size_ratio_percent = 200`, suppose L1 has two files, L2 has three, and L3 has eight. Which adjacent pair should be compacted next? If a new L0 file is flushed while that task runs, should applying the result change L0?
+
 ## Task 1: Simple Leveled Compaction
 
-In this chapter, we are going to implement our first compaction strategy -- simple leveled compaction. In this task, you will need to modify:
+In this task, implement the first scheduling policy: simple leveled compaction. You will need to modify:
 
 ```
 src/compact/simple_leveled.rs
 ```
 
-Simple leveled compaction is similar the original LSM paper's compaction strategy. It maintains a number of levels for the LSM tree. When a level (>= L1) is too large, it will merge all of this level's SSTs with next level. The compaction strategy is controlled by 3 parameters as defined in `SimpleLeveledCompactionOptions`.
+Simple leveled compaction is similar to the strategy in the original LSM-tree paper. It maintains a fixed number of levels. When a level at or below L1 is too large relative to the next level, the engine merges all of its SSTs with that lower level. Three parameters in `SimpleLeveledCompactionOptions` control the policy.
 
-* `size_ratio_percent`: lower level number of files / upper level number of files. In reality, we should compute the actual size of the files. However, we simplified the equation to use number of files to make it easier to do the simulation. When the ratio is too low (upper level has too many files), we should trigger a compaction.
-* `level0_file_num_compaction_trigger`: when the number of SSTs in L0 is larger than or equal to this number, trigger a compaction of L0 and L1.
+* `size_ratio_percent`: the target ratio of lower-level files to upper-level files. A production system would compare byte sizes, but this exercise compares file counts for simpler simulation. Trigger compaction when the actual ratio falls below this value.
+* `level0_file_num_compaction_trigger`: when L0 contains at least this many SSTs, compact L0 with L1.
 * `max_levels`: the number of levels (excluding L0) in the LSM tree.
 
-Assume size_ratio_percent=200 (Lower level should have 2x number of files as the upper level), max_levels=3, level0_file_num_compaction_trigger=2, let us take a look at the below example.
+Consider `size_ratio_percent = 200`, `max_levels = 3`, and `level0_file_num_compaction_trigger = 2`. Each lower level should contain at least twice as many files as the level above it.
 
 Assume the engine flushes two L0 SSTs. This reaches the `level0_file_num_compaction_trigger`, and your controller should trigger an L0->L1 compaction.
 
@@ -55,7 +71,7 @@ L2 (0): []
 L3 (0): []
 ```
 
-Now, L2 is empty while L1 has two files. The size ratio percent for L1 and L2 is `(L2/L1) * 100 = (0/2) * 100 = 0 < size_ratio_percent (200)`. Therefore, we will trigger a L1+L2 compaction to push the data lower to L2. The same applies to L2 and these two SSTs will be placed at the bottom-most level after 2 compactions.
+L2 is empty while L1 has two files, so `(L2 / L1) * 100 = (0 / 2) * 100 = 0`, which is below 200. The controller compacts L1 with L2. The same condition then holds between L2 and L3, so a second compaction moves the two files to the bottom level.
 
 ```
 --- After Compaction ---
@@ -70,7 +86,7 @@ L2 (0): []
 L3 (2): [7, 8]
 ```
 
-Continue flushing SSTs, we will find:
+After more flushes and compactions, the state can become:
 
 ```
 L0 (0): []
@@ -79,7 +95,7 @@ L2 (2): [13, 14]
 L3 (2): [7, 8]
 ```
 
-At this point, `L3/L2= (1 / 1) * 100 = 100 < size_ratio_percent (200)`. Therefore, we need to trigger a compaction between L2 and L3.
+At this point, `(L3 / L2) * 100 = (2 / 2) * 100 = 100`, which is below 200. The controller compacts L2 with L3.
 
 ```
 --- After Compaction ---
@@ -89,7 +105,7 @@ L2 (0): []
 L3 (4): [15, 16, 17, 18]
 ```
 
-As we flush more SSTs, we will possibly end up at a state as follows:
+After additional flushes, the state might become:
 
 ```
 --- After Flush ---
@@ -104,20 +120,20 @@ L2 (2): [23, 24]
 L3 (4): [15, 16, 17, 18]
 ```
 
-Because `L3/L2 = (4 / 2) * 100 = 200 >= size_ratio_percent (200)`, we do not need to merge L2 and L3 and will end up with the above state. Simple leveled compaction strategy always compact a full level, and keep a fanout size between levels, so that the lower level is always some multiplier times larger than the upper level.
+Because `L3/L2 = (4 / 2) * 100 = 200 >= size_ratio_percent (200)`, we do not need to merge L2 and L3. Simple leveled compaction always compacts a full level and maintains a target fanout between adjacent levels.
 
-We have already initialized the LSM state to have `max_level` levels. You should first implement `generate_compaction_task` that generates a compaction task based on the above 3 criteria. After that, implement `apply_compaction_result`. We recommend you implement L0 trigger first, run a compaction simulation, and then implement the size ratio trigger, and then run a compaction simulation. To run the compaction simulation,
+The LSM state already contains `max_levels` levels. First implement the L0 trigger in `generate_compaction_task` and inspect a simulation. Then add the size-ratio trigger and implement `apply_compaction_result`. Run the simulator with:
 
 ```shell
 cargo run --bin compaction-simulator-ref simple # Reference solution
 cargo run --bin compaction-simulator simple # Your solution
 ```
 
-The simulator will flush an L0 SST into the LSM state, run your compaction controller to generate a compaction task, and then apply the compaction result. Each time a new SST gets flushed, it will repetitively call the controller until no compaction needs to be scheduled, and therefore you should ensure your compaction task generator will converge.
+The simulator flushes an L0 SST, asks the controller for a task, and applies the result. After each flush, it repeatedly invokes the controller until no task remains, so your scheduling policy must converge.
 
-In your compaction implementation, you should reduce the number of active iterators (i.e., use concat iterator) as much as possible. Also, remember that merge order matters, and you will need to ensure that the iterators you create produces key-value pairs in the correct order, when multiple versions of a key appear.
+Use concat iterators for sorted runs to minimize active child iterators. Merge order still determines which version of a duplicate key survives, so construct every input in newest-to-oldest priority order.
 
-Also, note that some parameters in the implementation is 0-based, and some of them are 1-based. Be careful when you use the `level` as an index in a vector.
+Some values are zero-based vector indexes, while level numbers begin at one. Convert between them explicitly.
 
 **Note: we do not provide fine-grained unit tests for this part. You can run the compaction simulator and compare with the output of the reference solution to see if your implementation is correct.**
 
@@ -129,11 +145,11 @@ In this task, you will need to modify:
 src/compact.rs
 ```
 
-Now that you have implemented your compaction strategy, you will need to run it in a background thread, so as to compact the files in the background. In `compact.rs`, `trigger_compaction` will be called every 50ms, and you will need to:
+Run the controller from a background thread. `trigger_compaction` is called every 50 ms and should:
 
-1. generate a compaction task, if no task needs to be scheduled, return ok.
-2. run the compaction and get a list of new SSTs.
-3. Similar to `force_full_compaction` you have implemented in the previous chapter, update the LSM state.
+1. Generate a compaction task. If no task needs to be scheduled, return successfully.
+2. Run the compaction and obtain a list of new SSTs.
+3. As in `force_full_compaction`, install the result in the current LSM state.
 
 ## Task 3: Integrate with the Read Path
 
@@ -143,7 +159,7 @@ In this task, you will need to modify:
 src/lsm_storage.rs
 ```
 
-Now that you have multiple levels of SSTs, you can modify your read path to include the SSTs from the new levels. You will need to update the scan/get function to include all levels below L1. Also, you might need to change the `LsmStorageIterator` inner type again.
+Extend both `get` and `scan` across every level below L1. You will also need to change the inner type of `LsmStorageIterator` again.
 
 To test your implementation interactively,
 
@@ -167,7 +183,23 @@ scan 2000 2333
 
 You may print something, for example, the compaction task information, when the compactor triggers a compaction.
 
+## Chapter Checkpoint
+
+Your engine should now schedule simple leveled compactions in the background, preserve newer values across every merge, and read through all configured levels. The simulator should reach a state in which no further task is eligible.
+
+Compare a short simulator run with the reference output, then alter one parameter at a time. Explain why each task was selected, identify whether it reaches the bottom level, and verify that the next state still contains any L0 file created after the task snapshot.
+
 ## Test Your Understanding
+
+### Correctness and Scheduling
+
+* For a duplicate key present in both levels of a task, why must the upper-level iterator win? What stale result appears if the priority is reversed?
+* Why may a bottom-level compaction discard a tombstone while an L1-to-L2 compaction might need to retain it?
+* Construct a level-size configuration that causes an implementation with reversed ratio operands to select the wrong task.
+* What state must be rechecked when a background compaction finishes, and which concurrent change is expected rather than an error?
+* Can you merge L1 and L3 directly if there are SST files in L2? Does it still produce the correct result?
+
+### Amplification and Design
 
 * What is the estimated write amplification of leveled compaction?
 * What is the estimated read amplification of leveled compaction?
@@ -175,10 +207,9 @@ You may print something, for example, the compaction task information, when the 
 * Is it a good strategy to periodically do a full compaction on the LSM tree? Why or why not?
 * Actively choosing some old files/levels to compact even if they do not violate the level amplifier would be a good choice, is it true? (Look at the [Lethe](https://disc-projects.bu.edu/lethe/) paper!)
 * If the storage device can achieve a sustainable 1GB/s write throughput and the write amplification of the LSM tree is 10x, how much throughput can the user get from the LSM key-value interfaces?
-* Can you merge L1 and L3 directly if there are SST files in L2? Does it still produce correct result?
-* So far, we have assumed that our SST files use a monotonically increasing id as the file name. Is it okay to use `<level>_<begin_key>_<end_key>.sst` as the SST file name? What might be the potential problems with that? (You can ask yourself the same question in week 3...)
+* So far, SST filenames have used monotonically increasing IDs. What problems might arise from naming a file `<level>_<begin_key>_<end_key>.sst` instead? Revisit this question in Week 3.
 * What is your favorite boba shop in your city? (If you answered yes in week 1 day 3...)
 
-We do not provide reference answers to the questions, and feel free to discuss about them in the Discord community.
+We do not provide reference answers to these questions, so feel free to discuss them in the Discord community.
 
 {{#include copyright.md}}

--- a/mini-lsm-book/src/week2-03-tiered.md
+++ b/mini-lsm-book/src/week2-03-tiered.md
@@ -6,14 +6,16 @@
 
 ![Chapter Overview](./lsm-tutorial/week2-00-tiered.svg)
 
-In this chapter, you will:
+By the end of this chapter, you will be able to:
 
 * Implement a tiered compaction strategy and simulate it on the compaction simulator.
-* Incorporate tiered compaction strategy into the system.
+* Incorporate tiered compaction into the engine's flush, compaction, and read paths.
+* Explain how universal compaction's three triggers trade write, read, and space amplification.
+* Preserve newest-to-oldest tier order and determine whether a task includes the bottom tier.
 
-The tiered compaction we talk about in this chapter is the same as RocksDB's universal compaction. We will use these two terminologies interchangeably.
+This chapter's tiered policy is RocksDB's universal compaction. The chapter uses the two terms interchangeably.
 
-To copy the test cases into the starter code and run them,
+To copy the test cases into the starter code and run them:
 
 ```
 cargo x copy-test --week 2 --day 3
@@ -22,13 +24,27 @@ cargo x scheck
 
 <div class="warning">
 
-It might be helpful to take a look at [week 2 overview](./week2-overview.md) before reading this chapter to have a general overview of compactions.
+Read the [Week 2 overview](./week2-overview.md) before beginning this chapter for an introduction to compaction and amplification.
 
 </div>
 
+## Before You Begin
+
+Unlike leveled compaction, tiered compaction treats each flush as a new sorted run. The `levels` vector is repurposed to store tiers from newest to oldest; the numeric ID names a tier rather than describing a fixed depth.
+
+Keep these invariants in mind:
+
+1. `levels[0]` is the newest tier, and every tier is internally sorted and non-overlapping.
+2. A tiered task selects a contiguous prefix of tiers. The merge iterator must use the same newest-to-oldest order so that newer versions win.
+3. The controller considers triggers in order: minimum tier count, space amplification, size ratio, then reduction of sorted runs.
+4. `bottom_tier_included` is true only if the selected prefix contains the oldest tier. Tombstones must remain when an older tier is left out.
+5. A flush creates a one-SST tier at the front of `levels`; it does not add an L0 file.
+
+> **Predict before coding:** Suppose the tiers from newest to oldest have sizes `[1, 1, 3, 20]`, and the reduce-sorted-runs trigger is capped at `max_merge_width = 2`. Which tiers are selected? Does the task include the bottom tier, and may it discard a tombstone whose older value could be in the 20-file tier?
+
 ## Task 1: Universal Compaction
 
-In this chapter, you will implement RocksDB's universal compaction, which is of the tiered compaction family compaction strategies. Similar to the simple leveled compaction strategy, we only use number of files as the indicator in this compaction strategy. And when we trigger the compaction jobs, we always include a full sorted run (tier) in the compaction job.
+You will implement a simplified form of RocksDB's universal compaction. As in simple leveled compaction, the controller uses file counts rather than byte sizes. A task always includes each selected tier in full.
 
 ### Task 1.0: Precondition
 
@@ -38,7 +54,7 @@ In this task, you will need to modify:
 src/compact/tiered.rs
 ```
 
-In universal compaction, we do not use L0 SSTs in the LSM state. Instead, we directly flush new SSTs to a single sorted run (called tier). In the LSM state, `levels` will now include all tiers, where **the lowest index is the latest SST flushed**. Each element in the `levels` vector stores a tuple: level ID (used as tier ID) and the SSTs in that level. Every time you flush L0 SSTs, you should flush the SST into a tier placed at the front of the vector. The compaction simulator generates tier id based on the first SST id, and you should do the same in your implementation.
+In universal compaction, the LSM state does not use L0. Instead, each memtable flush creates a single-SST sorted run, or tier. The `levels` vector stores all tiers, with **the newest tier at the lowest index**. Each element is a tuple containing a tier ID and the SST IDs in that tier. Place every newly flushed SST in a tier at the front of the vector. The compaction simulator uses the first output SST ID as the tier ID; your implementation should do the same.
 
 Universal compaction will only trigger tasks when the number of tiers (sorted runs) reaches `num_tiers`. Otherwise, it does not trigger any compaction.
 
@@ -46,9 +62,9 @@ Universal compaction will only trigger tasks when the number of tiers (sorted ru
 
 The first trigger of universal compaction is by space amplification ratio. As we discussed in the overview chapter, space amplification can be estimated by `engine_size / last_level_size`. In our implementation, we compute the space amplification ratio by `all levels except last level size / last level size`, so that the ratio can be scaled to `[0, +inf)` instead of `[1, +inf]`. This is also consistent with the RocksDB implementation.
 
-The reason why we compute the space amplification ratio like this is because we model the engine in a way that it stores a fixed amount of user data (i.e., assume it's 100GB), and the user keeps updating the values by writing to the engine. Therefore, eventually, all keys get pushed down to the bottom-most tier, the bottom-most tier size should be equivalent to the amount of data (100GB), the upper tiers contain updates to the data that are not yet compacted to the bottom-most tier.
+This estimate models a fixed logical dataset—for example, 100 GB—that receives repeated updates. The bottom tier approximates the logical dataset, while upper tiers contain newer changes that have not yet reached the bottom. The implementation expresses excess space as `upper_tier_size / bottom_tier_size`, producing a range from zero upward.
 
-When `all levels except last level size / last level size` >= `max_size_amplification_percent * 1%`, we will need to trigger a full compaction. For example, if we have a LSM state like:
+Trigger full compaction when `upper_tier_size / bottom_tier_size` is at least `max_size_amplification_percent / 100`. For example:
 
 ```
 Tier 3: 1
@@ -77,7 +93,7 @@ L3 [3] L2 [2] L1 [1] -> [4, 5, 6]
 L4 (3): [3, 2, 1]
 ```
 
-With this trigger, we will only trigger full compaction when it reaches the space amplification ratio. And at the end of the simulation, you will see:
+With only this trigger implemented, the end of the simulation includes states like:
 
 ```bash
 cargo run --bin compaction-simulator tiered
@@ -145,15 +161,15 @@ Maximum Space Usage: 50/50=1.000x
 Read Amplification: 27x
 ```
 
-The `num_tiers` in the compaction simulator is set to 8. However, there are far more than 8 tiers in the LSM state, which incurs large read amplification.
+The simulator sets `num_tiers` to 8, but the state can still grow far beyond eight tiers because the threshold only enables scheduling; the space trigger does not guarantee that it will choose a task. This causes high read amplification.
 
-The current trigger only reduces space amplification. We will need to add new triggers to the compaction algorithm to reduce read amplification.
+The current trigger controls space amplification only. The next two triggers limit read amplification.
 
 ### Task 1.2: Triggered by Size Ratio
 
-The next trigger is the size ratio trigger. The trigger maintains the size ratio between the tiers. From the first tier, we compute the size of `this tier / sum of all previous tiers`. For the first encountered tier where this value `> (100 + size_ratio) * 1%`, we will compact all previous tiers excluding the current tier. We only do this compaction with there are more than `min_merge_width` tiers to be merged.
+The size-ratio trigger maintains geometric growth between tiers. Starting with the newest tier, compare each next tier's size with the total size of all newer tiers. At the first ratio greater than `(100 + size_ratio) / 100`, compact the newer prefix but exclude the tier that satisfied the ratio. Schedule the task only when the prefix contains at least `min_merge_width` tiers.
 
-For example, given the following LSM state, and assume `size_ratio` = 1, and `min_merge_width` = 2. We should compact when the ratio value > 101%:
+For example, with `size_ratio = 1` and `min_merge_width = 2`, compact when the ratio exceeds 101%:
 
 ```
 Tier 3: 1
@@ -227,11 +243,11 @@ Maximum Space Usage: 200/200=1.000x
 Read Amplification: 38x
 ```
 
-There will be fewer 1-SST tiers and the compaction algorithm will maintain the tiers to have smaller to larger sizes by size ratio. However, when there are more SSTs in the LSM state, there will still be cases that we have more than `num_tiers` tiers. To limit the number of tiers, we will need another trigger.
+This trigger produces fewer one-SST tiers and tends to keep tiers ordered from smaller to larger. The state can still exceed `num_tiers`, so one final trigger is required.
 
 ### Task 1.3: Reduce Sorted Runs
 
-If none of the previous triggers produce compaction tasks, we will do a major compaction that merges SST files from the first up to `max_merge_tiers` tiers into one tier to reduce the number of tiers.
+If none of the previous triggers produce a task, merge the first `max_merge_width` tiers into one tier to reduce the number of sorted runs. If `max_merge_width` is not set, select all tiers. Remember that a capped prefix does not include the bottom tier when older tiers remain.
 
 With this compaction trigger enabled, you will see:
 
@@ -250,7 +266,7 @@ Maximum Space Usage: 280/200=1.400x
 Read Amplification: 7x
 ```
 
-You can also try tiered compaction with more number of tiers:
+You can also try tiered compaction with a larger tier limit:
 
 ```bash
 cargo run --bin compaction-simulator tiered --iterations 200 --size-only --num-tiers 16
@@ -278,7 +294,13 @@ src/compact.rs
 src/lsm_storage.rs
 ```
 
-As tiered compaction does not use the L0 level of the LSM state, you should directly flush your memtables to a new tier instead of as an L0 SST. You can use `self.compaction_controller.flush_to_l0()` to know whether to flush to L0. You may use the first output SST id as the level/tier id for your new sorted run. You will also need to modify your compaction process to construct merge iterators for tiered compaction jobs.
+Tiered compaction does not use L0, so flush each memtable directly to a new tier. Use `self.compaction_controller.flush_to_l0()` to choose between the leveled and tiered flush paths. Name a compacted tier with its first output SST ID, and construct the compaction merge iterators in newest-to-oldest tier order.
+
+## Chapter Checkpoint
+
+Your engine should now flush directly into newest-first tiers, schedule the first eligible universal-compaction trigger, and retain tombstones whenever a task leaves older tiers behind. A task that includes the bottom tier may legitimately produce no SSTs when all surviving entries are tombstones.
+
+For several simulator iterations, annotate each task with the trigger that selected it, the tiers it consumes, and whether it reaches the bottom. Then use one duplicate key to verify merge priority across tiers. Finally, test a capped `max_merge_width` and confirm that the task does not claim to include an unselected bottom tier.
 
 ## Related Readings
 
@@ -286,16 +308,25 @@ As tiered compaction does not use the L0 level of the LSM state, you should dire
 
 ## Test Your Understanding
 
-* What is the estimated write amplification of leveled compaction? (Okay this is hard to estimate... But what if without the last *reduce sorted run* trigger?)
-* What is the estimated read amplification of leveled compaction?
-* What are the pros/cons of universal compaction compared with simple leveled/tiered compaction?
-* How much storage space is it required (compared with user data size) to run universal compaction?
-* Can we merge two tiers that are not adjacent in the LSM state?
+### Correctness and Scheduling
+
+* Why must every task select adjacent tiers from the newest end of the state? Construct a counterexample for a task that merges two non-adjacent tiers and places the output incorrectly.
+* When `max_merge_width` limits a task to only the newest tiers, why must `bottom_tier_included` be false?
+* What should the new LSM state contain if a bottom-tier compaction produces no output because every surviving entry is a tombstone?
+* Construct a tier-size sequence for which the space-amplification trigger wins, and another for which the size-ratio trigger wins.
+* If a new tier is flushed while a task is running, where should the compacted output be inserted relative to that tier?
+
+### Amplification and Design
+
+* What is the estimated write amplification of tiered compaction? This is difficult in general; begin by ignoring the final *reduce sorted runs* trigger.
+* What is the estimated read amplification of tiered compaction?
+* What are the advantages and disadvantages of universal compaction compared with leveled compaction?
+* How much free storage space does universal compaction require relative to the logical data size?
 * What happens if compaction speed cannot keep up with the SST flushes for tiered compaction?
-* What might needs to be considered if the system schedules multiple compaction tasks in parallel?
+* What must the system consider before scheduling multiple compaction tasks in parallel?
 * SSDs also write its own logs (basically it is a log-structured storage). If the SSD has a write amplification of 2x, what is the end-to-end write amplification of the whole system? Related: [ZNS: Avoiding the Block Interface Tax for Flash-based SSDs](https://www.usenix.org/conference/atc21/presentation/bjorling).
 * Consider the case that the user chooses to keep a large number of sorted runs (i.e., 300) for tiered compaction. To make the read path faster, is it a good idea to keep some data structure that helps reduce the time complexity (i.e., to `O(log n)`) of finding SSTs to read in each layer for some key ranges? Note that normally, you will need to do a binary search in each sorted run to find the key ranges that you will need to read. (Check out Neon's [layer map](https://neon.tech/blog/persistent-structures-in-neons-wal-indexing) implementation!)
 
-We do not provide reference answers to the questions, and feel free to discuss about them in the Discord community.
+We do not provide reference answers to these questions, so feel free to discuss them in the Discord community.
 
 {{#include copyright.md}}

--- a/mini-lsm-book/src/week2-04-leveled.md
+++ b/mini-lsm-book/src/week2-04-leveled.md
@@ -6,12 +6,14 @@
 
 ![Chapter Overview](./lsm-tutorial/week2-04-leveled.svg)
 
-In this chapter, you will:
+By the end of this chapter, you will be able to:
 
-* Implement a leveled compaction strategy and simulate it on the compaction simulator.
-* Incorporate leveled compaction strategy into the system.
+* Implement dynamic leveled compaction and simulate it with the compaction simulator.
+* Select a base level, rank overfull levels, and compact one upper-level SST with all overlapping lower-level SSTs.
+* Incorporate leveled compaction into the engine's read and compaction paths.
+* Explain why normal execution and manifest recovery require different result-application steps.
 
-To copy the test cases into the starter code and run them,
+To copy the test cases into the starter code and run them:
 
 ```
 cargo x copy-test --week 2 --day 4
@@ -20,18 +22,32 @@ cargo x scheck
 
 <div class="warning">
 
-It might be helpful to take a look at [week 2 overview](./week2-overview.md) before reading this chapter to have a general overview of compactions.
+Read the [Week 2 overview](./week2-overview.md) before beginning this chapter for an introduction to compaction and amplification.
 
 </div>
 
+## Before You Begin
+
+Simple leveled compaction established the basic level structure, but it rewrites whole levels and moves new data through levels whose target size is zero. This chapter makes both task selection and result application depend on SST sizes and key ranges.
+
+Keep these invariants in mind:
+
+1. L0 may overlap and is ordered newest to oldest. Every lower level is sorted by first key and contains non-overlapping SST ranges.
+2. The first level with a positive target size is the base level. L0 compaction targets it directly and has priority over size-based tasks.
+3. A non-L0 task selects exactly one upper-level SST and every lower-level SST whose inclusive key range overlaps it.
+4. The upper source is newer and wins duplicate keys. Tombstones are discarded only when the lower level is the bottom-most level.
+5. Applying the result removes exactly the selected files and restores first-key order in the lower level. During manifest replay, the SST objects are not loaded yet, so sorting must be deferred until recovery opens them.
+
+> **Predict before coding:** The selected upper SST covers `[100, 200]`; the lower level contains `[50, 99]`, `[100, 150]`, `[151, 250]`, and `[251, 300]`. Which lower SSTs belong in the task? If the task is being replayed from the manifest before SST metadata is loaded, when can the output files be sorted by first key?
+
 ## Task 1: Leveled Compaction
 
-In chapter 2 day 2, you have implemented the simple leveled compaction strategies. However, the implementation has a few problems:
+On Day 2, you implemented simple leveled compaction. That strategy has two important limitations:
 
-* Compaction always include a full level. Note that you cannot remove the old files until you finish the compaction, and therefore, your storage engine might use 2x storage space while the compaction is going on (if it is a full compaction). Tiered compaction has the same problem. In this chapter, we will implement partial compaction that we select one SST from the upper level for compaction, instead of the full level.
-* SSTs may be compacted across empty levels. As you have seen in the compaction simulator, when the LSM state is empty, and the engine flushes some L0 SSTs, these SSTs will be first compacted to L1, then from L1 to L2, etc. An optimal strategy is to directly place the SST from L0 to the lowest level possible, so as to avoid unnecessary write amplification.
+* Each task includes an entire level. Because input files cannot be removed until the output is complete and durable, full-level compaction can temporarily double the space used by the selected data. Tiered compaction has the same problem. Partial compaction reduces peak space by selecting one upper-level SST at a time.
+* New data moves through empty levels. Starting from an empty tree, simple leveled compaction first moves L0 to L1, then L1 to L2, and so on. Sending L0 directly to the lowest level with a positive target size avoids these unnecessary rewrites.
 
-In this chapter, you will implement a production-ready leveled compaction strategy. The strategy is the same as RocksDB's leveled compaction. You will need to modify:
+In this chapter, you will implement a more realistic leveled compaction strategy based on RocksDB's design. You will need to modify:
 
 ```
 src/compact/leveled.rs
@@ -45,23 +61,23 @@ cargo run --bin compaction-simulator leveled
 
 ### Task 1.1: Compute Target Sizes
 
-In this compaction strategy, you will need to know the first/last key of each SST and the size of the SSTs. The compaction simulator will set up some mock SSTs for you to access.
+This strategy needs each SST's size and inclusive first-to-last key range. The simulator supplies mock SST metadata.
 
-You will need to compute the target sizes of the levels. Assume `base_level_size_mb` is 200MB and the number of levels (except L0) is 6. When the LSM state is empty, the target sizes will be:
+First compute the target size of each level. With `base_level_size_mb = 200` and six levels below L0, an empty LSM tree has these targets:
 
 ```
 [0 0 0 0 0 200MB]
 ```
 
-Before the bottom level exceeds `base_level_size_mb`, all other intermediate levels will have target sizes of 0. The idea is that when the total amount of data is small, it's wasteful to create intermediate levels.
+Until the bottom level exceeds 200 MB, every intermediate level has a target size of zero. Small databases do not benefit from populating those levels.
 
-When the bottom level reaches or exceeds `base_level_size_mb`, we will compute the target size of the other levels by dividing the `level_size_multiplier` from the size. Assume the bottom level contains 300MB of data, and `level_size_multiplier=10`.
+Once the bottom level reaches the base size, work upward by dividing each lower target by `level_size_multiplier`. If the bottom contains 300 MB and the multiplier is 10, the targets are:
 
 ```
 0 0 0 0 30MB 300MB
 ```
 
-In addition, at most *one* level can have a positive target size below `base_level_size_mb`. Assume we now have 30GB files in the last level, the target sizes will be,
+At most *one* level may have a positive target below `base_level_size_mb`. If the bottom level contains 30 GB, the targets are:
 
 ```
 0 0 30MB 300MB 3GB 30GB
@@ -71,7 +87,7 @@ Notice in this case L1 and L2 have target size of 0, and L3 is the only level wi
 
 ### Task 1.2: Decide Base Level
 
-Now, let us solve the problem that SSTs may be compacted across empty levels in the simple leveled compaction strategy. When we compact L0 SSTs with lower levels, we do not directly put it to L1. Instead, we compact it with the first level with `target size > 0`. For example, when the target level sizes are:
+To avoid moving SSTs through empty levels, compact L0 with the first level whose target size is positive. For example, given these targets:
 
 ```
 0 0 0 0 30MB 300MB
@@ -103,7 +119,7 @@ The number of levels in the compaction simulator is 4. Therefore, the SSTs shoul
 
 ### Task 1.3: Decide Level Priorities
 
-Now that we will need to handle compactions below L0. L0 compaction always has the top priority, thus you should compact L0 with other levels first if it reaches the threshold. After that, we can compute the compaction priorities of each level by `current_size / target_size`. We only compact levels with this ratio `> 1.0` The one with the largest ratio will be chosen for compaction with the lower level. For example, if we have:
+After checking the L0 trigger, compute each lower level's priority as `current_size / target_size`. Only ratios greater than 1.0 are eligible. Compact the level with the highest priority into the next level. For example:
 
 ```
 L3: 200MB, target_size=20MB
@@ -120,17 +136,17 @@ L4: 202MB/200MB = 1.01
 L5: 1.9GB/2GB = 0.95
 ```
 
-L3 and L4 needs to be compacted with their lower level respectively, while L5 does not. And L3 has a larger ratio, and therefore we will produce a compaction task of L3 and L4. After the compaction is done, it is likely that we will schedule compactions of L4 and L5.
+L3 and L4 are over their targets, while L5 is not. L3 has the highest priority, so the controller selects an L3-to-L4 task. After that task completes, L4 might become eligible for compaction into L5.
 
 ### Task 1.4: Select SST to Compact
 
-Now, let us solve the problem that compaction always include a full level from the simple leveled compaction strategy. When we decide to compact two levels, we always select the oldest SST from the upper level. You can know the time that the SST is produced by comparing the SST id.
+To avoid compacting a full level, select only the oldest SST in the chosen upper level. SST IDs increase monotonically, so the smallest ID identifies the oldest file.
 
 There are other ways of choosing the compacting SST, for example, by looking into the number of delete tombstones. You can implement this as part of the bonus task.
 
-After you choose the upper level SST, you will need to find all SSTs in the lower level with overlapping keys of the upper level SST. Then, you can generate a compaction task that contain exactly one SST in the upper level and overlapping SSTs in the lower level.
+After choosing the upper SST, find every lower-level SST whose key range overlaps it. The task contains exactly one upper SST and all of those lower SSTs.
 
-When the compaction completes, you will need to remove the SSTs from the state and insert new SSTs into the correct place. Note that you should keep SST ids ordered by first keys in all levels except L0.
+When compaction completes, remove the selected files and insert the outputs in the correct lower-level position. In every level except L0, keep SST IDs ordered by first key.
 
 Running the compaction simulator, you should see:
 
@@ -150,7 +166,7 @@ Upper L1 [224.sst 7cd080e..=33d79d04]
 Lower L2 [210.sst 1c657df4..=31a00e1b, 211.sst 31a00e1c..=46da9e43] -> [228.sst 7cd080e..=1cd18f74, 229.sst 1cd18f75..=31d616db, 230.sst 31d616dc..=46da9e43]
 ```
 
-...should only have one SST from the upper layer.
+...should contain only one SST from the upper level.
 
 **Note: we do not provide fine-grained unit tests for this part. You can run the compaction simulator and compare with the output of the reference solution to see if your implementation is correct.**
 
@@ -163,7 +179,13 @@ src/compact.rs
 src/lsm_storage.rs
 ```
 
-The implementation should be similar to simple leveled compaction. Remember to change both get/scan read path and the compaction iterators.
+The integration is similar to simple leveled compaction. Update both `get` and `scan`, as well as the iterators used to execute compaction.
+
+## Chapter Checkpoint
+
+Your controller should now compute dynamic target sizes, send L0 directly to the base level, and otherwise select one SST from the most overfull eligible level. Applying a result must preserve non-overlap and first-key order without requiring SST metadata during manifest replay.
+
+For one simulator task, calculate the target sizes and priorities by hand. Verify the chosen upper SST and enumerate every overlapping lower SST using inclusive endpoints. Then replay the same task with `in_recovery = true` and explain why sorting at that point would fail.
 
 ## Related Readings
 
@@ -171,20 +193,30 @@ The implementation should be similar to simple leveled compaction. Remember to c
 
 ## Test Your Understanding
 
+### Correctness and Scheduling
+
+* Why does L0 compaction take priority over a lower level with a larger size score?
+* Construct an overlap example that fails if endpoint equality is treated as non-overlapping.
+* Why must output SSTs be merged with untouched lower-level SSTs and sorted by first key?
+* What information is unavailable while manifest records are being replayed, and what phase of recovery makes it available?
+* If a new L0 file appears while an L0-to-base-level task runs, how does result application retain it?
+
+### Amplification and Design
+
 * What is the estimated write amplification of leveled compaction?
 * What is the estimated read amplification of leveled compaction?
 * Finding a good key split point for compaction may potentially reduce the write amplification, or it does not matter at all? (Consider that case that the user write keys beginning with some prefixes, `00` and `01`. The number of keys under these two prefixes are different and their write patterns are different. If we can always split `00` and `01` into different SSTs...)
 * Imagine that a user was using tiered (universal) compaction before and wants to migrate to leveled compaction. What might be the challenges of this migration? And how to do the migration?
 * And if we do it reversely, what if the user wants to migrate from leveled compaction to tiered compaction?
 * What happens if compaction speed cannot keep up with the SST flushes for leveled compaction?
-* What might needs to be considered if the system schedules multiple compaction tasks in parallel?
+* What must the system consider before scheduling multiple compaction tasks in parallel?
 * What is the peak storage usage for leveled compaction? Compared with universal compaction?
 * Is it true that with a lower `level_size_multiplier`, you can always get a lower write amplification?
 * What needs to be done if a user not using compaction at all decides to migrate to leveled compaction?
 * Some people propose to do intra-L0 compaction (compact L0 tables and still put them in L0) before pushing them to lower layers. What might be the benefits of doing so? (Might be related: [PebblesDB SOSP'17](https://www.cs.utexas.edu/~vijay/papers/sosp17-pebblesdb.pdf))
 * Consider the case that the upper level has two tables of `[100, 200], [201, 300]` and the lower level has `[50, 150], [151, 250], [251, 350]`. In this case, do you still want to compact one file in the upper level at a time? Why?
 
-We do not provide reference answers to the questions, and feel free to discuss about them in the Discord community.
+We do not provide reference answers to these questions, so feel free to discuss them in the Discord community.
 
 ## Bonus Tasks
 

--- a/mini-lsm-book/src/week2-05-manifest.md
+++ b/mini-lsm-book/src/week2-05-manifest.md
@@ -6,23 +6,39 @@
 
 ![Chapter Overview](./lsm-tutorial/week2-05-overview.svg)
 
-In this chapter, you will:
+By the end of this chapter, you will be able to:
 
-* Implement encoding and decoding of the manifest file.
-* Recover from the manifest when the system restarts.
+* Encode and append structural changes to the manifest.
+* Order SST, directory, and manifest synchronization so recovery never references an SST that was not made durable.
+* Replay manifest records, open the live SSTs, and restore the next unused file ID.
+* Flush all memtables during a clean close when WALs are disabled.
 
-To copy the test cases into the starter code and run them,
+To copy the test cases into the starter code and run them:
 
 ```
 cargo x copy-test --week 2 --day 5
 cargo x scheck
 ```
 
+## Before You Begin
+
+Until this chapter, `LsmStorageState` is authoritative only while the process is running. The SST files survive a restart, but filenames alone do not say which files are live, which level or tier owns them, or which compaction replaced them.
+
+Keep these invariants in mind:
+
+1. The manifest is an ordered, append-only log of structural state changes. Replaying every record from an empty state must reconstruct the same live file layout.
+2. An SST file and its directory entry must be durable before a manifest record is allowed to reference it.
+3. A file made obsolete by a durable manifest record may be deleted afterward. Recovery must tolerate the old file still being present because it is no longer part of the logical state.
+4. Manifest replay determines the live SST IDs before the engine opens SST metadata. Leveled SSTs are sorted by first key only after all live files have been opened.
+5. `next_sst_id` must be greater than every ID observed in recovered SSTs and, after Day 6, memtables.
+
+> **Predict before coding:** The engine has written and synced a new SST but crashes before appending its flush record. What state should recovery produce, and what kind of file is left behind? Now reverse the unsafe order: the manifest is synced before the new SST's directory entry. What can recovery attempt to open after a power loss?
+
 ## Task 1: Manifest Encoding
 
-The system uses a manifest file to record all operations happened in the engine. Currently, there are only two types of them: compaction and SST flush. When the engine restarts, it will read the manifest file, reconstruct the state, and load the SST files on the disk.
+The system uses a manifest to record structural operations in the engine. For now, there are two record types: compaction and SST flush. On restart, the engine reads the manifest, reconstructs the logical state, and opens the referenced SST files.
 
-There are many approaches to storing the LSM state. One of the easiest way is to simply store the full state into a JSON file. Every time we do a compaction or flush a new SST, we can serialize the entire LSM state into a file. The problem with this approach is that when the database gets super large (i.e., 10k SSTs), writing the manifest to the disk would be super slow. Therefore, we designed the manifest to be a append-only file.
+One simple design would rewrite the complete state as JSON after every flush or compaction. That approach becomes expensive when the database contains thousands of SSTs, so Mini-LSM uses an append-only manifest instead.
 
 In this task, you will need to modify:
 
@@ -30,7 +46,7 @@ In this task, you will need to modify:
 src/manifest.rs
 ```
 
-We encode the manifest records using JSON. You may use `serde_json::to_vec` to encode a manifest record to a json, write it to the manifest file, and do a fsync. When you read from the manifest file, you may use `serde_json::Deserializer::from_slice` and it will return a stream of records. You do not need to store the record length or so, as `serde_json` can automatically find the split of the records.
+Encode each record as JSON with `serde_json::to_vec`, append it, and synchronize the manifest. During recovery, `serde_json::Deserializer::from_slice` can stream adjacent JSON values without an explicit record length.
 
 
 The manifest format is like:
@@ -39,25 +55,25 @@ The manifest format is like:
 | JSON record | JSON record | JSON record | JSON record |
 ```
 
-Again, note that we do not record the information of how many bytes each record has.
+At this stage, the format does not store each record's byte length. Day 7 will add explicit framing and checksums.
 
-After the engine runs for several hours, the manifest file might get very large. At that time, you may periodically compact the manifest file to store the current snapshot and truncate the logs. This is an optimization you may implement as part of bonus tasks.
+Over time, the manifest can become large. A production engine can periodically replace it with a snapshot of the current state followed by a fresh log; this is a bonus task.
 
 
 ## Task 2: Write Manifests
 
-You can now go ahead and modify your LSM engine to write manifests when necessary. In this task, you will need to modify:
+Now append manifest records whenever the LSM structure changes. You will need to modify:
 
 ```
 src/lsm_storage.rs
 src/compact.rs
 ```
 
-For now, we only use two types of the manifest records: SST flush and compaction. SST flush record stores the SST id that gets flushed to the disk. Compaction record stores the compaction task and the produced SST ids. Every time you write some new files to the disk, first sync the files and the storage directory, and then write to the manifest and sync the manifest. The manifest file should be written to `<path>/MANIFEST`.
+For now, the manifest has two record types: SST flush and compaction. An SST flush record stores the ID written to disk. A compaction record stores the task and its output SST IDs. Whenever an operation creates files, first sync those files and the storage directory. Only then append the corresponding manifest record and sync the manifest. Delete obsolete input files after that record is durable, then sync the directory again. The manifest file should be written to `<path>/MANIFEST`.
 
-To sync the directory, you may implement the `sync_dir` function, where you can use `File::open(dir).sync_all()?` to sync it. On Linux, directory is a file that contains the list of files in the directory. By doing fsync on the directory, you will ensure that the newly-written (or removed) files can be visible to the user if the power goes off.
+Implement `sync_dir` with `File::open(dir).sync_all()?`. Synchronizing a file persists its contents; synchronizing the directory persists additions and removals of filenames.
 
-Remember to write a compaction manifest record for both the background compaction trigger (leveled/simple/universal) and when the user requests to do a force compaction.
+Append a compaction record for both background compaction and a user-requested full compaction.
 
 ## Task 3: Flush on Close
 
@@ -67,7 +83,7 @@ In this task, you will need to modify:
 src/lsm_storage.rs
 ```
 
-You will need to implement the `close` function. If `self.options.enable_wal = false` (we will cover WAL in the next chapter), you should flush all memtables to the disk before stopping the storage engine, so that all user changes will be persisted.
+Implement `close`. When `self.options.enable_wal` is false, flush every non-empty memtable before stopping the engine so a clean shutdown preserves all writes.
 
 ## Task 4: Recover from the State
 
@@ -77,11 +93,11 @@ In this task, you will need to modify:
 src/lsm_storage.rs
 ```
 
-Now, you may modify the `open` function to recover the engine state from the manifest file. To recover it, you will need to first generate the list of SSTs you will need to load. You can do this by calling `apply_compaction_result` and recover SST ids in the LSM state. After that, you may iterate the state and load all SSTs (update the sstables hash map). During the process, you will need to compute the maximum SST id and update the `next_sst_id` field. After that, you may create a new memtable using that id and increment the id by one.
+Modify `open` to replay the manifest into an initially empty LSM state. Apply flush and compaction records to recover the live SST IDs, then open those files and populate the `sstables` map. Track the maximum ID, create a new memtable with the next ID, and advance `next_sst_id` again.
 
-If you have implemented leveled compaction, you might have sorted the SSTs every time you apply the compaction result. However, with manifest recover, your sorting logic will be broken, because during the recovery process, you cannot know the start key and the end key of each of the SST. To resolve this, you will need to read the `in_recovery` flag of the `apply_compaction_result` function. During the recovery process, you should not attempt to retrieve the first key of the SST. After the LSM state is recovered and all SSTs are opened, you can do a sorting at the end of the recovery process.
+Leveled compaction normally sorts result IDs by first key. During manifest replay, however, the SST objects and their key ranges are not loaded yet. Honor `apply_compaction_result`'s `in_recovery` flag and defer sorting. Once every live SST is open, sort each leveled run by first key.
 
-Optionally, you may include the start key and the end key of each of the SSTs in the manifest. This strategy is used in RocksDB/BadgerDB, so that you do not need to distinguish the recovery mode and the normal mode during the compaction apply process.
+Alternatively, store each SST's key range in the manifest, as systems such as RocksDB and BadgerDB do. Result application could then use the same ordering logic during recovery and normal execution.
 
 You may use the mini-lsm-cli to test your implementation.
 
@@ -93,10 +109,25 @@ cargo run --bin mini-lsm-cli
 get 1500
 ```
 
+## Chapter Checkpoint
+
+After a clean close without WALs, the engine should have no non-empty memtables. Reopening it should replay the manifest, open exactly the referenced SSTs, restore leveled ordering after metadata becomes available, and allocate an ID greater than every recovered file ID.
+
+Write down the durable events for one flush and one compaction. Insert a hypothetical crash after each event and determine whether recovery sees the old state or the new state. Both outcomes can be valid at some boundaries; a manifest state that references a missing file is not.
+
 ## Test Your Understanding
+
+### Recovery and Durability
 
 * When do you need to call `fsync`? Why do you need to fsync the directory?
 * What are the places you will need to write to the manifest?
+* Why must newly created SSTs and their directory entries be synced before the manifest record that references them?
+* Why is it safe for an obsolete SST to remain on disk after the compaction record is durable? Is it safe to delete the SST before that point?
+* During recovery, why can leveled compaction results not be sorted by first key while manifest records are being replayed?
+* Construct a record sequence containing flushes and compactions, replay it by hand, and compute the next unused SST ID.
+
+### Alternative Designs
+
 * Consider an alternative implementation of an LSM engine that does not use a manifest file. Instead, it records the level/tier information in the header of each file, scans the storage directory every time it restarts, and recover the LSM state solely from the files present in the directory. Is it possible to correctly maintain the LSM state in this implementation and what might be the problems/challenges with that?
 * Currently, we create all SST/concat iterators before creating the merge iterator, which means that we have to load the first block of the first SST in all levels into memory before starting the scanning process. We have start/end key in the manifest, and is it possible to leverage this information to delay the loading of the data blocks and make the time to return the first key-value pair faster?
 * Is it possible not to store the tier/level information in the manifest? i.e., we only store the list of SSTs we have in the manifest without the level information, and rebuild the tier/level using the key range and timestamp information (SST metadata).

--- a/mini-lsm-book/src/week2-06-wal.md
+++ b/mini-lsm-book/src/week2-06-wal.md
@@ -6,17 +6,33 @@
 
 ![Chapter Overview](./lsm-tutorial/week2-06-overview.svg)
 
-In this chapter, you will:
+By the end of this chapter, you will be able to:
 
-* Implement encoding and decoding of the write-ahead log file.
-* Recover memtables from the WALs when the system restarts.
+* Encode memtable updates in a write-ahead log and synchronize its buffered data.
+* Record memtable lifetimes in the manifest and recover them from WALs after a restart.
+* Restore newest-to-oldest memtable order and a collision-free next SST ID.
+* Explain the exact durability guarantee provided by `sync` and `close`.
 
-To copy the test cases into the starter code and run them,
+To copy the test cases into the starter code and run them:
 
 ```
 cargo x copy-test --week 2 --day 6
 cargo x scheck
 ```
+
+## Before You Begin
+
+The manifest makes the SST layout recoverable, but it cannot restore writes that were still in memory when the process crashed. A WAL persists the contents of each memtable until that memtable is safely represented by an SST.
+
+Keep these invariants in mind:
+
+1. Every WAL record belongs to exactly one memtable, and the WAL ID becomes the SST ID if that memtable is flushed.
+2. The manifest records each new memtable so recovery knows which WAL files are live. A flush record retires the corresponding WAL logically before the file is removed physically.
+3. Writes may remain in `BufWriter` and the operating-system page cache. They become durable only after `flush()` followed by `sync_all()`.
+4. Recovered immutable memtables are ordered newest to oldest, just like memtables created during normal execution.
+5. `next_sst_id` is one greater than the maximum ID observed in either SST state or live WAL state.
+
+> **Predict before coding:** The manifest contains `NewMemtable(7)` but no `Flush(7)`, and `00007.wal` contains `k -> v`. What should recovery construct? If `Flush(7)` is durable but the old WAL file was not deleted before the crash, should recovery replay it?
 
 ## Task 1: WAL Encoding
 
@@ -26,17 +42,17 @@ In this task, you will need to modify:
 src/wal.rs
 ```
 
-In the previous chapter, we have implemented the manifest file, so that the LSM state can be persisted. And we implemented the `close` function to flush all memtables to SSTs before stopping the engine. Now, what if the system crashes (i.e., powered off)? We can log memtable modifications to WAL (write-ahead log), and recover WALs when restarting the database. WAL is only enabled when `self.options.enable_wal = true`.
+The previous chapter persisted the LSM structure and flushed every memtable during a clean close. A crash can bypass that close path. To recover unflushed data, log each memtable update to a write-ahead log. WALs are enabled only when `self.options.enable_wal` is true.
 
-The WAL encoding is simply a list of key-value pairs.
+The WAL encoding is a list of key-value pairs.
 
 ```
 | key_len | key | value_len | value |
 ```
 
-You will also need to implement the `recover` function to read the WAL and recover the state of a memtable.
+Implement `recover` to replay the WAL into a memtable and reopen the file for appending.
 
-Note that we are using a `BufWriter` for writing the WAL. Using a `BufWriter` can reduce the number of syscalls into the OS, so as to reduce the latency of the write path. The data is not guaranteed to be written to the disk when the user modifies a key. Instead, the engine only guarantee that the data is persisted when `sync` is called. To correctly persist the data to the disk, you will need to first flush the data from the buffer writer to the file object by calling `flush()`, and then do a fsync on the file by using `get_mut().sync_all()`. Note that you *only* need to fsync when the engine's `sync` gets called. You *do not* need to fsync every time on writing data.
+The WAL uses a `BufWriter` to reduce the number of system calls on the write path. Updating a key does not by itself guarantee that the record has reached durable storage. The engine makes that guarantee when `sync` succeeds. Implement `sync` by first calling `flush()` to move bytes from `BufWriter` to the file and then calling `get_mut().sync_all()` to synchronize the file. You do not need to call `sync_all()` for every individual write.
 
 ## Task 2: Integrate WALs
 
@@ -48,9 +64,9 @@ src/wal.rs
 src/lsm_storage.rs
 ```
 
-`MemTable` has a WAL field. If the `wal` field is set to `Some(wal)`, you will need to append to the WAL when updating the memtable. In your LSM engine, you will need to create WALs if `enable_wal = true`. You will also need update the manifest using the `ManifestRecord::NewMemtable` record when new memtable is created.
+`MemTable` has an optional WAL. When it is present, append every update to that WAL. If `enable_wal` is true, create each memtable with `create_with_wal` and append `ManifestRecord::NewMemtable` before making the new WAL-backed memtable available for writes.
 
-You can create a memtable with WAL by using the `create_with_wal` function. WAL should be written to `<memtable_id>.wal` in the storage directory. The memtable id should be the same as the SST id if this memtable gets flushed as an L0 SST.
+Store each WAL as `<memtable_id>.wal` in the database directory. If the memtable is later flushed, reuse that ID for its SST.
 
 ## Task 3: Recover from the WALs
 
@@ -60,22 +76,36 @@ In this task, you will need to modify:
 src/lsm_storage.rs
 ```
 
-If WAL is enabled, you will need to recover the memtables based on WALs when loading the database. You will also need to implement the `sync` function of the database. The basic guarantee of `sync` is that the engine is sure that the data is persisted to the disk (and will be recovered when it restarts). To achieve this, you can simply sync the WAL corresponding to the current memtable.
+If WAL is enabled, recover live memtables from their WALs when opening the database. Also implement the database's `sync` method. After `sync` returns successfully, writes completed before that synchronization point must be recoverable after restart. In this design, synchronizing the current memtable's WAL provides that guarantee because frozen memtables are synchronized when they are replaced.
 
 ```
 cargo run --bin mini-lsm-cli -- --enable-wal
 ```
 
-Remember to recover the correct `next_sst_id` from the state, which should be `max{memtable id, sst id}` + 1. In your `close` function, you should not flush memtables to SSTs if `enable_wal` is set to true, as WAL itself provides persistency. You should wait until all compaction and flush threads to exit before closing the database.
+Restore `next_sst_id` as `max{memtable ID, SST ID} + 1`. When WALs are enabled, `close` synchronizes them instead of flushing every memtable to an SST. Stop and join the compaction and flush threads before returning.
+
+## Chapter Checkpoint
+
+With WALs enabled, synchronized writes should survive a restart even when their memtables were never flushed. Recovery should ignore stale WAL files retired by manifest flush records, rebuild live immutable memtables in newest-to-oldest order, create a fresh mutable memtable with a new WAL, and choose an unused ID.
+
+Test more than a clean close: create several memtables, synchronize, reopen, and trace the manifest records that identify each live WAL. Explain which writes are guaranteed to survive if the process stops before `sync`, after `sync`, and after a flush record becomes durable but before its WAL file is removed.
 
 ## Test Your Understanding
+
+### Recovery and Durability
 
 * When should you call `fsync` in your engine? What happens if you call `fsync` too often (i.e., on every put key request)?
 * How costly is the `fsync` operation in general on an SSD (solid state drive)?
 * When can you tell the user that their modifications (put/delete) have been persisted?
+* Why must a new memtable be recorded in the manifest before a synchronized write to its WAL can be considered recoverable?
+* Why should a flushed memtable's WAL be deleted only after the manifest's flush record is durable?
+* Given WAL IDs 4 and 9 plus live SST IDs 3, 7, and 12, what ID should the next memtable use?
 * How can you handle corrupted data in WAL?
+
+### Performance and Design
+
 * Is it possible to design an LSM engine without WAL (i.e., use L0 as WAL)? What will be the implications of this design?
 
-We do not provide reference answers to the questions, and feel free to discuss about them in the Discord community.
+We do not provide reference answers to these questions, so feel free to discuss them in the Discord community.
 
 {{#include copyright.md}}

--- a/mini-lsm-book/src/week2-07-snacks.md
+++ b/mini-lsm-book/src/week2-07-snacks.md
@@ -6,32 +6,48 @@
 
 <!-- ![Chapter Overview](./lsm-tutorial/week2-07-overview.svg) -->
 
-In the previous chapter, you already built a full LSM-based storage engine. At the end of this week, we will implement some easy but important optimizations of the storage engine. Welcome to Mini-LSM's week 2 snack time!
+The previous chapter completed the persistent LSM engine. This final chapter adds a small API improvement and integrity checks for every on-disk format. Welcome to Week 2 snack time!
 
-In this chapter, you will:
+By the end of this chapter, you will be able to:
 
 * Implement the batch write interface.
-* Add checksums to the blocks, SST metadata, manifest, and WALs.
+* Add checksums to data blocks, SST metadata, bloom filters, manifest records, and WAL records.
+* Define the exact byte range protected by each checksum and reject corrupted input.
+* Explain why framing information is necessary for checksummed variable-length records.
 
-**Note: We do not have unit tests for this chapter. As long as you pass all previous tests and ensure checksums are properly encoded in your file format, it would be fine.**
+**Note:** The starter suite does not provide dedicated tests for this chapter. Run every earlier test, inspect each encoded format, and add corruption cases that verify your checksum boundaries.
+
+## Before You Begin
+
+This chapter changes every persistent format that the earlier chapters created. A checksum is useful only when the writer and reader agree on the exact bytes it covers and the reader can locate both those bytes and the stored checksum without trusting corrupted length fields blindly.
+
+Keep these invariants in mind:
+
+1. `put` and `delete` delegate to `write_batch`, so the existing single-record behavior remains unchanged. This Week 2 API processes a group of records but does not yet promise transactional atomicity.
+2. A checksum is computed over the encoded bytes exactly as they appear on disk, including a consistent byte order for integer fields.
+3. Each decoder isolates the same byte range that its encoder checksummed and verifies it before decoding or exposing the protected payload.
+4. Offsets and lengths delimit variable-size sections. The checksum itself and unrelated preceding bytes are not accidentally included.
+5. Corruption produces an error rather than silently returning data. Handling torn or truncated records without panicking is a separate robustness concern to consider.
+
+> **Predict before coding:** `Bloom::encode` appends a bloom filter to an SST buffer that already contains data blocks and metadata. If the checksum is computed over the entire buffer, what happens when `Bloom::decode` receives only the bloom-filter section? Which offset must the encoder remember?
 
 ## Task 1: Write Batch Interface
 
-In this task, we will prepare for week 3 of this course by adding a write batch API. You will need to modify:
+Prepare for Week 3 by adding a write-batch API. You will need to modify:
 
 ```
 src/lsm_storage.rs
 ```
 
-The user provides `write_batch` with a batch of records to be written to the database. The records are `WriteBatchRecord<T: AsRef<[u8]>>`, and therefore it can be either `Bytes`, `&[u8]` or `Vec<u8>`. There are two types of records: delete and put. You may handle them in the same way as your `put` and `delete` function.
+The user passes `write_batch` a slice of `WriteBatchRecord<T: AsRef<[u8]>>`, so keys and values may use types such as `Bytes`, `&[u8]`, or `Vec<u8>`. The two record variants are delete and put. Handle them with the same semantics as the existing `delete` and `put` methods.
 
-After that, you may refactor your original `put` and `delete` function to call `write_batch`.
+Then refactor `put` and `delete` to call `write_batch` with one record.
 
-You should pass all test cases in previous chapters after implementing this functionality.
+All tests from earlier chapters should continue to pass.
 
 ## Task 2: Block Checksum
 
-In this task, you will need to add a block checksum at the end of each block when encoding the SST. You will need to modify:
+Add a checksum after each encoded data block. You will need to modify:
 
 ```
 src/table/builder.rs
@@ -49,15 +65,15 @@ The format of the SST will be changed to:
 ---------------------------------------------------------------------------------------------------------------------------
 ```
 
-We use crc32 as our checksum algorithm. You can use `crc32fast::hash` to generate the checksum for the block after building a block.
+Use CRC-32 through `crc32fast::hash` to checksum each encoded block.
 
-Usually, when user specify the target block size in the storage options, the size should include both block content and checksum. For example, if the target block size is 4096, and the checksum takes 4 bytes, the actual block content target size should be 4092. However, to avoid breaking previous test cases and for simplicity, in our course, we will **still** use the target block size as the target content size, and simply append the checksum at the end of the block.
+Normally, the configured block size includes both content and checksum. A 4,096-byte target with a four-byte checksum would therefore leave 4,092 bytes for block content. To preserve the earlier tests, Mini-LSM continues to treat the configured size as the content target and appends the checksum afterward.
 
-When you read the block, you should verify the checksum in `read_block` correctly generate the slices for the block content. You should pass all test cases in previous chapters after implementing this functionality.
+In `read_block`, separate the content from its checksum, verify the content, and decode it only after verification succeeds. Run every earlier test after changing the format.
 
 ## Task 3: SST Meta Checksum
 
-In this task, you will need to add a block checksum for bloom filters and block metadata:
+Add checksums for bloom filters and block metadata. You will need to modify:
 
 ```
 src/table.rs
@@ -74,9 +90,9 @@ src/table/builder.rs
 ----------------------------------------------------------------------------------------------------------
 ```
 
-You will need to add a checksum at the end of the bloom filter in `Bloom::encode` and `Bloom::decode`. Note that most of our APIs take an existing buffer that the implementation will write into, for example, `Bloom::encode`. Therefore, you should record the offset of the beginning of the bloom filter before writing the encoded content, and only checksum the bloom filter itself instead of the whole buffer.
+Append a checksum in `Bloom::encode` and verify it in `Bloom::decode`. Because `encode` appends to an existing buffer, record the bloom filter's starting offset and checksum only the bytes added for that filter.
 
-After that, you can add a checksum at the end of block metadata. You might find it helpful to also add a length of metadata at the beginning of the section, so that it will be easier to know where to stop when decoding the block metadata.
+Then append a checksum to the block metadata. The existing block count can guide decoding; an explicit metadata length is another possible framing design.
 
 ## Task 4: WAL Checksum
 
@@ -86,12 +102,12 @@ In this task, you will need to modify:
 src/wal.rs
 ```
 
-We will do a per-record checksum in the write-ahead log. To do this, you have two choices:
+Protect each WAL record with its own checksum. You have two implementation choices:
 
 * Generate a buffer of the key-value record, and use `crc32fast::hash` to compute the checksum at once.
 * Write one field at a time (e.g., key length, key slice), and use a `crc32fast::Hasher` to compute the checksum incrementally on each field.
 
-This is up to your choice and you will need to *choose your own adventure*. Both method should produce exactly the same result, as long as you handle little endian / big endian correctly. The new WAL encoding should be like:
+Choose whichever approach makes the protected byte range clearest. Both methods must produce the same checksum: incremental hashing must feed the exact encoded bytes in their on-disk byte order. The new WAL encoding is:
 
 ```
 | key_len | key | value_len | value | checksum |
@@ -99,7 +115,7 @@ This is up to your choice and you will need to *choose your own adventure*. Both
 
 ## Task 5: Manifest Checksum
 
-Lastly, let us add a checksum on the manifest file. Manifest is similar to a WAL, except that previously, we do not store the length of each record. To make the implementation easier, we now add a header of record length at the beginning of a record, and add a checksum at the end of the record.
+Finally, protect each manifest record. Unlike the WAL, the Day 5 manifest did not store record lengths. Add a length header before each JSON record and a checksum after it.
 
 The new manifest format is like:
 
@@ -107,17 +123,32 @@ The new manifest format is like:
 | len | JSON record | checksum | len | JSON record | checksum | len | JSON record | checksum |
 ```
 
-After implementing everything, you should pass all previous test cases. We do not provide new test cases in this chapter.
+After implementing every format change, run all previous tests and your own corruption cases.
+
+## Chapter Checkpoint
+
+All earlier behavior should still pass after the format changes. In addition, every persistent section should round-trip successfully and fail verification when one protected byte is changed. Confirm that appending a bloom filter or metadata section to a non-empty buffer does not make its checksum depend on preceding sections.
+
+Build a small SST and identify every offset, length, payload, and checksum by byte range. Do the same for one WAL and one manifest record. For each format, flip a payload byte and predict which decoder reports the error. Also consider a truncated length or checksum and decide whether your decoder returns an error or panics.
 
 ## Test Your Understanding
 
-* Consider the case that an LSM storage engine only provides `write_batch` as the write interface (instead of single put + delete). Is it possible to implement it as follows: there is a single write thread with an mpsc channel receiver to get the changes, and all threads send write batches to the write thread. The write thread is the single point to write to the database. What are the pros/cons of this implementation? (Congrats if you do so you get BadgerDB!)
-* Is it okay to put all block checksums altogether at the end of the SST file instead of store it along with the block? Why?
+### Correctness and Corruption
 
-We do not provide reference answers to the questions, and feel free to discuss about them in the Discord community.
+* Does `write_batch` in this chapter provide atomic visibility or durability for the whole batch? What additional synchronization would be needed to make that guarantee?
+* Why must an incremental WAL checksum hash the encoded byte order of each length rather than the integer's native in-memory representation?
+* For every SST checksum, identify the first protected byte, the last protected byte, and the location of the stored checksum.
+* What happens if corruption changes a length or offset before the decoder has located the protected payload? How can a decoder validate bounds before slicing?
+* Is it okay to put all block checksums together at the end of the SST file instead of storing each checksum with its block? Why or why not?
+
+### API and Design
+
+* Consider the case that an LSM storage engine only provides `write_batch` as the write interface (instead of single put + delete). Is it possible to implement it as follows: there is a single write thread with an mpsc channel receiver to get the changes, and all threads send write batches to the write thread. The write thread is the single point to write to the database. What are the pros/cons of this implementation? (Congrats if you do so you get BadgerDB!)
+
+We do not provide reference answers to these questions, so feel free to discuss them in the Discord community.
 
 ## Bonus Tasks
 
-* **Recovering when Corruption**. If there is a checksum error, open the database in a safe mode so that no writes can be performed and non-corrupted data can still be retrieved.
+* **Recovering from Corruption.** If a checksum fails, open the database in a read-only safe mode that can retrieve unaffected data.
 
 {{#include copyright.md}}

--- a/mini-lsm-book/src/week2-overview.md
+++ b/mini-lsm-book/src/week2-overview.md
@@ -6,24 +6,37 @@
 
 ![Chapter Overview](./lsm-tutorial/week2-overview.svg)
 
-In the last week, you have implemented all necessary structures for an LSM storage engine, and your storage engine already supports read and write interfaces. In this week, we will deep dive into the disk organization of the SST files and investigate an optimal way to achieve both performance and cost efficiency in the system. We will spend 4 days learning different compaction strategies, from the easiest to the most complex ones, and then implement the remaining parts for the storage engine persistence. At the end of this week, you will have a fully functional and efficient LSM storage engine.
+In Week 1, you built the core structures of an LSM storage engine and implemented its read and write interfaces. This week, you will organize SSTs on disk, compare compaction strategies, and make the engine recoverable. The first four chapters progress from the mechanics of one compaction to increasingly realistic scheduling policies. The final three chapters persist the LSM state and unflushed writes, then protect every on-disk format with checksums.
 
-We have 7 chapters (days) in this part:
+| Chapter | Before | After |
+| --- | --- | --- |
+| [Day 1: Compaction Implementation](./week2-01-compaction.md) | Every flushed SST remains in L0. | The engine can merge L0 and L1 into a non-overlapping sorted run and read through it efficiently. |
+| [Day 2: Simple Leveled Compaction](./week2-02-simple.md) | Compaction runs only when requested explicitly. | A background controller maintains several levels using file-count ratios. |
+| [Day 3: Tiered/Universal Compaction](./week2-03-tiered.md) | Every strategy writes new SSTs through L0. | The engine can maintain newest-to-oldest tiers and trade read and space amplification for fewer rewrites. |
+| [Day 4: Leveled Compaction](./week2-04-leveled.md) | Simple leveled compaction rewrites entire levels and moves data through empty levels. | Dynamic target sizes and partial compaction reduce unnecessary rewrites and peak space usage. |
+| [Day 5: Manifest](./week2-05-manifest.md) | The LSM's file layout exists only in memory. | An append-only manifest reconstructs the durable SST layout after a restart. |
+| [Day 6: Write-Ahead Log (WAL)](./week2-06-wal.md) | Unflushed writes survive only a clean close. | WAL-backed memtables make acknowledged, synchronized writes recoverable after a crash. |
+| [Day 7: Batch Write and Checksums](./week2-07-snacks.md) | Writes are submitted one at a time, and corrupted files may be consumed silently. | The engine accepts write batches and verifies the integrity of its SSTs, manifest, and WALs. |
 
+## How to Use This Week
 
-* [Day 1: Compaction Implementation](./week2-01-compaction.md). You will merge all L0 SSTs into a sorted run.
-* [Day 2: Simple Leveled Compaction](./week2-02-simple.md). You will implement a classic leveled compaction algorithm and use compaction simulator to see how well it works.
-* [Day 3: Tiered/Universal Compaction](./week2-03-tiered.md). You will implement the RocksDB universal compaction algorithm and understand the pros/cons.
-* [Day 4: Leveled Compaction](./week2-04-leveled.md). You will implement the RocksDB leveled compaction algorithm. This compaction algorithm also supports partial compaction, so as to reduce peak space usage.
-* [Day 5: Manifest](./week2-05-manifest.md). You will store the LSM state on the disk and recover from the state.
-* [Day 6: Write-Ahead Log (WAL)](./week2-06-wal.md). User requests will be routed to both memtable and WAL so that all operations will be persisted.
-* [Day 7: Write Batch and Checksums](./week2-07-snacks.md). You will implement write batch API (for preparation for week 3 MVCC) and checksums for all of your storage formats.
+Compaction code can produce plausible-looking output while violating version order, retaining stale files, or deleting tombstones too early. Persistence code can pass restart tests while still using an unsafe write order. Treat each chapter as an exercise in preserving invariants, not only as an exercise in matching simulator output.
+
+For each chapter:
+
+1. Write down the ordering and ownership invariants before implementing the task.
+2. Predict the next compaction task or recovered state for the chapter's small example.
+3. Run the focused tests and compare simulator output with the reference implementation where instructed.
+4. Trace one overwrite and one deletion through the new structure. For persistence chapters, also trace a crash between each pair of durable writes.
+5. Answer the correctness questions with a concrete state, execution, or corrupted byte sequence.
+
+The simulator measures useful structural properties, but it does not prove that reads return the newest value or that concurrent flushes are retained. Likewise, a successful reopen test exercises only a few possible crash points. Use the chapter checkpoints to review the cases that automated validation does not cover.
 
 ## Compaction and Read Amplification
 
-Let us talk about compaction first. In the previous part, you simply flush the memtable to an L0 SST. Imagine that you have written gigabytes of data and now you have 100 SSTs. Every read request (without filtering) will need to read 100 blocks from these SSTs. This amplification is read amplification -- the number of I/O requests you will need to send to the disk for one get operation.
+Let us begin with compaction. In the previous part, you flushed each memtable to an L0 SST. Imagine that you have written gigabytes of data and now have 100 overlapping SSTs. Without filters, one point read might need to probe all 100 files. **Read amplification** is the amount of physical read work required for one logical read; in this simplified example, it is the number of blocks read from disk.
 
-To reduce read amplification, we can merge all the L0 SSTs into a larger structure, so that it would be possible to only read one SST and one block to retrieve the requested data. Say that we still have these 100 SSTs, and now, we do a merge sort of these 100 SSTs to produce another 100 SSTs, each of them contains non-overlapping key ranges. This process is **compaction**, and these 100 non-overlapping SSTs is a **sorted run**.
+To reduce read amplification, we can merge the L0 SSTs into files with non-overlapping key ranges. A point lookup then needs to inspect at most one candidate SST in that group. The merge-and-rewrite process is **compaction**, and an ordered collection of non-overlapping SSTs is a **sorted run**.
 
 To make this process clearer, let us take a look at this concrete example:
 
@@ -33,7 +46,7 @@ SST 2: key range 00005 - key 10005, 1000 keys
 SST 3: key range 00010 - key 10010, 1000 keys
 ```
 
-We have 3 SSTs in the LSM structure. If we need to access key 02333, we will need to probe all of these 3 SSTs. If we can do a compaction, we might get the following 3 new SSTs:
+The three SSTs have overlapping key ranges, so a lookup for key 02333 might probe all of them. After compaction, the engine might produce these three SSTs:
 
 ```
 SST 4: key range 00000 - key 03000, 1000 keys
@@ -41,13 +54,13 @@ SST 5: key range 03001 - key 06000, 1000 keys
 SST 6: key range 06000 - key 10010, 1000 keys
 ```
 
-The 3 new SSTs are created by merging SST 1, 2, and 3. We can get a sorted 3000 keys and then split them into 3 files, so as to avoid having a super large SST file. Now our LSM state has 3 non-overlapping SSTs, and we only need to access SST 4 to find key 02333.
+The engine merges SSTs 1, 2, and 3, resolves duplicate keys, and splits the sorted result to avoid producing one oversized file. The three output SSTs have non-overlapping ranges, so a lookup for key 02333 needs to inspect only SST 4.
 
 ## Two Extremes of Compaction and Write Amplification
 
-So from the above example, we have 2 naive ways of handling the LSM structure -- not doing compactions at all, and always do full compaction when new SSTs are flushed.
+The example suggests two extremes: never compact, or run a full compaction after every flush.
 
-Compaction is a time-consuming operation. It will need to read all data from some files, and write the same amount of files to the disk. This operation takes a lot of CPU resources and I/O resources. Not doing compactions at all leads to high read amplification, but it does not need to write new files. Always doing full compaction reduces the read amplification, but it will need to constantly rewrite the files on the disk.
+Compaction consumes CPU and I/O because it reads input files and writes replacement files. Never compacting avoids rewrites but causes high read amplification. Always running full compaction lowers read amplification but repeatedly rewrites the entire database.
 
 ![no compaction](./lsm-tutorial/week2-00-two-extremes-1.svg)
 
@@ -57,46 +70,56 @@ Compaction is a time-consuming operation. It will need to read all data from som
 
 <p class="caption">Always compact when new SST being flushed</p>
 
-The ratio of memtables flushed to the disk versus total data written to the disk is write amplification. That is to say, no compaction has a write amplification ratio of 1x, because once the SSTs are flushed to the disk, they will stay there. Always doing compaction has a very high write amplification. If we do a full compaction every time we get an SST, the data written to the disk will be quadratic to the number of SSTs flushed. For example, if we flushed 100 SSTs to the disk, we will do compactions of 2 files, 3 files, ..., 100 files, where the actual total amount of data we wrote to the disk is about 5000 SSTs. The write amplification after writing 100 SSTs in this cause would be 50x.
+**Write amplification** is the ratio of total physical bytes written to the logical bytes flushed into the LSM tree. With no compaction, the ratio is 1x because each SST is written once and never rewritten. Compacting everything after every flush has very high write amplification: after 100 equal-sized flushes, the engine rewrites approximately 2 + 3 + ... + 100 SSTs' worth of data. It therefore writes about 5,000 SSTs' worth for 100 SSTs of logical input, or roughly 50x write amplification.
 
-A good compaction strategy can balance read amplification, write amplification, and space amplification (we will talk about it soon). In a general-purpose LSM storage engine, it is generally impossible to find a strategy that can achieve the lowest amplification in all 3 of these factors, unless there are some specific data pattern that the engine could use. The good thing about LSM is that we can theoretically analyze the amplifications of a compaction strategy and all these things happen in the background. We can choose compaction strategies and dynamically change some parameters of them to adjust our storage engine to the optimal state. Compaction strategies are all about tradeoffs, and LSM-based storage engine enables us to select what to be traded at runtime.
+A good compaction strategy balances read, write, and space amplification. A general-purpose LSM storage engine cannot minimize all three simultaneously unless it can exploit a specific workload pattern. Because compaction happens in the background, the engine can select a strategy and tune its parameters as the workload changes. Compaction policy is therefore an explicit choice about which costs to trade for others.
 
 ![compaction tradeoffs](./lsm-tutorial/week2-00-triangle.svg)
 
-One typical workload in the industry is like: the user first batch ingests data into the storage engine, usually gigabytes per second, when they start a product. Then, the system goes live and users start doing small transactions over the system. In the first phase, the engine should be able to quickly ingest data, and therefore we can use a compaction strategy that minimize write amplification to accelerate this process. Then, we adjust the parameters of the compaction algorithm to make it optimized for read amplification, and do a full compaction to reorder existing data, so that the system can run stably when it goes live.
+A common production workload begins with a high-throughput bulk ingest and later shifts to small online transactions. During ingestion, the engine can favor low write amplification. Before serving the online workload, it can retune compaction for lower read amplification and reorganize the existing data.
 
-If the workload is like a time-series database, it is possible that the user always populate and truncate data by time. Therefore, even if there is no compaction, these append-only data can still have low amplification on the disk. Therefore, in real life, you should watch for patterns or specific requirements from the users, and use these information to optimize your system.
+For a time-series workload, users might append and expire data in time order. Such a pattern can have low amplification even with little compaction. In practice, observe the workload and its requirements rather than selecting a policy from aggregate ratios alone.
 
 ## Compaction Strategies Overview
 
-Compaction strategies usually aim to control the number of sorted runs, so as to keep read amplification in a reasonable amount of number. There are generally two categories of compaction strategies: leveled and tiered.
+Compaction strategies control the number and sizes of sorted runs to keep read amplification within a chosen bound. They generally fall into two categories: leveled and tiered.
 
-In leveled compaction, the user can specify a maximum number of levels, which is the number of sorted runs in the system (except L0). For example, RocksDB usually keeps 6 levels (sorted runs) in leveled compaction mode. During the compaction process, SSTs from two adjacent levels will be merged and then the produced SSTs will be put to the lower level of the two levels. Therefore, you will usually see a small sorted run merged with a large sorted run in leveled compaction. The sorted runs (levels) grow exponentially in size -- the lower level will be `<some number>` of the upper level in size.
+In leveled compaction, the user specifies a maximum number of levels, excluding L0. Each level is one sorted run. A compaction merges data from two adjacent levels and places the output in the lower one, so a relatively small sorted run is often merged into a much larger run. Target level sizes grow geometrically according to a configured multiplier.
 
 ![leveled compaction](./lsm-tutorial/week2-00-leveled.svg)
 
-In tiered compaction, the engine will dynamically adjust the number of sorted runs by merging them or letting new SSTs flushed as new sorted run (a tier) to minimize write amplification. In this strategy, you will usually see the engine merge two equally-sized sorted runs. The number of tiers can be high if the compaction strategy does not choose to merge tiers, therefore making read amplification high. In this course, we will implement RocksDB's universal compaction, which is a kind of tiered compaction strategy.
+In tiered compaction, each flush can create a new sorted run, or tier, and the engine merges tiers to control their count. The policy often merges runs of similar sizes, reducing write amplification compared with repeatedly merging a small run into a large one. Allowing too many tiers, however, increases read amplification. This course implements RocksDB's universal compaction, a tiered strategy.
 
 ![tiered compaction](./lsm-tutorial/week2-00-tiered.svg)
 
 ## Space Amplification
 
-The most intuitive way to compute space amplification is to divide the actual space used by the LSM engine by the user space usage (i.e., database size, number of rows in the database, etc.) . The engine will need to store delete tombstones, and sometimes multiple version of the same key if compaction is not happening frequently enough, therefore causing space amplification.
+The most intuitive measure of **space amplification** is the physical space used by the LSM engine divided by the logical size of the live user data. Tombstones and obsolete versions consume space until compaction can remove them.
 
-On the engine side, it is usually hard to know the exact amount of data the user is storing, unless we scan the whole database and see how many dead versions are there in the engine. Therefore, one way of estimating the space amplification is to divide the full storage file size by the last level size. The assumption behind this estimation method is that the insertion and deletion rate of a workload should be the same after the user fills the initial data. We assume the user-side data size does not change, and therefore the last level contains the snapshot of the user data at some point, and the upper levels contain new changes. When compaction merges everything to the last level, we can get a space amplification factor of 1x using this estimation method.
+The engine cannot know the exact logical data size without scanning for obsolete versions. One practical estimate divides the total SST size by the last level's size. This estimate assumes a steady-state workload whose logical size remains roughly constant: the bottom level approximates an older complete snapshot, while upper levels contain subsequent changes. After a full compaction moves all live data to the bottom, the estimate approaches 1x.
 
-Note that compaction also takes space -- you cannot remove files being compacted before the compaction is complete. If you do a full compaction of the database, you will need free storage space as much as the current engine file size.
+Compaction also requires temporary space because its input files cannot be removed before the output is complete and durable. A full compaction may therefore require free space comparable to the current database size.
 
-In this part, we will have a compaction simulator to help you visualize the compaction process and the decision of your compaction algorithm. We provide minimal test cases to check the properties of your compaction algorithm, and you should watch closely on the statistics and the output of the compaction simulator to know how well your compaction algorithm works.
+The compaction simulator visualizes each scheduling decision and reports its amplification statistics. The tests check only a few structural properties, so inspect the simulator output closely and compare it with the reference implementation.
 
 ## Persistence
 
-After implementing the compaction algorithms, we will implement two key components in the system: manifest, which is a file that stores the LSM state, and WAL, which persists memtable data to the disk before it is flushed as an SST. After finishing these two components, the storage engine will have full persistence support and can be used in your products.
+After implementing the compaction algorithms, you will add two persistence components: the manifest, which records structural changes to the LSM tree, and the WAL, which preserves memtable updates before they are flushed to SSTs. Together they let the engine reconstruct both its on-disk layout and its unflushed state after a restart.
 
-If you do not want to dive too deep into compactions, you can also finish chapter 2.1 and 2.2 to implement a very simple leveled compaction algorithm, and directly go for the persistence part. Implementing full leveled compaction and universal compaction are not required to build a working storage engine in week 2.
+If you do not want to explore every compaction policy, complete Days 1 and 2 and then continue to persistence. Universal compaction and dynamic leveled compaction are not required to build a working Week 2 engine.
 
 ## Snack Time
 
 After implementing compaction and persistence, we will have a short chapter on implementing the batch write interface and checksums.
+
+Before moving to Week 3, check that you can explain:
+
+- how every compaction input is ordered and why the newest version wins;
+- when a tombstone may be discarded and why dropping it earlier can resurrect a value;
+- how leveled and tiered policies trade read, write, and space amplification;
+- how a compaction result is installed without losing an L0 flush that completed concurrently;
+- which facts belong in the manifest and which bytes belong in a WAL;
+- the required durable-write order for creating and deleting files;
+- what each checksum covers and how a decoder finds that exact byte range.
 
 {{#include copyright.md}}

--- a/mini-lsm-mvcc/src/compact/tiered.rs
+++ b/mini-lsm-mvcc/src/compact/tiered.rs
@@ -108,7 +108,7 @@ impl TieredCompactionController {
                 .take(num_tiers_to_take)
                 .cloned()
                 .collect::<Vec<_>>(),
-            bottom_tier_included: snapshot.levels.len() >= num_tiers_to_take,
+            bottom_tier_included: snapshot.levels.len() == num_tiers_to_take,
         })
     }
 
@@ -140,7 +140,7 @@ impl TieredCompactionController {
                 // retain the tier
                 levels.push((*tier_id, files.clone()));
             }
-            if tier_to_remove.is_empty() && !new_tier_added {
+            if tier_to_remove.is_empty() && !new_tier_added && !output.is_empty() {
                 // add the compacted tier to the LSM tree
                 new_tier_added = true;
                 levels.push((output[0], output.to_vec()));

--- a/mini-lsm-mvcc/src/lsm_storage.rs
+++ b/mini-lsm-mvcc/src/lsm_storage.rs
@@ -482,6 +482,7 @@ impl LsmStorageInner {
     }
 
     pub fn sync(&self) -> Result<()> {
+        let _state_lock = self.state_lock.lock();
         self.state.read().memtable.sync_wal()
     }
 
@@ -711,13 +712,15 @@ impl LsmStorageInner {
             Arc::new(MemTable::create(memtable_id))
         };
 
-        self.freeze_memtable_with_memtable(memtable)?;
-
+        if self.options.enable_wal {
+            self.sync_dir()?;
+        }
         self.manifest().add_record(
             state_lock_observer,
             ManifestRecord::NewMemtable(memtable_id),
         )?;
-        self.sync_dir()?;
+
+        self.freeze_memtable_with_memtable(memtable)?;
 
         Ok(())
     }
@@ -745,6 +748,7 @@ impl LsmStorageInner {
             Some(self.block_cache.clone()),
             self.path_of_sst(sst_id),
         )?);
+        self.sync_dir()?;
 
         // Add the flushed L0 table to the list.
         {
@@ -767,12 +771,12 @@ impl LsmStorageInner {
             *guard = Arc::new(snapshot);
         }
 
+        self.manifest()
+            .add_record(&state_lock, ManifestRecord::Flush(sst_id))?;
+
         if self.options.enable_wal {
             std::fs::remove_file(self.path_of_wal(sst_id))?;
         }
-
-        self.manifest()
-            .add_record(&state_lock, ManifestRecord::Flush(sst_id))?;
 
         self.sync_dir()?;
 

--- a/mini-lsm/src/compact/tiered.rs
+++ b/mini-lsm/src/compact/tiered.rs
@@ -108,7 +108,7 @@ impl TieredCompactionController {
                 .take(num_tiers_to_take)
                 .cloned()
                 .collect::<Vec<_>>(),
-            bottom_tier_included: snapshot.levels.len() >= num_tiers_to_take,
+            bottom_tier_included: snapshot.levels.len() == num_tiers_to_take,
         })
     }
 
@@ -140,7 +140,7 @@ impl TieredCompactionController {
                 // retain the tier
                 levels.push((*tier_id, files.clone()));
             }
-            if tier_to_remove.is_empty() && !new_tier_added {
+            if tier_to_remove.is_empty() && !new_tier_added && !output.is_empty() {
                 // add the compacted tier to the LSM tree
                 new_tier_added = true;
                 levels.push((output[0], output.to_vec()));

--- a/mini-lsm/src/lsm_storage.rs
+++ b/mini-lsm/src/lsm_storage.rs
@@ -465,6 +465,7 @@ impl LsmStorageInner {
     }
 
     pub fn sync(&self) -> Result<()> {
+        let _state_lock = self.state_lock.lock();
         self.state.read().memtable.sync_wal()
     }
 
@@ -655,13 +656,15 @@ impl LsmStorageInner {
             Arc::new(MemTable::create(memtable_id))
         };
 
-        self.freeze_memtable_with_memtable(memtable)?;
-
+        if self.options.enable_wal {
+            self.sync_dir()?;
+        }
         self.manifest.as_ref().unwrap().add_record(
             state_lock_observer,
             ManifestRecord::NewMemtable(memtable_id),
         )?;
-        self.sync_dir()?;
+
+        self.freeze_memtable_with_memtable(memtable)?;
 
         Ok(())
     }
@@ -689,6 +692,7 @@ impl LsmStorageInner {
             Some(self.block_cache.clone()),
             self.path_of_sst(sst_id),
         )?);
+        self.sync_dir()?;
 
         // Add the flushed L0 table to the list.
         {
@@ -711,14 +715,14 @@ impl LsmStorageInner {
             *guard = Arc::new(snapshot);
         }
 
-        if self.options.enable_wal {
-            std::fs::remove_file(self.path_of_wal(sst_id))?;
-        }
-
         self.manifest
             .as_ref()
             .unwrap()
             .add_record(&state_lock, ManifestRecord::Flush(sst_id))?;
+
+        if self.options.enable_wal {
+            std::fs::remove_file(self.path_of_wal(sst_id))?;
+        }
 
         self.sync_dir()?;
 

--- a/mini-lsm/src/tests/week2_day3.rs
+++ b/mini-lsm/src/tests/week2_day3.rs
@@ -15,7 +15,10 @@
 use tempfile::tempdir;
 
 use crate::{
-    compact::{CompactionOptions, TieredCompactionOptions},
+    compact::{
+        CompactionOptions, TieredCompactionController, TieredCompactionOptions,
+        TieredCompactionTask,
+    },
     lsm_storage::{LsmStorageOptions, MiniLsm},
 };
 
@@ -40,4 +43,56 @@ fn test_integration() {
 
     compaction_bench(storage.clone());
     check_compaction_ratio(storage.clone());
+}
+
+#[test]
+fn test_reduce_sorted_runs_respects_max_merge_width() {
+    let options = TieredCompactionOptions {
+        num_tiers: 4,
+        max_size_amplification_percent: 10_000,
+        size_ratio: 10_000,
+        min_merge_width: 2,
+        max_merge_width: Some(2),
+    };
+    let controller = TieredCompactionController::new(options.clone());
+    let dir = tempdir().unwrap();
+    let storage = MiniLsm::open(
+        &dir,
+        LsmStorageOptions::default_for_week2_test(CompactionOptions::Tiered(options)),
+    )
+    .unwrap();
+    let mut snapshot = storage.inner.state.read().as_ref().clone();
+    snapshot.levels = vec![(4, vec![4]), (3, vec![3]), (2, vec![2]), (1, vec![1])];
+
+    let task = controller.generate_compaction_task(&snapshot).unwrap();
+    assert_eq!(task.tiers, snapshot.levels[..2]);
+    assert!(!task.bottom_tier_included);
+}
+
+#[test]
+fn test_tiered_compaction_accepts_empty_output() {
+    let options = TieredCompactionOptions {
+        num_tiers: 2,
+        max_size_amplification_percent: 200,
+        size_ratio: 1,
+        min_merge_width: 2,
+        max_merge_width: None,
+    };
+    let controller = TieredCompactionController::new(options.clone());
+    let dir = tempdir().unwrap();
+    let storage = MiniLsm::open(
+        &dir,
+        LsmStorageOptions::default_for_week2_test(CompactionOptions::Tiered(options)),
+    )
+    .unwrap();
+    let mut snapshot = storage.inner.state.read().as_ref().clone();
+    snapshot.levels = vec![(2, vec![2]), (1, vec![1])];
+    let task = TieredCompactionTask {
+        tiers: snapshot.levels.clone(),
+        bottom_tier_included: true,
+    };
+
+    let (result, removed) = controller.apply_compaction_result(&snapshot, &task, &[]);
+    assert!(result.levels.is_empty());
+    assert_eq!(removed, vec![2, 1]);
 }

--- a/mini-lsm/src/wal.rs
+++ b/mini-lsm/src/wal.rs
@@ -56,12 +56,12 @@ impl Wal {
         while rbuf.has_remaining() {
             let mut hasher = crc32fast::Hasher::new();
             let key_len = rbuf.get_u16() as usize;
-            hasher.write_u16(key_len as u16);
+            hasher.write(&(key_len as u16).to_be_bytes());
             let key = Bytes::copy_from_slice(&rbuf[..key_len]);
             hasher.write(&key);
             rbuf.advance(key_len);
             let value_len = rbuf.get_u16() as usize;
-            hasher.write_u16(value_len as u16);
+            hasher.write(&(value_len as u16).to_be_bytes());
             let value = Bytes::copy_from_slice(&rbuf[..value_len]);
             hasher.write(&value);
             rbuf.advance(value_len);
@@ -78,14 +78,15 @@ impl Wal {
 
     pub fn put(&self, key: &[u8], value: &[u8]) -> Result<()> {
         let mut file = self.file.lock();
-        let mut buf: Vec<u8> =
-            Vec::with_capacity(key.len() + value.len() + std::mem::size_of::<u16>());
+        let mut buf: Vec<u8> = Vec::with_capacity(
+            key.len() + value.len() + std::mem::size_of::<u16>() * 2 + std::mem::size_of::<u32>(),
+        );
         let mut hasher = crc32fast::Hasher::new();
-        hasher.write_u16(key.len() as u16);
+        hasher.write(&(key.len() as u16).to_be_bytes());
         buf.put_u16(key.len() as u16);
         hasher.write(key);
         buf.put_slice(key);
-        hasher.write_u16(value.len() as u16);
+        hasher.write(&(value.len() as u16).to_be_bytes());
         buf.put_u16(value.len() as u16);
         buf.put_slice(value);
         hasher.write(value);
@@ -105,5 +106,27 @@ impl Wal {
         file.flush()?;
         file.get_mut().sync_all()?;
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use bytes::Buf;
+    use tempfile::tempdir;
+
+    use super::Wal;
+
+    #[test]
+    fn test_checksum_covers_encoded_record() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("test.wal");
+        let wal = Wal::create(&path).unwrap();
+        wal.put(b"key", b"value").unwrap();
+        wal.sync().unwrap();
+
+        let data = std::fs::read(path).unwrap();
+        let checksum_offset = data.len() - std::mem::size_of::<u32>();
+        let expected = (&data[checksum_offset..]).get_u32();
+        assert_eq!(crc32fast::hash(&data[..checksum_offset]), expected);
     }
 }


### PR DESCRIPTION
Week 2 currently leaves several ordering, tombstone, and durability invariants implicit, which makes plausible but incorrect implementations difficult to diagnose.

- Reframe the overview and all seven chapters around concrete invariants, predictions, checkpoints, and evidence-based review questions.
- Correct capped and empty-output tiered compaction behavior in both reference implementations.
- Make WAL checksums cover the encoded bytes and order WAL, SST, directory, and manifest updates safely across crashes.

_AI-assisted: Codex._