### PR TITLE
add Agent Fast Forward in 3 Days course track

### DIFF
--- a/mini-lsm-book/src/SUMMARY.md
+++ b/mini-lsm-book/src/SUMMARY.md
@@ -9,6 +9,7 @@
 [Environment Setup](./00-get-started.md)
 
 - [Week 1 Overview: Mini-LSM](./week1-overview.md)
+  - [Fast-Forward Week 1: Build with a Coding Agent](./week1-fast-forward.md)
   - [Memtable](./week1-01-memtable.md)
   - [Merge Iterator](./week1-02-merge-iterator.md)
   - [Block](./week1-03-block.md)

--- a/mini-lsm-book/src/SUMMARY.md
+++ b/mini-lsm-book/src/SUMMARY.md
@@ -8,9 +8,6 @@
 [Mini-LSM Overview](./00-overview.md)
 [Environment Setup](./00-get-started.md)
 
-- [Agent Fast Forward in 3 Days](./agent-fast-forward-overview.md)
-  - [Day 1: Week 1 — Mini-LSM](./week1-fast-forward.md)
-
 - [Week 1 Overview: Mini-LSM](./week1-overview.md)
   - [Memtable](./week1-01-memtable.md)
   - [Merge Iterator](./week1-02-merge-iterator.md)
@@ -38,6 +35,9 @@
   - [Serializable Snapshot Isolation](./week3-06-serializable.md)
   - [Snack Time: Compaction Filters](./week3-07-compaction-filter.md)
 - [The Rest of Your Life (TBD)](./week4-overview.md)
+
+- [Agent Fast Forward in 3 Days](./agent-fast-forward-overview.md)
+  - [Day 1: Week 1 — Mini-LSM](./week1-fast-forward.md)
 
 ---
 

--- a/mini-lsm-book/src/SUMMARY.md
+++ b/mini-lsm-book/src/SUMMARY.md
@@ -8,8 +8,10 @@
 [Mini-LSM Overview](./00-overview.md)
 [Environment Setup](./00-get-started.md)
 
+- [Agent Fast Forward in 3 Days](./agent-fast-forward-overview.md)
+  - [Day 1: Week 1 — Mini-LSM](./week1-fast-forward.md)
+
 - [Week 1 Overview: Mini-LSM](./week1-overview.md)
-  - [Fast-Forward Week 1: Build with a Coding Agent](./week1-fast-forward.md)
   - [Memtable](./week1-01-memtable.md)
   - [Merge Iterator](./week1-02-merge-iterator.md)
   - [Block](./week1-03-block.md)

--- a/mini-lsm-book/src/agent-fast-forward-overview.md
+++ b/mini-lsm-book/src/agent-fast-forward-overview.md
@@ -2,7 +2,7 @@
   mini-lsm-book © 2022-2025 by Alex Chi Z is licensed under CC BY-NC-SA 4.0
 -->
 
-# Agent Fast Forward in 3 Days
+# Agent Fast Forward in 3 Days (WIP)
 
 This is an alternative course track for students who intend to use a coding agent. Instead of spending seven chapters on each original course week, you will use one focused day to specify, generate, review, and challenge that week's system.
 

--- a/mini-lsm-book/src/agent-fast-forward-overview.md
+++ b/mini-lsm-book/src/agent-fast-forward-overview.md
@@ -1,0 +1,111 @@
+<!--
+  mini-lsm-book © 2022-2025 by Alex Chi Z is licensed under CC BY-NC-SA 4.0
+-->
+
+# Agent Fast Forward in 3 Days
+
+This is an alternative course track for students who intend to use a coding agent. Instead of spending seven chapters on each original course week, you will use one focused day to specify, generate, review, and challenge that week's system.
+
+The agent may write most of the code. Your job is to define what correct means, constrain the work, inspect the result, and leave with a mental model you can use without the agent.
+
+| Fast-forward day | Original course material | Outcome |
+| --- | --- | --- |
+| [Day 1](./week1-fast-forward.md) | Week 1: Mini-LSM | A working storage engine with memtables, SSTs, reads, writes, and flushes. |
+| Day 2 | Week 2: Compaction and persistence | Coming later. |
+| Day 3 | Week 3: MVCC | Coming later. |
+
+The original chapters remain a reference library. This track changes the pacing and the student's role; it does not remove the need to understand ordering, representation, concurrency, and failure modes.
+
+## Prepare the Repository and the Agent
+
+Do all repository-wide preparation before beginning Day 1, then start the agent from the starter directory—not from the repository root.
+
+### 1. Install the Toolchain and Course Tools
+
+Install Rust with [rustup](https://rustup.rs) if it is not already available. Then clone the repository and install the tools used by the course:
+
+```shell
+git clone https://github.com/skyzh/mini-lsm
+cd mini-lsm
+cargo x install-tools
+```
+
+The repository pins its Rust toolchain in `rust-toolchain.toml`, so Cargo will select it automatically when Rust is managed by `rustup`.
+
+If you already have the repository and tools, update your checkout as appropriate and begin from the repository root.
+
+### 2. Copy the Complete Week 1 Test Suite
+
+The normal course reveals tests one chapter at a time. Day 1 of the fast-forward track starts with the complete Week 1 acceptance suite:
+
+```shell
+for day in 1 2 3 4 5 6 7; do
+  cargo x copy-test --week 1 --day "$day"
+done
+cargo x scheck
+```
+
+The initial check should fail because the starter contains unfinished code. Record the first failure; it gives you a reproducible baseline. Do not ask the agent to make this failure disappear by changing the tests.
+
+### 3. Start the Agent from `mini-lsm-starter`
+
+Change into the starter directory before launching your coding agent:
+
+```shell
+cd mini-lsm-starter
+pwd
+# Start your coding agent here using the command for your tool.
+```
+
+The final component of `pwd` should be `mini-lsm-starter`. This matters for two reasons:
+
+1. repository-aware agents discover the `AGENTS.md` in this directory and apply its learning constraints; and
+2. the agent begins with the starter as its working scope instead of treating the neighboring reference implementation as ordinary project context.
+
+Starting in this directory is not a security sandbox: an agent can still traverse to a parent directory if instructed. The local `AGENTS.md` therefore explicitly prohibits reading, searching, diffing, or copying `../mini-lsm/`, including attempts to reconstruct the solution through Git history or an online copy.
+
+Do not open the whole repository as the agent's workspace if your tool lets you choose a directory. Open `mini-lsm-starter`. The agent may consult the copied tests, starter interfaces, Rust documentation, and course chapters under `../mini-lsm-book/src/`.
+
+### 4. Verify the Instructions Before Coding
+
+Do not assume the tool discovered `AGENTS.md`. Make the first prompt a handshake that performs no implementation:
+
+> Before editing anything, confirm that your working directory is `mini-lsm-starter` and read `./AGENTS.md`. Summarize its hard boundaries and working agreement. You must never inspect or copy the reference solution in `../mini-lsm`, directly or indirectly. Tell me which local sources you are allowed to use, then stop without changing files.
+
+If the response omits the reference-solution boundary, test protection, or review stops, correct the agent before continuing. If the tool cannot load repository instructions automatically, paste the contents of `AGENTS.md` into its persistent project instructions.
+
+## Prompt the Agent in Reviewable Steps
+
+A useful prompt states the scope, invariant, evidence, and stopping point. “Implement everything and make the tests pass” gives the agent no reason to expose its assumptions and gives you no natural place to inspect them.
+
+Use three kinds of prompts throughout the fast-forward track.
+
+### Prompt 1: Ask for a Model, Not Code
+
+Each day begins with a task-specific kickoff prompt. Ask the agent to map the system, state its invariants, divide the work into review gates, identify ambiguities, and ask you to predict a boundary case before it edits anything. The day page provides the concrete prompt.
+
+Answer the prediction before asking the agent to evaluate it. This turns the first exchange into a check of your current model rather than a generated summary to skim.
+
+### Prompt 2: Implement One Gate
+
+Use a fresh prompt for each review gate:
+
+> Implement only Review Gate `<number and name>`. Before editing, restate the invariants for this gate and list the files you expect to change. Keep the diff focused and do not modify supplied tests, public interfaces, or unrelated code.
+>
+> Run focused checks while working. When the gate is implemented, stop and report the changed behavior, the exact commands and results, one remaining uncertainty, and one adversarial case that I should predict. Do not continue to the next gate.
+
+A gate may require several internal iterations, but it should produce one coherent diff that you can review before the next subsystem depends on it.
+
+### Prompt 3: Challenge the Result
+
+After inspecting the diff and answering the agent's boundary question, ask for evidence rather than reassurance:
+
+> Review this gate as an untrusted contribution. Connect each changed behavior to an invariant and a supplied test. Identify one plausible bug that could still pass those tests, propose the smallest additional test or manual check that exposes it, and wait for my approval before adding that test. If you find a real problem, explain the failing invariant before changing the implementation.
+
+Do not let “all tests pass” end the review. Conversely, do not ask the agent to invent speculative refactors once the gate's contract and adversarial checks are satisfied.
+
+Repeat Prompts 2 and 3 for each gate. The review stops are where you catch a locally reasonable decision before it spreads across the system.
+
+When the workspace is prepared and the instruction handshake succeeds, continue to [Day 1: Week 1 — Mini-LSM](./week1-fast-forward.md).
+
+{{#include copyright.md}}

--- a/mini-lsm-book/src/week1-fast-forward.md
+++ b/mini-lsm-book/src/week1-fast-forward.md
@@ -2,18 +2,16 @@
   mini-lsm-book © 2022-2025 by Alex Chi Z is licensed under CC BY-NC-SA 4.0
 -->
 
-# Fast-Forward Week 1: Build Mini-LSM with a Coding Agent
+# Day 1: Week 1 — Mini-LSM
 
-This is an alternative path through Week 1 for students who intend to use a coding agent. The agent may write most of the code. Your job is to define what correct means, constrain the work, challenge the result, and leave with a mental model you can use without the agent.
-
-The goal is not to finish seven chapters as quickly as possible. It is to build and defend one working storage engine:
+This is the first day of [Agent Fast Forward in 3 Days](./agent-fast-forward-overview.md). You will use a coding agent to build and defend one working storage engine from the original Week 1 material:
 
 ```text
 put/delete -> mutable memtable -> immutable memtables -> L0 SSTs
                      \____________ read + merge ____________/
 ```
 
-Use the existing Week 1 chapters as a reference library when you need a deeper explanation. You do not need to follow them one day at a time.
+Use the existing Week 1 chapters as a reference library when you need a deeper explanation. You do not need to follow them one chapter at a time.
 
 ## The Completion Contract
 
@@ -27,73 +25,9 @@ At the end of this path:
 
 The tests are evidence, not the specification. Generated code remains untrusted until you can connect it to an invariant and try to falsify it.
 
-## Prepare the Repository and the Agent
+## Start Day 1
 
-This section contains the complete setup for the agent-assisted path. Do all repository-wide preparation first, then start the agent from the starter directory—not from the repository root.
-
-### 1. Install the Toolchain and Course Tools
-
-Install Rust with [rustup](https://rustup.rs) if it is not already available. Then clone the repository and install the tools used by the course:
-
-```shell
-git clone https://github.com/skyzh/mini-lsm
-cd mini-lsm
-cargo x install-tools
-```
-
-The repository pins its Rust toolchain in `rust-toolchain.toml`, so Cargo will select it automatically when Rust is managed by `rustup`.
-
-If you already have the repository and tools, update your checkout as appropriate and begin from the repository root.
-
-### 2. Copy the Complete Week 1 Test Suite
-
-The normal course reveals tests one chapter at a time. The fast-forward path starts with the complete acceptance suite:
-
-```shell
-for day in 1 2 3 4 5 6 7; do
-  cargo x copy-test --week 1 --day "$day"
-done
-cargo x scheck
-```
-
-The initial check should fail because the starter contains unfinished code. Record the first failure; it gives you a reproducible baseline. Do not ask the agent to make this failure disappear by changing the tests.
-
-### 3. Start the Agent from `mini-lsm-starter`
-
-Change into the starter directory before launching your coding agent:
-
-```shell
-cd mini-lsm-starter
-pwd
-# Start your coding agent here using the command for your tool.
-```
-
-The final component of `pwd` should be `mini-lsm-starter`. This matters for two reasons:
-
-1. repository-aware agents discover the `AGENTS.md` in this directory and apply its learning constraints; and
-2. the agent begins with the starter as its working scope instead of treating the neighboring reference implementation as ordinary project context.
-
-Starting in this directory is not a security sandbox: an agent can still traverse to a parent directory if instructed. The local `AGENTS.md` therefore explicitly prohibits reading, searching, diffing, or copying `../mini-lsm/`, including attempts to reconstruct the solution through Git history or an online copy.
-
-Do not open the whole repository as the agent's workspace if your tool lets you choose a directory. Open `mini-lsm-starter`. The agent may consult the copied tests, starter interfaces, Rust documentation, and the Week 1 chapters under `../mini-lsm-book/src/`.
-
-### 4. Verify the Instructions Before Coding
-
-Do not assume the tool discovered `AGENTS.md`. Make the first prompt a handshake that performs no implementation:
-
-> Before editing anything, confirm that your working directory is `mini-lsm-starter` and read `./AGENTS.md`. Summarize its hard boundaries and working agreement. You must never inspect or copy the reference solution in `../mini-lsm`, directly or indirectly. Tell me which local sources you are allowed to use, then stop without changing files.
-
-If the response omits the reference-solution boundary, test protection, or review stops, correct the agent before continuing. If the tool cannot load repository instructions automatically, paste the contents of `AGENTS.md` into its persistent project instructions.
-
-## Prompt the Agent in Reviewable Steps
-
-A useful prompt states the scope, invariant, evidence, and stopping point. “Implement Week 1 and make the tests pass” gives the agent no reason to expose its assumptions and gives you no natural place to inspect them.
-
-Use three kinds of prompts throughout this path.
-
-### Prompt 1: Ask for a Model, Not Code
-
-After the instruction handshake, ask the agent to understand the whole task without editing:
+Complete the repository and agent preparation in the [track overview](./agent-fast-forward-overview.md#prepare-the-repository-and-the-agent). With the agent running from `mini-lsm-starter` and the instruction handshake complete, send this kickoff prompt:
 
 > We are completing Week 1 of Mini-LSM in this starter directory. Use the starter interfaces, copied Week 1 tests, and Week 1 book chapters, but never access `../mini-lsm`. Do not edit yet.
 >
@@ -108,25 +42,7 @@ After the instruction handshake, ask the agent to understand the whole task with
 
 Answer the prediction before asking the agent to evaluate it. This turns the first exchange into a check of your current model rather than a generated summary to skim.
 
-### Prompt 2: Implement One Gate
-
-Use a fresh prompt for each review gate:
-
-> Implement only Review Gate `<number and name>`. Before editing, restate the invariants for this gate and list the files you expect to change. Keep the diff focused and do not modify supplied tests, public interfaces, or unrelated code.
->
-> Run focused checks while working. When the gate is implemented, stop and report the changed behavior, the exact commands and results, one remaining uncertainty, and one adversarial case that I should predict. Do not continue to the next gate.
-
-Replace the placeholder with the gate below. A gate may require several internal iterations, but it should produce one coherent diff that you can review before the next subsystem depends on it.
-
-### Prompt 3: Challenge the Result
-
-After inspecting the diff and answering the agent's boundary question, ask for evidence rather than reassurance:
-
-> Review this gate as an untrusted contribution. Connect each changed behavior to an invariant and a supplied test. Identify one plausible bug that could still pass those tests, propose the smallest additional test or manual check that exposes it, and wait for my approval before adding that test. If you find a real problem, explain the failing invariant before changing the implementation.
-
-Do not let “all tests pass” end the review. Conversely, do not ask the agent to invent speculative refactors once the gate's contract and adversarial checks are satisfied.
-
-Repeat Prompts 2 and 3 for each gate. The review stops are where you catch a locally reasonable decision before it spreads across the system.
+When its plan matches the three gates below, use the overview's implementation and challenge prompts for each gate in turn.
 
 ## Review Gate 1: Ordered State
 

--- a/mini-lsm-book/src/week1-fast-forward.md
+++ b/mini-lsm-book/src/week1-fast-forward.md
@@ -58,11 +58,15 @@ The resulting implementation must preserve these properties:
 | Merge inputs are ordered by recency, and the earlier input wins equal keys. | Reverse two inputs containing the same key and predict the changed result. |
 | Iterators remain fused after exhaustion or error. | Call `next` again and verify that iteration does not resume. |
 
+An ordinary write must retain the `state` read guard until insertion into the mutable memtable completes. Writing through a cloned snapshot after releasing the guard creates a race in which a concurrent freeze can make that memtable immutable before the write occurs.
+
 Before approving this gate, ask the agent to point to the exact comparison that resolves duplicate keys. Then explain in your own words why changing `>` to `>=`, or reversing the input order, would affect correctness.
 
 ## Review Gate 2: Durable Representation
 
 Have the agent implement blocks, block iterators, SST builders, SST readers, and SST iterators. Consult [Block](./week1-03-block.md), [Sorted String Table](./week1-04-sst.md), and [SST Optimizations](./week1-07-sst-optimizations.md) as needed.
+
+Because this path copies all seven test suites at the start, implement the final Day 7 prefix-compressed block format directly. There is no learning value in first implementing Day 3's uncompressed key layout only to replace it during the same review gate.
 
 Treat the file format as a protocol between the writer and reader. Check these properties:
 
@@ -72,6 +76,14 @@ Treat the file format as a protocol between the writer and reader. Check these p
 - an oversized entry still produces a valid block rather than an empty table or loop;
 - every prefix-compressed key decodes to its original bytes; and
 - Bloom filters may return false positives but never false negatives.
+
+Use this exact high-level SST trailer grammar so the writer and reader agree on where each variable-length section ends:
+
+```text
+blocks | metadata | metadata_offset:u32 | bloom | bloom_offset:u32
+```
+
+The final four bytes contain `bloom_offset`; the metadata offset is the four-byte field immediately before the Bloom section, at `bloom_offset - 4`.
 
 Ask the agent to sketch one encoded block, including its entries and offset table, using three short keys. Decode the sketch manually. A convincing explanation of the format is more valuable than a summary of the Rust functions.
 
@@ -100,6 +112,8 @@ after:  remove exactly that memtable and insert its SST at the newest side of L0
 ```
 
 Expensive SST construction and I/O should happen outside the `state` read-write lock. Structural changes still need `state_lock` so two flushes cannot select and install the same memtable concurrently.
+
+For Day 1, `close` stops and joins the existing worker threads and is harmless when called again after their handles have already been taken. It does not implicitly flush the remaining mutable memtable. If you choose a different lifecycle contract, state it and add tests before changing the implementation.
 
 Before approving this gate, construct one key that appears in the mutable memtable, an immutable memtable, and an L0 SST. Predict `get` and `scan` results when the newest entry is first a value and then a tombstone. Also exercise included, excluded, and unbounded scan endpoints.
 

--- a/mini-lsm-book/src/week1-fast-forward.md
+++ b/mini-lsm-book/src/week1-fast-forward.md
@@ -1,0 +1,156 @@
+<!--
+  mini-lsm-book © 2022-2025 by Alex Chi Z is licensed under CC BY-NC-SA 4.0
+-->
+
+# Fast-Forward Week 1: Build Mini-LSM with a Coding Agent
+
+This is an alternative path through Week 1 for students who intend to use a coding agent. The agent may write most of the code. Your job is to define what correct means, constrain the work, challenge the result, and leave with a mental model you can use without the agent.
+
+The goal is not to finish seven chapters as quickly as possible. It is to build and defend one working storage engine:
+
+```text
+put/delete -> mutable memtable -> immutable memtables -> L0 SSTs
+                     \____________ read + merge ____________/
+```
+
+Use the existing Week 1 chapters as a reference library when you need a deeper explanation. You do not need to follow them one day at a time.
+
+## The Completion Contract
+
+At the end of this path:
+
+- `put`, `delete`, `get`, and bounded `scan` work across memory and disk;
+- a frozen memtable can be flushed into an L0 SST;
+- Bloom filters and prefix encoding improve the implementation without changing its results;
+- the complete Week 1 test suite passes; and
+- you can trace a key through the engine, explain why the newest value wins, and design a test for a plausible bug.
+
+The tests are evidence, not the specification. Generated code remains untrusted until you can connect it to an invariant and try to falsify it.
+
+## Prepare the Workspace
+
+Start in the repository root and copy the entire Week 1 test suite into the starter project:
+
+```shell
+for day in 1 2 3 4 5 6 7; do
+  cargo x copy-test --week 1 --day "$day"
+done
+cargo x scheck
+```
+
+The initial check should fail because the starter contains unfinished code. Record the first failure; it gives you a reproducible baseline.
+
+Keep the agent's implementation work inside `mini-lsm-starter`. The repository also contains the reference solution in `mini-lsm`; tell the agent not to inspect or copy it. Otherwise the exercise becomes code transfer rather than systems reasoning.
+
+## Give the Agent a Contract, Not Just a Goal
+
+You can give the following brief to your coding agent. Adapt the tool-specific wording, but keep the constraints and review gates.
+
+> We are completing Week 1 of Mini-LSM in `mini-lsm-starter`. You may edit the starter implementation, but do not modify tests and do not inspect or copy the reference implementation in `mini-lsm`.
+>
+> First inspect the starter interfaces, the copied Week 1 tests, and the Week 1 book chapters. Before editing, return:
+>
+> 1. a map of the write, read, and flush paths;
+> 2. the ordering and ownership invariants that connect their components;
+> 3. an implementation plan divided into the three review gates on this page; and
+> 4. any ambiguity you found between the prose, interfaces, and tests.
+>
+> Implement one review gate at a time. Keep changes within that gate, format the code, and run the relevant tests before continuing. For every gate, report the invariants preserved, the commands run, any failure encountered, and one additional adversarial test or check. Do not weaken assertions, delete tests, or change public interfaces merely to make a test pass. Stop after each gate so I can review the diff and explanation.
+
+Do not begin by asking for the whole course to be implemented in one uninterrupted pass. The review stops are where you inspect assumptions before they spread across the system.
+
+## Review Gate 1: Ordered State
+
+Have the agent implement the memtable and iterator layers. Use the [Memtable](./week1-01-memtable.md) and [Merge Iterator](./week1-02-merge-iterator.md) chapters when the code or tests do not explain a decision.
+
+The resulting implementation must preserve these properties:
+
+| Invariant | How to challenge it |
+| --- | --- |
+| A memtable exposes keys in bytewise sorted order. | Insert keys out of order, then scan them. |
+| Rewriting a key leaves only its newest value visible. | Put two values for one key before reading it. |
+| An empty value is a tombstone, not a reason to search older state. | Delete a key that still has a value in an older memtable. |
+| Merge inputs are ordered by recency, and the earlier input wins equal keys. | Reverse two inputs containing the same key and predict the changed result. |
+| Iterators remain fused after exhaustion or error. | Call `next` again and verify that iteration does not resume. |
+
+Before approving this gate, ask the agent to point to the exact comparison that resolves duplicate keys. Then explain in your own words why changing `>` to `>=`, or reversing the input order, would affect correctness.
+
+## Review Gate 2: Durable Representation
+
+Have the agent implement blocks, block iterators, SST builders, SST readers, and SST iterators. Consult [Block](./week1-03-block.md), [Sorted String Table](./week1-04-sst.md), and [SST Optimizations](./week1-07-sst-optimizations.md) as needed.
+
+Treat the file format as a protocol between the writer and reader. Check these properties:
+
+- entries and offsets agree on exact byte boundaries;
+- a seek returns the first key greater than or equal to its target;
+- the first and last keys in SST metadata describe the actual key range;
+- an oversized entry still produces a valid block rather than an empty table or loop;
+- every prefix-compressed key decodes to its original bytes; and
+- Bloom filters may return false positives but never false negatives.
+
+Ask the agent to sketch one encoded block, including its entries and offset table, using three short keys. Decode the sketch manually. A convincing explanation of the format is more valuable than a summary of the Rust functions.
+
+For an adversarial check, use keys with no shared prefix, a long shared prefix, and an empty value. Confirm that encoding and decoding preserve all three cases.
+
+## Review Gate 3: One Logical Engine
+
+Have the agent connect the read path, write path, freezing, flushing, SST filtering, Bloom-filter lookup, and iterator accounting. Use [Read Path](./week1-05-read-path.md) and [Write Path](./week1-06-write-path.md) when reviewing the integration.
+
+The central rule is:
+
+```text
+mutable memtable
+  > immutable memtables, newest to oldest
+  > L0 SSTs, newest to oldest
+```
+
+For a duplicate key, the first visible entry wins. If that entry is a tombstone, the key is absent; an older value must not be resurrected.
+
+Review the following state transition carefully:
+
+```text
+before: imm = [newest, ..., oldest], L0 = [newest, ..., oldest]
+flush:  build an SST from the oldest immutable memtable
+after:  remove exactly that memtable and insert its SST at the newest side of L0
+```
+
+Expensive SST construction and I/O should happen outside the `state` read-write lock. Structural changes still need `state_lock` so two flushes cannot select and install the same memtable concurrently.
+
+Before approving this gate, construct one key that appears in the mutable memtable, an immutable memtable, and an L0 SST. Predict `get` and `scan` results when the newest entry is first a value and then a tombstone. Also exercise included, excluded, and unbounded scan endpoints.
+
+## Audit the Finished Engine
+
+Run the full project check from the repository root:
+
+```shell
+cargo x scheck
+```
+
+Then ask the agent for a final evidence report containing:
+
+1. the commands it ran and their outcomes;
+2. a data-flow trace for one `put`, one `get`, one bounded `scan`, and one flush;
+3. the source-priority rule used by both point reads and scans;
+4. one concurrency risk around freezing or flushing and the synchronization that prevents it;
+5. one optimization that must not alter logical results; and
+6. one weakness or boundary case not established by the supplied tests.
+
+Review actual diffs and test output, not only the report. Search for removed assertions, changed tests, broad lint suppressions, and error paths replaced with `unwrap` without justification.
+
+Finally, introduce one small, deliberate fault—for example, reverse equal-key precedence in a merge iterator or make an excluded upper bound inclusive. Predict which test should fail, run it, and revert the fault. This verifies that the tests can detect at least one mistake you understand.
+
+## The Student Checkpoint
+
+You are ready for Week 2 when you can do these without delegating the answer back to the agent:
+
+- draw the write, read, and flush paths from memory;
+- explain the ordering rule that selects one value from duplicate keys;
+- explain the byte layout of a block and how an SST locates one;
+- identify where tombstones are created and where they are filtered;
+- explain why a Bloom-filter negative is safe and a positive is inconclusive;
+- describe an unsafe flush interleaving and how the implementation prevents it; and
+- turn a suspected invariant violation into a minimal test.
+
+If you cannot yet do one of these, use the corresponding Week 1 chapter and ask the agent to quiz you with concrete states or byte layouts. The measure of success is not whether you typed the implementation. It is whether you can specify, inspect, test, and change the system with confidence.
+
+{{#include copyright.md}}

--- a/mini-lsm-book/src/week1-fast-forward.md
+++ b/mini-lsm-book/src/week1-fast-forward.md
@@ -42,6 +42,8 @@ The initial check should fail because the starter contains unfinished code. Reco
 
 Keep the agent's implementation work inside `mini-lsm-starter`. The repository also contains the reference solution in `mini-lsm`; tell the agent not to inspect or copy it. Otherwise the exercise becomes code transfer rather than systems reasoning.
 
+The starter workspace includes an `AGENTS.md` with these learning boundaries. Agents that support repository instructions should load it automatically; keep the constraints in your prompt as well so the working agreement is explicit.
+
 ## Give the Agent a Contract, Not Just a Goal
 
 You can give the following brief to your coding agent. Adapt the tool-specific wording, but keep the constraints and review gates.

--- a/mini-lsm-book/src/week1-fast-forward.md
+++ b/mini-lsm-book/src/week1-fast-forward.md
@@ -27,9 +27,27 @@ At the end of this path:
 
 The tests are evidence, not the specification. Generated code remains untrusted until you can connect it to an invariant and try to falsify it.
 
-## Prepare the Workspace
+## Prepare the Repository and the Agent
 
-Start in the repository root and copy the entire Week 1 test suite into the starter project:
+This section contains the complete setup for the agent-assisted path. Do all repository-wide preparation first, then start the agent from the starter directory—not from the repository root.
+
+### 1. Install the Toolchain and Course Tools
+
+Install Rust with [rustup](https://rustup.rs) if it is not already available. Then clone the repository and install the tools used by the course:
+
+```shell
+git clone https://github.com/skyzh/mini-lsm
+cd mini-lsm
+cargo x install-tools
+```
+
+The repository pins its Rust toolchain in `rust-toolchain.toml`, so Cargo will select it automatically when Rust is managed by `rustup`.
+
+If you already have the repository and tools, update your checkout as appropriate and begin from the repository root.
+
+### 2. Copy the Complete Week 1 Test Suite
+
+The normal course reveals tests one chapter at a time. The fast-forward path starts with the complete acceptance suite:
 
 ```shell
 for day in 1 2 3 4 5 6 7; do
@@ -38,28 +56,77 @@ done
 cargo x scheck
 ```
 
-The initial check should fail because the starter contains unfinished code. Record the first failure; it gives you a reproducible baseline.
+The initial check should fail because the starter contains unfinished code. Record the first failure; it gives you a reproducible baseline. Do not ask the agent to make this failure disappear by changing the tests.
 
-Keep the agent's implementation work inside `mini-lsm-starter`. The repository also contains the reference solution in `mini-lsm`; tell the agent not to inspect or copy it. Otherwise the exercise becomes code transfer rather than systems reasoning.
+### 3. Start the Agent from `mini-lsm-starter`
 
-The starter workspace includes an `AGENTS.md` with these learning boundaries. Agents that support repository instructions should load it automatically; keep the constraints in your prompt as well so the working agreement is explicit.
+Change into the starter directory before launching your coding agent:
 
-## Give the Agent a Contract, Not Just a Goal
+```shell
+cd mini-lsm-starter
+pwd
+# Start your coding agent here using the command for your tool.
+```
 
-You can give the following brief to your coding agent. Adapt the tool-specific wording, but keep the constraints and review gates.
+The final component of `pwd` should be `mini-lsm-starter`. This matters for two reasons:
 
-> We are completing Week 1 of Mini-LSM in `mini-lsm-starter`. You may edit the starter implementation, but do not modify tests and do not inspect or copy the reference implementation in `mini-lsm`.
+1. repository-aware agents discover the `AGENTS.md` in this directory and apply its learning constraints; and
+2. the agent begins with the starter as its working scope instead of treating the neighboring reference implementation as ordinary project context.
+
+Starting in this directory is not a security sandbox: an agent can still traverse to a parent directory if instructed. The local `AGENTS.md` therefore explicitly prohibits reading, searching, diffing, or copying `../mini-lsm/`, including attempts to reconstruct the solution through Git history or an online copy.
+
+Do not open the whole repository as the agent's workspace if your tool lets you choose a directory. Open `mini-lsm-starter`. The agent may consult the copied tests, starter interfaces, Rust documentation, and the Week 1 chapters under `../mini-lsm-book/src/`.
+
+### 4. Verify the Instructions Before Coding
+
+Do not assume the tool discovered `AGENTS.md`. Make the first prompt a handshake that performs no implementation:
+
+> Before editing anything, confirm that your working directory is `mini-lsm-starter` and read `./AGENTS.md`. Summarize its hard boundaries and working agreement. You must never inspect or copy the reference solution in `../mini-lsm`, directly or indirectly. Tell me which local sources you are allowed to use, then stop without changing files.
+
+If the response omits the reference-solution boundary, test protection, or review stops, correct the agent before continuing. If the tool cannot load repository instructions automatically, paste the contents of `AGENTS.md` into its persistent project instructions.
+
+## Prompt the Agent in Reviewable Steps
+
+A useful prompt states the scope, invariant, evidence, and stopping point. “Implement Week 1 and make the tests pass” gives the agent no reason to expose its assumptions and gives you no natural place to inspect them.
+
+Use three kinds of prompts throughout this path.
+
+### Prompt 1: Ask for a Model, Not Code
+
+After the instruction handshake, ask the agent to understand the whole task without editing:
+
+> We are completing Week 1 of Mini-LSM in this starter directory. Use the starter interfaces, copied Week 1 tests, and Week 1 book chapters, but never access `../mini-lsm`. Do not edit yet.
 >
-> First inspect the starter interfaces, the copied Week 1 tests, and the Week 1 book chapters. Before editing, return:
+> Return:
 >
 > 1. a map of the write, read, and flush paths;
-> 2. the ordering and ownership invariants that connect their components;
+> 2. the ordering, ownership, and file-format invariants that connect their components;
 > 3. an implementation plan divided into the three review gates on this page; and
 > 4. any ambiguity you found between the prose, interfaces, and tests.
 >
-> Implement one review gate at a time. Keep changes within that gate, format the code, and run the relevant tests before continuing. For every gate, report the invariants preserved, the commands run, any failure encountered, and one additional adversarial test or check. Do not weaken assertions, delete tests, or change public interfaces merely to make a test pass. Stop after each gate so I can review the diff and explanation.
+> Ask me to predict one important boundary case, then stop.
 
-Do not begin by asking for the whole course to be implemented in one uninterrupted pass. The review stops are where you inspect assumptions before they spread across the system.
+Answer the prediction before asking the agent to evaluate it. This turns the first exchange into a check of your current model rather than a generated summary to skim.
+
+### Prompt 2: Implement One Gate
+
+Use a fresh prompt for each review gate:
+
+> Implement only Review Gate `<number and name>`. Before editing, restate the invariants for this gate and list the files you expect to change. Keep the diff focused and do not modify supplied tests, public interfaces, or unrelated code.
+>
+> Run focused checks while working. When the gate is implemented, stop and report the changed behavior, the exact commands and results, one remaining uncertainty, and one adversarial case that I should predict. Do not continue to the next gate.
+
+Replace the placeholder with the gate below. A gate may require several internal iterations, but it should produce one coherent diff that you can review before the next subsystem depends on it.
+
+### Prompt 3: Challenge the Result
+
+After inspecting the diff and answering the agent's boundary question, ask for evidence rather than reassurance:
+
+> Review this gate as an untrusted contribution. Connect each changed behavior to an invariant and a supplied test. Identify one plausible bug that could still pass those tests, propose the smallest additional test or manual check that exposes it, and wait for my approval before adding that test. If you find a real problem, explain the failing invariant before changing the implementation.
+
+Do not let “all tests pass” end the review. Conversely, do not ask the agent to invent speculative refactors once the gate's contract and adversarial checks are satisfied.
+
+Repeat Prompts 2 and 3 for each gate. The review stops are where you catch a locally reasonable decision before it spreads across the system.
 
 ## Review Gate 1: Ordered State
 

--- a/mini-lsm-starter/AGENTS.md
+++ b/mini-lsm-starter/AGENTS.md
@@ -1,0 +1,87 @@
+# Mini-LSM Starter Agent Instructions
+
+## Purpose
+
+This directory is a learning workspace. You may write implementation code, but optimize for the student's understanding and ability to review the system, not for finishing the repository with the fewest interactions.
+
+The student owns the specification and the proof of correctness. Treat your code as an untrusted contribution that must be explained, tested, and challenged.
+
+## Hard Boundaries
+
+- Never read, search, inspect, diff, or copy the reference implementation in `../mini-lsm/`.
+- Never reconstruct the reference implementation from Git history, another branch or tag, a remote repository, generated documentation, build artifacts, or an online copy.
+- Running `cargo x copy-test` is allowed. After it copies tests into this starter directory, you may read those copied tests. Do not directly open the source test files under `../mini-lsm/`.
+- Do not hand-edit provided tests, the test harness, or `src/tests.rs`; only `cargo x copy-test` may add test modules and rewrite `src/tests.rs`. Do not disable, ignore, weaken, or delete tests or assertions.
+- Do not change expected output, public interfaces, dependencies, or workspace configuration merely to make the implementation easier or make a check pass. If a task genuinely requires one of these changes, explain why and get the student's approval first.
+- Do not add broad lint suppressions, placeholder success values, fake implementations, or catch-all error handling that hides unfinished behavior.
+- Keep changes inside `mini-lsm-starter` unless the student explicitly asks for a change elsewhere.
+- Do not commit, push, rewrite Git history, or discard existing work unless the student explicitly asks.
+
+You may consult the Week 1 chapters in `../mini-lsm-book/src/`, Rust and dependency documentation, and the starter code's existing interfaces. External documentation is for understanding APIs and concepts, not for locating another Mini-LSM solution.
+
+## Working Agreement
+
+Before editing code:
+
+1. Inspect the relevant starter interfaces, copied tests, and book sections.
+2. Describe the data flow affected by the task.
+3. State the correctness invariants that the implementation must preserve.
+4. Propose a small implementation and validation plan.
+5. Ask the student to predict one important boundary case before revealing its result.
+
+If the request spans more than one of the review gates below, stop after presenting the plan and wait for the student to approve the first gate. Implement one gate at a time and stop after each gate for review.
+
+### Review Gate 1: Ordered State
+
+Scope: memtables and merge iterators.
+
+Confirm key ordering, overwrite behavior, tombstone precedence, duplicate resolution, error propagation, and fused-iterator behavior.
+
+### Review Gate 2: Durable Representation
+
+Scope: blocks, SST builders and readers, block and SST iterators, prefix encoding, and Bloom filters.
+
+Confirm byte boundaries, offset encoding, seek semantics, first/last-key metadata, exact decode round trips, and the absence of Bloom-filter false negatives.
+
+### Review Gate 3: One Logical Engine
+
+Scope: integrated reads and writes, freezing, flushing, SST filtering, and iterator accounting.
+
+Confirm source recency, tombstone handling, range-bound semantics, state transitions, lock lifetimes, and that optimizations do not change logical results.
+
+For a task contained within one gate, you may proceed after presenting the invariants and plan unless the student asks you to wait.
+
+## Implementation and Debugging
+
+- Prefer the smallest coherent diff that satisfies the current gate.
+- Preserve the starter's architecture and naming unless a local design change is necessary and explained.
+- Do not perform unrelated refactors while implementing a task.
+- Make one testable debugging hypothesis at a time. Use the smallest relevant check before stacking speculative fixes.
+- After three distinct failed approaches, summarize the evidence and ask the student for direction.
+- Never claim a test passed unless you ran it and saw a successful result.
+- Treat a passing supplied suite as necessary but not sufficient. Propose at least one adversarial example for each gate and ask the student to predict its outcome. Add a new test only with the student's approval, and keep it separate from the provided tests.
+- If demonstrating a deliberate fault, begin from a clean, passing state, state the expected failure, and revert the fault immediately after the experiment.
+
+## Validation
+
+Run focused tests while working. Before declaring Week 1 complete, run from the repository root:
+
+```shell
+cargo x scheck
+```
+
+Also inspect the final diff for modified tests, removed assertions, new lint suppressions, unjustified `unwrap` calls, unrelated changes, and unresolved placeholders.
+
+## Handoff to the Student
+
+At each review stop, report:
+
+- the files and behavior changed;
+- the invariants the code relies on;
+- the exact commands run and their outcomes;
+- one boundary case the supplied tests may not establish; and
+- one question the student should be able to answer before continuing.
+
+Do not answer the final understanding question immediately. Let the student make a concrete attempt, then correct or extend their reasoning with evidence from the implementation.
+
+The work is complete only when the code passes its checks and the student can explain the relevant data flow, ordering rule, representation, failure mode, and test strategy without delegating the explanation back to you.

--- a/mini-lsm-starter/AGENTS.md
+++ b/mini-lsm-starter/AGENTS.md
@@ -37,11 +37,15 @@ Scope: memtables and merge iterators.
 
 Confirm key ordering, overwrite behavior, tombstone precedence, duplicate resolution, error propagation, and fused-iterator behavior.
 
+A mutable write must retain the `state` read guard until the skiplist insertion completes. Do not write through a cloned state snapshot after releasing that guard: a concurrent freeze could otherwise turn the target into an immutable memtable before the insertion.
+
 ### Review Gate 2: Durable Representation
 
 Scope: blocks, SST builders and readers, block and SST iterators, prefix encoding, and Bloom filters.
 
 Confirm byte boundaries, offset encoding, seek semantics, first/last-key metadata, exact decode round trips, and the absence of Bloom-filter false negatives.
+
+When all Week 1 tests are present, implement the final Day 7 prefix-compressed block format directly instead of first implementing and then replacing Day 3's uncompressed key layout.
 
 ### Review Gate 3: One Logical Engine
 


### PR DESCRIPTION
Students using coding agents need a course structure centered on specifying, reviewing, and challenging systems rather than compressing the existing manual steps.

This introduces a top-level Agent Fast Forward in 3 Days track, with Day 1 transforming the original Week 1 into one agent-assisted workflow. Shared setup and prompting live in the track overview, starter-scoped instructions prohibit reference-solution access and test tampering, and the original seven-chapter Week 1 hierarchy remains unchanged. Days 2 and 3 are left as roadmap entries for the next experiments.

_AI-assisted: Codex._