### PR TITLE
clarify student-owned fast-forward checkpoints

### DIFF
--- a/mini-lsm-book/src/00-get-started.md
+++ b/mini-lsm-book/src/00-get-started.md
@@ -1,5 +1,5 @@
 <!--
-  mini-lsm-book © 2022-2025 by Alex Chi Z is licensed under CC BY-NC-SA 4.0
+  mini-lsm-book © 2022-2026 by Alex Chi Z is licensed under CC BY-NC-SA 4.0
 -->
 
 # Environment Setup

--- a/mini-lsm-book/src/00-overview.md
+++ b/mini-lsm-book/src/00-overview.md
@@ -1,5 +1,5 @@
 <!--
-  mini-lsm-book © 2022-2025 by Alex Chi Z is licensed under CC BY-NC-SA 4.0
+  mini-lsm-book © 2022-2026 by Alex Chi Z is licensed under CC BY-NC-SA 4.0
 -->
 
 # Mini-LSM Course Overview

--- a/mini-lsm-book/src/00-preface.md
+++ b/mini-lsm-book/src/00-preface.md
@@ -1,5 +1,5 @@
 <!--
-  mini-lsm-book © 2022-2025 by Alex Chi Z is licensed under CC BY-NC-SA 4.0
+  mini-lsm-book © 2022-2026 by Alex Chi Z is licensed under CC BY-NC-SA 4.0
 -->
 
 # Preface

--- a/mini-lsm-book/src/00-v1.md
+++ b/mini-lsm-book/src/00-v1.md
@@ -1,5 +1,5 @@
 <!--
-  mini-lsm-book © 2022-2025 by Alex Chi Z is licensed under CC BY-NC-SA 4.0
+  mini-lsm-book © 2022-2026 by Alex Chi Z is licensed under CC BY-NC-SA 4.0
 -->
 
 # Mini-LSM v1

--- a/mini-lsm-book/src/01-block.md
+++ b/mini-lsm-book/src/01-block.md
@@ -1,5 +1,5 @@
 <!--
-  mini-lsm-book © 2022-2025 by Alex Chi Z is licensed under CC BY-NC-SA 4.0
+  mini-lsm-book © 2022-2026 by Alex Chi Z is licensed under CC BY-NC-SA 4.0
 -->
 
 # Block Builder and Block Iterator

--- a/mini-lsm-book/src/02-sst.md
+++ b/mini-lsm-book/src/02-sst.md
@@ -1,5 +1,5 @@
 <!--
-  mini-lsm-book © 2022-2025 by Alex Chi Z is licensed under CC BY-NC-SA 4.0
+  mini-lsm-book © 2022-2026 by Alex Chi Z is licensed under CC BY-NC-SA 4.0
 -->
 
 # SST Builder and SST Iterator

--- a/mini-lsm-book/src/03-memtable.md
+++ b/mini-lsm-book/src/03-memtable.md
@@ -1,5 +1,5 @@
 <!--
-  mini-lsm-book © 2022-2025 by Alex Chi Z is licensed under CC BY-NC-SA 4.0
+  mini-lsm-book © 2022-2026 by Alex Chi Z is licensed under CC BY-NC-SA 4.0
 -->
 
 # Mem Table and Merge Iterators

--- a/mini-lsm-book/src/04-engine.md
+++ b/mini-lsm-book/src/04-engine.md
@@ -1,5 +1,5 @@
 <!--
-  mini-lsm-book © 2022-2025 by Alex Chi Z is licensed under CC BY-NC-SA 4.0
+  mini-lsm-book © 2022-2026 by Alex Chi Z is licensed under CC BY-NC-SA 4.0
 -->
 
 # Storage Engine and Block Cache

--- a/mini-lsm-book/src/05-compaction.md
+++ b/mini-lsm-book/src/05-compaction.md
@@ -1,5 +1,5 @@
 <!--
-  mini-lsm-book © 2022-2025 by Alex Chi Z is licensed under CC BY-NC-SA 4.0
+  mini-lsm-book © 2022-2026 by Alex Chi Z is licensed under CC BY-NC-SA 4.0
 -->
 
 # Leveled Compaction

--- a/mini-lsm-book/src/06-recovery.md
+++ b/mini-lsm-book/src/06-recovery.md
@@ -1,5 +1,5 @@
 <!--
-  mini-lsm-book © 2022-2025 by Alex Chi Z is licensed under CC BY-NC-SA 4.0
+  mini-lsm-book © 2022-2026 by Alex Chi Z is licensed under CC BY-NC-SA 4.0
 -->
 
 # Write-Ahead Log for Recovery

--- a/mini-lsm-book/src/07-bloom-filter.md
+++ b/mini-lsm-book/src/07-bloom-filter.md
@@ -1,5 +1,5 @@
 <!--
-  mini-lsm-book © 2022-2025 by Alex Chi Z is licensed under CC BY-NC-SA 4.0
+  mini-lsm-book © 2022-2026 by Alex Chi Z is licensed under CC BY-NC-SA 4.0
 -->
 
 # Bloom Filters

--- a/mini-lsm-book/src/08-key-compression.md
+++ b/mini-lsm-book/src/08-key-compression.md
@@ -1,5 +1,5 @@
 <!--
-  mini-lsm-book © 2022-2025 by Alex Chi Z is licensed under CC BY-NC-SA 4.0
+  mini-lsm-book © 2022-2026 by Alex Chi Z is licensed under CC BY-NC-SA 4.0
 -->
 
 # Key Compression

--- a/mini-lsm-book/src/09-whats-next.md
+++ b/mini-lsm-book/src/09-whats-next.md
@@ -1,5 +1,5 @@
 <!--
-  mini-lsm-book © 2022-2025 by Alex Chi Z is licensed under CC BY-NC-SA 4.0
+  mini-lsm-book © 2022-2026 by Alex Chi Z is licensed under CC BY-NC-SA 4.0
 -->
 
 # What's Next

--- a/mini-lsm-book/src/SUMMARY.md
+++ b/mini-lsm-book/src/SUMMARY.md
@@ -1,5 +1,5 @@
 <!--
-  mini-lsm-book © 2022-2025 by Alex Chi Z is licensed under CC BY-NC-SA 4.0
+  mini-lsm-book © 2022-2026 by Alex Chi Z is licensed under CC BY-NC-SA 4.0
 -->
 
 # LSM in a Week

--- a/mini-lsm-book/src/agent-fast-forward-overview.md
+++ b/mini-lsm-book/src/agent-fast-forward-overview.md
@@ -1,5 +1,5 @@
 <!--
-  mini-lsm-book © 2022-2025 by Alex Chi Z is licensed under CC BY-NC-SA 4.0
+  mini-lsm-book © 2022-2026 by Alex Chi Z is licensed under CC BY-NC-SA 4.0
 -->
 
 # Agent Fast Forward in 3 Days (WIP)

--- a/mini-lsm-book/src/agent-fast-forward-overview.md
+++ b/mini-lsm-book/src/agent-fast-forward-overview.md
@@ -72,7 +72,7 @@ Do not assume the tool discovered `AGENTS.md`. Make the first prompt a handshake
 
 > Before editing anything, confirm that your working directory is `mini-lsm-starter` and read `./AGENTS.md`. Summarize its hard boundaries and working agreement. You must never inspect or copy the reference solution in `../mini-lsm`, directly or indirectly. Tell me which local sources you are allowed to use, then stop without changing files.
 
-If the response omits the reference-solution boundary, test protection, or review stops, correct the agent before continuing. If the tool cannot load repository instructions automatically, paste the contents of `AGENTS.md` into its persistent project instructions.
+If the response omits the reference-solution boundary, test protection, or checkpoint stops, correct the agent before continuing. If the tool cannot load repository instructions automatically, paste the contents of `AGENTS.md` into its persistent project instructions.
 
 ## Prompt the Agent in Reviewable Steps
 
@@ -82,29 +82,29 @@ Use three kinds of prompts throughout the fast-forward track.
 
 ### Prompt 1: Ask for a Model, Not Code
 
-Each day begins with a task-specific kickoff prompt. Ask the agent to map the system, state its invariants, divide the work into review gates, identify ambiguities, and ask you to predict a boundary case before it edits anything. The day page provides the concrete prompt.
+Each day begins with a task-specific kickoff prompt. Ask the agent to map the system, state its invariants, divide the work into checkpoints, identify ambiguities, and ask you to predict a boundary case before it edits anything. The day page provides the concrete prompt.
 
 Answer the prediction before asking the agent to evaluate it. This turns the first exchange into a check of your current model rather than a generated summary to skim.
 
-### Prompt 2: Implement One Gate
+### Prompt 2: Implement One Checkpoint
 
-Use a fresh prompt for each review gate:
+Use a fresh prompt for each checkpoint. You choose the checkpoint; the agent must not infer that passing one checkpoint authorizes it to begin the next:
 
-> Implement only Review Gate `<number and name>`. Before editing, restate the invariants for this gate and list the files you expect to change. Keep the diff focused and do not modify supplied tests, public interfaces, or unrelated code.
+> Implement only Checkpoint `<number and name>`. Before editing, restate the invariants for this checkpoint and list the files you expect to change. Keep the diff focused and do not modify supplied tests, public interfaces, or unrelated code.
 >
-> Run focused checks while working. When the gate is implemented, stop and report the changed behavior, the exact commands and results, one remaining uncertainty, and one adversarial case that I should predict. Do not continue to the next gate.
+> Run focused checks while working. When the checkpoint is implemented, stop and report the changed behavior, the exact commands and results, one remaining uncertainty, and one adversarial case that I should predict. Do not continue to the next checkpoint.
 
-A gate may require several internal iterations, but it should produce one coherent diff that you can review before the next subsystem depends on it.
+A checkpoint may require several internal iterations, but it should produce one coherent diff that you can review before the next subsystem depends on it.
 
 ### Prompt 3: Challenge the Result
 
 After inspecting the diff and answering the agent's boundary question, ask for evidence rather than reassurance:
 
-> Review this gate as an untrusted contribution. Connect each changed behavior to an invariant and a supplied test. Identify one plausible bug that could still pass those tests, propose the smallest additional test or manual check that exposes it, and wait for my approval before adding that test. If you find a real problem, explain the failing invariant before changing the implementation.
+> Review this checkpoint as an untrusted contribution. Connect each changed behavior to an invariant and a supplied test. Identify one plausible bug that could still pass those tests, propose the smallest additional test or manual check that exposes it, and wait for my approval before adding that test. If you find a real problem, explain the failing invariant before changing the implementation.
 
-Do not let “all tests pass” end the review. Conversely, do not ask the agent to invent speculative refactors once the gate's contract and adversarial checks are satisfied.
+Do not let “all tests pass” end the review. Conversely, do not ask the agent to invent speculative refactors once the checkpoint's contract and adversarial checks are satisfied.
 
-Repeat Prompts 2 and 3 for each gate. The review stops are where you catch a locally reasonable decision before it spreads across the system.
+Repeat Prompts 2 and 3 for each checkpoint. The checkpoint stops are where you catch a locally reasonable decision before it spreads across the system.
 
 When the workspace is prepared and the instruction handshake succeeds, continue to [Day 1: Week 1 — Mini-LSM](./week1-fast-forward.md).
 

--- a/mini-lsm-book/src/copyright.md
+++ b/mini-lsm-book/src/copyright.md
@@ -1,5 +1,5 @@
 <!--
-  mini-lsm-book © 2022-2025 by Alex Chi Z is licensed under CC BY-NC-SA 4.0
+  mini-lsm-book © 2022-2026 by Alex Chi Z is licensed under CC BY-NC-SA 4.0
 -->
 
-<p style="text-align: center; margin-top: 3em"><small>Your feedback is greatly appreciated. Welcome to join our <a href="https://skyzh.dev/join/discord">Discord Community</a>.<br>Found an issue? Create an issue / pull request on <a href="https://github.com/skyzh/mini-lsm">github.com/skyzh/mini-lsm</a>.<br>mini-lsm-book © 2022-2025 by Alex Chi Z is licensed under CC BY-NC-SA 4.0.</small></p>
+<p style="text-align: center; margin-top: 3em"><small>Your feedback is greatly appreciated. Welcome to join our <a href="https://skyzh.dev/join/discord">Discord Community</a>.<br>Found an issue? Create an issue / pull request on <a href="https://github.com/skyzh/mini-lsm">github.com/skyzh/mini-lsm</a>.<br>mini-lsm-book © 2022-2026 by Alex Chi Z is licensed under CC BY-NC-SA 4.0.</small></p>

--- a/mini-lsm-book/src/week1-01-memtable.md
+++ b/mini-lsm-book/src/week1-01-memtable.md
@@ -1,5 +1,5 @@
 <!--
-  mini-lsm-book © 2022-2025 by Alex Chi Z is licensed under CC BY-NC-SA 4.0
+  mini-lsm-book © 2022-2026 by Alex Chi Z is licensed under CC BY-NC-SA 4.0
 -->
 
 # Memtables

--- a/mini-lsm-book/src/week1-02-merge-iterator.md
+++ b/mini-lsm-book/src/week1-02-merge-iterator.md
@@ -1,5 +1,5 @@
 <!--
-  mini-lsm-book © 2022-2025 by Alex Chi Z is licensed under CC BY-NC-SA 4.0
+  mini-lsm-book © 2022-2026 by Alex Chi Z is licensed under CC BY-NC-SA 4.0
 -->
 
 # Merge Iterator

--- a/mini-lsm-book/src/week1-03-block.md
+++ b/mini-lsm-book/src/week1-03-block.md
@@ -1,5 +1,5 @@
 <!--
-  mini-lsm-book © 2022-2025 by Alex Chi Z is licensed under CC BY-NC-SA 4.0
+  mini-lsm-book © 2022-2026 by Alex Chi Z is licensed under CC BY-NC-SA 4.0
 -->
 
 # Block

--- a/mini-lsm-book/src/week1-04-sst.md
+++ b/mini-lsm-book/src/week1-04-sst.md
@@ -1,5 +1,5 @@
 <!--
-  mini-lsm-book © 2022-2025 by Alex Chi Z is licensed under CC BY-NC-SA 4.0
+  mini-lsm-book © 2022-2026 by Alex Chi Z is licensed under CC BY-NC-SA 4.0
 -->
 
 # Sorted String Table (SST)

--- a/mini-lsm-book/src/week1-05-read-path.md
+++ b/mini-lsm-book/src/week1-05-read-path.md
@@ -1,5 +1,5 @@
 <!--
-  mini-lsm-book © 2022-2025 by Alex Chi Z is licensed under CC BY-NC-SA 4.0
+  mini-lsm-book © 2022-2026 by Alex Chi Z is licensed under CC BY-NC-SA 4.0
 -->
 
 # Read Path

--- a/mini-lsm-book/src/week1-06-write-path.md
+++ b/mini-lsm-book/src/week1-06-write-path.md
@@ -1,5 +1,5 @@
 <!--
-  mini-lsm-book © 2022-2025 by Alex Chi Z is licensed under CC BY-NC-SA 4.0
+  mini-lsm-book © 2022-2026 by Alex Chi Z is licensed under CC BY-NC-SA 4.0
 -->
 
 # Write Path

--- a/mini-lsm-book/src/week1-07-sst-optimizations.md
+++ b/mini-lsm-book/src/week1-07-sst-optimizations.md
@@ -1,5 +1,5 @@
 <!--
-  mini-lsm-book © 2022-2025 by Alex Chi Z is licensed under CC BY-NC-SA 4.0
+  mini-lsm-book © 2022-2026 by Alex Chi Z is licensed under CC BY-NC-SA 4.0
 -->
 
 # Snack Time: SST Optimizations

--- a/mini-lsm-book/src/week1-fast-forward.md
+++ b/mini-lsm-book/src/week1-fast-forward.md
@@ -1,5 +1,5 @@
 <!--
-  mini-lsm-book © 2022-2025 by Alex Chi Z is licensed under CC BY-NC-SA 4.0
+  mini-lsm-book © 2022-2026 by Alex Chi Z is licensed under CC BY-NC-SA 4.0
 -->
 
 # Day 1: Week 1 — Mini-LSM

--- a/mini-lsm-book/src/week1-fast-forward.md
+++ b/mini-lsm-book/src/week1-fast-forward.md
@@ -35,16 +35,16 @@ Complete the repository and agent preparation in the [track overview](./agent-fa
 >
 > 1. a map of the write, read, and flush paths;
 > 2. the ordering, ownership, and file-format invariants that connect their components;
-> 3. an implementation plan divided into the three review gates on this page; and
+> 3. an implementation plan divided into the three checkpoints on this page; and
 > 4. any ambiguity you found between the prose, interfaces, and tests.
 >
 > Ask me to predict one important boundary case, then stop.
 
 Answer the prediction before asking the agent to evaluate it. This turns the first exchange into a check of your current model rather than a generated summary to skim.
 
-When its plan matches the three gates below, use the overview's implementation and challenge prompts for each gate in turn.
+When its plan matches the three checkpoints below, choose the first checkpoint and use the overview's implementation and challenge prompts. Begin each later checkpoint only when you explicitly ask the agent to do so.
 
-## Review Gate 1: Ordered State
+## Checkpoint 1: Ordered State
 
 Have the agent implement the memtable and iterator layers. Use the [Memtable](./week1-01-memtable.md) and [Merge Iterator](./week1-02-merge-iterator.md) chapters when the code or tests do not explain a decision.
 
@@ -60,13 +60,13 @@ The resulting implementation must preserve these properties:
 
 An ordinary write must retain the `state` read guard until insertion into the mutable memtable completes. Writing through a cloned snapshot after releasing the guard creates a race in which a concurrent freeze can make that memtable immutable before the write occurs.
 
-Before approving this gate, ask the agent to point to the exact comparison that resolves duplicate keys. Then explain in your own words why changing `>` to `>=`, or reversing the input order, would affect correctness.
+Before approving this checkpoint, ask the agent to point to the exact comparison that resolves duplicate keys. Then explain in your own words why changing `>` to `>=`, or reversing the input order, would affect correctness.
 
-## Review Gate 2: Durable Representation
+## Checkpoint 2: Durable Representation
 
 Have the agent implement blocks, block iterators, SST builders, SST readers, and SST iterators. Consult [Block](./week1-03-block.md), [Sorted String Table](./week1-04-sst.md), and [SST Optimizations](./week1-07-sst-optimizations.md) as needed.
 
-Because this path copies all seven test suites at the start, implement the final Day 7 prefix-compressed block format directly. There is no learning value in first implementing Day 3's uncompressed key layout only to replace it during the same review gate.
+Because this path copies all seven test suites at the start, implement the final Day 7 prefix-compressed block format directly. There is no learning value in first implementing Day 3's uncompressed key layout only to replace it during the same checkpoint.
 
 Treat the file format as a protocol between the writer and reader. Check these properties:
 
@@ -89,7 +89,7 @@ Ask the agent to sketch one encoded block, including its entries and offset tabl
 
 For an adversarial check, use keys with no shared prefix, a long shared prefix, and an empty value. Confirm that encoding and decoding preserve all three cases.
 
-## Review Gate 3: One Logical Engine
+## Checkpoint 3: One Logical Engine
 
 Have the agent connect the read path, write path, freezing, flushing, SST filtering, Bloom-filter lookup, and iterator accounting. Use [Read Path](./week1-05-read-path.md) and [Write Path](./week1-06-write-path.md) when reviewing the integration.
 
@@ -115,7 +115,7 @@ Expensive SST construction and I/O should happen outside the `state` read-write 
 
 For Day 1, `close` stops and joins the existing worker threads and is harmless when called again after their handles have already been taken. It does not implicitly flush the remaining mutable memtable. If you choose a different lifecycle contract, state it and add tests before changing the implementation.
 
-Before approving this gate, construct one key that appears in the mutable memtable, an immutable memtable, and an L0 SST. Predict `get` and `scan` results when the newest entry is first a value and then a tombstone. Also exercise included, excluded, and unbounded scan endpoints.
+Before approving this checkpoint, construct one key that appears in the mutable memtable, an immutable memtable, and an L0 SST. Predict `get` and `scan` results when the newest entry is first a value and then a tombstone. Also exercise included, excluded, and unbounded scan endpoints.
 
 ## Audit the Finished Engine
 
@@ -138,7 +138,7 @@ Review actual diffs and test output, not only the report. Search for removed ass
 
 Finally, introduce one small, deliberate fault—for example, reverse equal-key precedence in a merge iterator or make an excluded upper bound inclusive. Predict which test should fail, run it, and revert the fault. This verifies that the tests can detect at least one mistake you understand.
 
-## The Student Checkpoint
+## Day 1 Completion Checkpoint
 
 You are ready for Week 2 when you can do these without delegating the answer back to the agent:
 

--- a/mini-lsm-book/src/week1-overview.md
+++ b/mini-lsm-book/src/week1-overview.md
@@ -1,5 +1,5 @@
 <!--
-  mini-lsm-book © 2022-2025 by Alex Chi Z is licensed under CC BY-NC-SA 4.0
+  mini-lsm-book © 2022-2026 by Alex Chi Z is licensed under CC BY-NC-SA 4.0
 -->
 
 # Week 1 Overview: Mini-LSM

--- a/mini-lsm-book/src/week2-01-compaction.md
+++ b/mini-lsm-book/src/week2-01-compaction.md
@@ -1,5 +1,5 @@
 <!--
-  mini-lsm-book © 2022-2025 by Alex Chi Z is licensed under CC BY-NC-SA 4.0
+  mini-lsm-book © 2022-2026 by Alex Chi Z is licensed under CC BY-NC-SA 4.0
 -->
 
 # Compaction Implementation

--- a/mini-lsm-book/src/week2-02-simple.md
+++ b/mini-lsm-book/src/week2-02-simple.md
@@ -1,5 +1,5 @@
 <!--
-  mini-lsm-book © 2022-2025 by Alex Chi Z is licensed under CC BY-NC-SA 4.0
+  mini-lsm-book © 2022-2026 by Alex Chi Z is licensed under CC BY-NC-SA 4.0
 -->
 
 # Simple Compaction Strategy

--- a/mini-lsm-book/src/week2-03-tiered.md
+++ b/mini-lsm-book/src/week2-03-tiered.md
@@ -1,5 +1,5 @@
 <!--
-  mini-lsm-book © 2022-2025 by Alex Chi Z is licensed under CC BY-NC-SA 4.0
+  mini-lsm-book © 2022-2026 by Alex Chi Z is licensed under CC BY-NC-SA 4.0
 -->
 
 # Tiered Compaction Strategy

--- a/mini-lsm-book/src/week2-04-leveled.md
+++ b/mini-lsm-book/src/week2-04-leveled.md
@@ -1,5 +1,5 @@
 <!--
-  mini-lsm-book © 2022-2025 by Alex Chi Z is licensed under CC BY-NC-SA 4.0
+  mini-lsm-book © 2022-2026 by Alex Chi Z is licensed under CC BY-NC-SA 4.0
 -->
 
 # Leveled Compaction Strategy

--- a/mini-lsm-book/src/week2-05-manifest.md
+++ b/mini-lsm-book/src/week2-05-manifest.md
@@ -1,5 +1,5 @@
 <!--
-  mini-lsm-book © 2022-2025 by Alex Chi Z is licensed under CC BY-NC-SA 4.0
+  mini-lsm-book © 2022-2026 by Alex Chi Z is licensed under CC BY-NC-SA 4.0
 -->
 
 # Manifest

--- a/mini-lsm-book/src/week2-06-wal.md
+++ b/mini-lsm-book/src/week2-06-wal.md
@@ -1,5 +1,5 @@
 <!--
-  mini-lsm-book © 2022-2025 by Alex Chi Z is licensed under CC BY-NC-SA 4.0
+  mini-lsm-book © 2022-2026 by Alex Chi Z is licensed under CC BY-NC-SA 4.0
 -->
 
 # Write-Ahead Log (WAL)

--- a/mini-lsm-book/src/week2-07-snacks.md
+++ b/mini-lsm-book/src/week2-07-snacks.md
@@ -1,5 +1,5 @@
 <!--
-  mini-lsm-book © 2022-2025 by Alex Chi Z is licensed under CC BY-NC-SA 4.0
+  mini-lsm-book © 2022-2026 by Alex Chi Z is licensed under CC BY-NC-SA 4.0
 -->
 
 # Batch Write and Checksums

--- a/mini-lsm-book/src/week2-overview.md
+++ b/mini-lsm-book/src/week2-overview.md
@@ -1,5 +1,5 @@
 <!--
-  mini-lsm-book © 2022-2025 by Alex Chi Z is licensed under CC BY-NC-SA 4.0
+  mini-lsm-book © 2022-2026 by Alex Chi Z is licensed under CC BY-NC-SA 4.0
 -->
 
 # Week 2 Overview: Compaction and Persistence

--- a/mini-lsm-book/src/week3-01-ts-key-refactor.md
+++ b/mini-lsm-book/src/week3-01-ts-key-refactor.md
@@ -1,5 +1,5 @@
 <!--
-  mini-lsm-book © 2022-2025 by Alex Chi Z is licensed under CC BY-NC-SA 4.0
+  mini-lsm-book © 2022-2026 by Alex Chi Z is licensed under CC BY-NC-SA 4.0
 -->
 
 # Timestamp Key Encoding + Refactor

--- a/mini-lsm-book/src/week3-02-snapshot-read-part-1.md
+++ b/mini-lsm-book/src/week3-02-snapshot-read-part-1.md
@@ -1,5 +1,5 @@
 <!--
-  mini-lsm-book © 2022-2025 by Alex Chi Z is licensed under CC BY-NC-SA 4.0
+  mini-lsm-book © 2022-2026 by Alex Chi Z is licensed under CC BY-NC-SA 4.0
 -->
 
 # Snapshot Read - Memtables and Timestamps

--- a/mini-lsm-book/src/week3-03-snapshot-read-part-2.md
+++ b/mini-lsm-book/src/week3-03-snapshot-read-part-2.md
@@ -1,5 +1,5 @@
 <!--
-  mini-lsm-book © 2022-2025 by Alex Chi Z is licensed under CC BY-NC-SA 4.0
+  mini-lsm-book © 2022-2026 by Alex Chi Z is licensed under CC BY-NC-SA 4.0
 -->
 
 # Snapshot Read - Engine Read Path and Transaction API

--- a/mini-lsm-book/src/week3-04-watermark.md
+++ b/mini-lsm-book/src/week3-04-watermark.md
@@ -1,5 +1,5 @@
 <!--
-  mini-lsm-book © 2022-2025 by Alex Chi Z is licensed under CC BY-NC-SA 4.0
+  mini-lsm-book © 2022-2026 by Alex Chi Z is licensed under CC BY-NC-SA 4.0
 -->
 
 # Watermark and Garbage Collection

--- a/mini-lsm-book/src/week3-05-txn-occ.md
+++ b/mini-lsm-book/src/week3-05-txn-occ.md
@@ -1,5 +1,5 @@
 <!--
-  mini-lsm-book © 2022-2025 by Alex Chi Z is licensed under CC BY-NC-SA 4.0
+  mini-lsm-book © 2022-2026 by Alex Chi Z is licensed under CC BY-NC-SA 4.0
 -->
 
 # Transaction and Optimistic Concurrency Control

--- a/mini-lsm-book/src/week3-06-serializable.md
+++ b/mini-lsm-book/src/week3-06-serializable.md
@@ -1,5 +1,5 @@
 <!--
-  mini-lsm-book © 2022-2025 by Alex Chi Z is licensed under CC BY-NC-SA 4.0
+  mini-lsm-book © 2022-2026 by Alex Chi Z is licensed under CC BY-NC-SA 4.0
 -->
 
 # (A Partial) Serializable Snapshot Isolation

--- a/mini-lsm-book/src/week3-07-compaction-filter.md
+++ b/mini-lsm-book/src/week3-07-compaction-filter.md
@@ -1,5 +1,5 @@
 <!--
-  mini-lsm-book © 2022-2025 by Alex Chi Z is licensed under CC BY-NC-SA 4.0
+  mini-lsm-book © 2022-2026 by Alex Chi Z is licensed under CC BY-NC-SA 4.0
 -->
 
 # Snack Time: Compaction Filters

--- a/mini-lsm-book/src/week3-overview.md
+++ b/mini-lsm-book/src/week3-overview.md
@@ -1,5 +1,5 @@
 <!--
-  mini-lsm-book © 2022-2025 by Alex Chi Z is licensed under CC BY-NC-SA 4.0
+  mini-lsm-book © 2022-2026 by Alex Chi Z is licensed under CC BY-NC-SA 4.0
 -->
 
 # Week 3 Overview: Multi-Version Concurrency Control

--- a/mini-lsm-book/src/week4-overview.md
+++ b/mini-lsm-book/src/week4-overview.md
@@ -1,5 +1,5 @@
 <!--
-  mini-lsm-book © 2022-2025 by Alex Chi Z is licensed under CC BY-NC-SA 4.0
+  mini-lsm-book © 2022-2026 by Alex Chi Z is licensed under CC BY-NC-SA 4.0
 -->
 
 # The Rest of Your Life (TBD)

--- a/mini-lsm-mvcc/README.md
+++ b/mini-lsm-mvcc/README.md
@@ -1,5 +1,5 @@
 <!--
-  Copyright (c) 2022-2025 Alex Chi Z
+  Copyright (c) 2022-2026 Alex Chi Z
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/mini-lsm-mvcc/src/bin/wrapper.rs
+++ b/mini-lsm-mvcc/src/bin/wrapper.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2025 Alex Chi Z
+// Copyright (c) 2022-2026 Alex Chi Z
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/mini-lsm-mvcc/src/block.rs
+++ b/mini-lsm-mvcc/src/block.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2025 Alex Chi Z
+// Copyright (c) 2022-2026 Alex Chi Z
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/mini-lsm-mvcc/src/block/builder.rs
+++ b/mini-lsm-mvcc/src/block/builder.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2025 Alex Chi Z
+// Copyright (c) 2022-2026 Alex Chi Z
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/mini-lsm-mvcc/src/block/iterator.rs
+++ b/mini-lsm-mvcc/src/block/iterator.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2025 Alex Chi Z
+// Copyright (c) 2022-2026 Alex Chi Z
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/mini-lsm-mvcc/src/compact.rs
+++ b/mini-lsm-mvcc/src/compact.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2025 Alex Chi Z
+// Copyright (c) 2022-2026 Alex Chi Z
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/mini-lsm-mvcc/src/compact/leveled.rs
+++ b/mini-lsm-mvcc/src/compact/leveled.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2025 Alex Chi Z
+// Copyright (c) 2022-2026 Alex Chi Z
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/mini-lsm-mvcc/src/compact/simple_leveled.rs
+++ b/mini-lsm-mvcc/src/compact/simple_leveled.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2025 Alex Chi Z
+// Copyright (c) 2022-2026 Alex Chi Z
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/mini-lsm-mvcc/src/compact/tiered.rs
+++ b/mini-lsm-mvcc/src/compact/tiered.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2025 Alex Chi Z
+// Copyright (c) 2022-2026 Alex Chi Z
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/mini-lsm-mvcc/src/iterators.rs
+++ b/mini-lsm-mvcc/src/iterators.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2025 Alex Chi Z
+// Copyright (c) 2022-2026 Alex Chi Z
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/mini-lsm-mvcc/src/iterators/concat_iterator.rs
+++ b/mini-lsm-mvcc/src/iterators/concat_iterator.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2025 Alex Chi Z
+// Copyright (c) 2022-2026 Alex Chi Z
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/mini-lsm-mvcc/src/iterators/merge_iterator.rs
+++ b/mini-lsm-mvcc/src/iterators/merge_iterator.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2025 Alex Chi Z
+// Copyright (c) 2022-2026 Alex Chi Z
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/mini-lsm-mvcc/src/iterators/two_merge_iterator.rs
+++ b/mini-lsm-mvcc/src/iterators/two_merge_iterator.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2025 Alex Chi Z
+// Copyright (c) 2022-2026 Alex Chi Z
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/mini-lsm-mvcc/src/key.rs
+++ b/mini-lsm-mvcc/src/key.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2025 Alex Chi Z
+// Copyright (c) 2022-2026 Alex Chi Z
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/mini-lsm-mvcc/src/lib.rs
+++ b/mini-lsm-mvcc/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2025 Alex Chi Z
+// Copyright (c) 2022-2026 Alex Chi Z
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/mini-lsm-mvcc/src/lsm_iterator.rs
+++ b/mini-lsm-mvcc/src/lsm_iterator.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2025 Alex Chi Z
+// Copyright (c) 2022-2026 Alex Chi Z
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/mini-lsm-mvcc/src/lsm_storage.rs
+++ b/mini-lsm-mvcc/src/lsm_storage.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2025 Alex Chi Z
+// Copyright (c) 2022-2026 Alex Chi Z
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/mini-lsm-mvcc/src/manifest.rs
+++ b/mini-lsm-mvcc/src/manifest.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2025 Alex Chi Z
+// Copyright (c) 2022-2026 Alex Chi Z
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/mini-lsm-mvcc/src/mem_table.rs
+++ b/mini-lsm-mvcc/src/mem_table.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2025 Alex Chi Z
+// Copyright (c) 2022-2026 Alex Chi Z
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/mini-lsm-mvcc/src/mvcc.rs
+++ b/mini-lsm-mvcc/src/mvcc.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2025 Alex Chi Z
+// Copyright (c) 2022-2026 Alex Chi Z
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/mini-lsm-mvcc/src/mvcc/txn.rs
+++ b/mini-lsm-mvcc/src/mvcc/txn.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2025 Alex Chi Z
+// Copyright (c) 2022-2026 Alex Chi Z
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/mini-lsm-mvcc/src/mvcc/watermark.rs
+++ b/mini-lsm-mvcc/src/mvcc/watermark.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2025 Alex Chi Z
+// Copyright (c) 2022-2026 Alex Chi Z
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/mini-lsm-mvcc/src/table.rs
+++ b/mini-lsm-mvcc/src/table.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2025 Alex Chi Z
+// Copyright (c) 2022-2026 Alex Chi Z
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/mini-lsm-mvcc/src/table/bloom.rs
+++ b/mini-lsm-mvcc/src/table/bloom.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2025 Alex Chi Z
+// Copyright (c) 2022-2026 Alex Chi Z
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/mini-lsm-mvcc/src/table/builder.rs
+++ b/mini-lsm-mvcc/src/table/builder.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2025 Alex Chi Z
+// Copyright (c) 2022-2026 Alex Chi Z
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/mini-lsm-mvcc/src/table/iterator.rs
+++ b/mini-lsm-mvcc/src/table/iterator.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2025 Alex Chi Z
+// Copyright (c) 2022-2026 Alex Chi Z
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/mini-lsm-mvcc/src/tests.rs
+++ b/mini-lsm-mvcc/src/tests.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2025 Alex Chi Z
+// Copyright (c) 2022-2026 Alex Chi Z
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/mini-lsm-mvcc/src/tests/week3_day1.rs
+++ b/mini-lsm-mvcc/src/tests/week3_day1.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2025 Alex Chi Z
+// Copyright (c) 2022-2026 Alex Chi Z
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/mini-lsm-mvcc/src/tests/week3_day2.rs
+++ b/mini-lsm-mvcc/src/tests/week3_day2.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2025 Alex Chi Z
+// Copyright (c) 2022-2026 Alex Chi Z
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/mini-lsm-mvcc/src/tests/week3_day3.rs
+++ b/mini-lsm-mvcc/src/tests/week3_day3.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2025 Alex Chi Z
+// Copyright (c) 2022-2026 Alex Chi Z
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/mini-lsm-mvcc/src/tests/week3_day4.rs
+++ b/mini-lsm-mvcc/src/tests/week3_day4.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2025 Alex Chi Z
+// Copyright (c) 2022-2026 Alex Chi Z
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/mini-lsm-mvcc/src/tests/week3_day5.rs
+++ b/mini-lsm-mvcc/src/tests/week3_day5.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2025 Alex Chi Z
+// Copyright (c) 2022-2026 Alex Chi Z
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/mini-lsm-mvcc/src/tests/week3_day6.rs
+++ b/mini-lsm-mvcc/src/tests/week3_day6.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2025 Alex Chi Z
+// Copyright (c) 2022-2026 Alex Chi Z
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/mini-lsm-mvcc/src/tests/week3_day7.rs
+++ b/mini-lsm-mvcc/src/tests/week3_day7.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2025 Alex Chi Z
+// Copyright (c) 2022-2026 Alex Chi Z
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/mini-lsm-mvcc/src/wal.rs
+++ b/mini-lsm-mvcc/src/wal.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2025 Alex Chi Z
+// Copyright (c) 2022-2026 Alex Chi Z
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/mini-lsm-starter/AGENTS.md
+++ b/mini-lsm-starter/AGENTS.md
@@ -29,41 +29,19 @@ Before editing code:
 4. Propose a small implementation and validation plan.
 5. Ask the student to predict one important boundary case before revealing its result.
 
-If the request spans more than one of the review gates below, stop after presenting the plan and wait for the student to approve the first gate. Implement one gate at a time and stop after each gate for review.
+The course material, not this file, defines the checkpoints and their system-specific invariants. The student directs their sequence. Do not choose or begin a checkpoint merely because the preceding checkpoint passed.
 
-### Review Gate 1: Ordered State
-
-Scope: memtables and merge iterators.
-
-Confirm key ordering, overwrite behavior, tombstone precedence, duplicate resolution, error propagation, and fused-iterator behavior.
-
-A mutable write must retain the `state` read guard until the skiplist insertion completes. Do not write through a cloned state snapshot after releasing that guard: a concurrent freeze could otherwise turn the target into an immutable memtable before the insertion.
-
-### Review Gate 2: Durable Representation
-
-Scope: blocks, SST builders and readers, block and SST iterators, prefix encoding, and Bloom filters.
-
-Confirm byte boundaries, offset encoding, seek semantics, first/last-key metadata, exact decode round trips, and the absence of Bloom-filter false negatives.
-
-When all Week 1 tests are present, implement the final Day 7 prefix-compressed block format directly instead of first implementing and then replacing Day 3's uncompressed key layout.
-
-### Review Gate 3: One Logical Engine
-
-Scope: integrated reads and writes, freezing, flushing, SST filtering, and iterator accounting.
-
-Confirm source recency, tombstone handling, range-bound semantics, state transitions, lock lifetimes, and that optimizations do not change logical results.
-
-For a task contained within one gate, you may proceed after presenting the invariants and plan unless the student asks you to wait.
+A request that names one checkpoint authorizes work only on that checkpoint. Before editing, restate its scope and invariants and list the files you expect to change. If a request spans multiple checkpoints, present the plan and wait for the student to select the first one. Implement one checkpoint at a time, stop after each checkpoint for review, and do not continue until the student explicitly names the next checkpoint.
 
 ## Implementation and Debugging
 
-- Prefer the smallest coherent diff that satisfies the current gate.
+- Prefer the smallest coherent diff that satisfies the current checkpoint.
 - Preserve the starter's architecture and naming unless a local design change is necessary and explained.
 - Do not perform unrelated refactors while implementing a task.
 - Make one testable debugging hypothesis at a time. Use the smallest relevant check before stacking speculative fixes.
 - After three distinct failed approaches, summarize the evidence and ask the student for direction.
 - Never claim a test passed unless you ran it and saw a successful result.
-- Treat a passing supplied suite as necessary but not sufficient. Propose at least one adversarial example for each gate and ask the student to predict its outcome. Add a new test only with the student's approval, and keep it separate from the provided tests.
+- Treat a passing supplied suite as necessary but not sufficient. Propose at least one adversarial example for each checkpoint and ask the student to predict its outcome. Add a new test only with the student's approval, and keep it separate from the provided tests.
 - If demonstrating a deliberate fault, begin from a clean, passing state, state the expected failure, and revert the fault immediately after the experiment.
 
 ## Validation
@@ -78,7 +56,7 @@ Also inspect the final diff for modified tests, removed assertions, new lint sup
 
 ## Handoff to the Student
 
-At each review stop, report:
+At each checkpoint stop, report:
 
 - the files and behavior changed;
 - the invariants the code relies on;

--- a/mini-lsm-starter/src/bin/compaction-simulator.rs
+++ b/mini-lsm-starter/src/bin/compaction-simulator.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2025 Alex Chi Z
+// Copyright (c) 2022-2026 Alex Chi Z
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/mini-lsm-starter/src/bin/mini-lsm-cli.rs
+++ b/mini-lsm-starter/src/bin/mini-lsm-cli.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2025 Alex Chi Z
+// Copyright (c) 2022-2026 Alex Chi Z
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/mini-lsm-starter/src/bin/wrapper.rs
+++ b/mini-lsm-starter/src/bin/wrapper.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2025 Alex Chi Z
+// Copyright (c) 2022-2026 Alex Chi Z
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/mini-lsm-starter/src/block.rs
+++ b/mini-lsm-starter/src/block.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2025 Alex Chi Z
+// Copyright (c) 2022-2026 Alex Chi Z
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/mini-lsm-starter/src/block/builder.rs
+++ b/mini-lsm-starter/src/block/builder.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2025 Alex Chi Z
+// Copyright (c) 2022-2026 Alex Chi Z
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/mini-lsm-starter/src/block/iterator.rs
+++ b/mini-lsm-starter/src/block/iterator.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2025 Alex Chi Z
+// Copyright (c) 2022-2026 Alex Chi Z
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/mini-lsm-starter/src/compact.rs
+++ b/mini-lsm-starter/src/compact.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2025 Alex Chi Z
+// Copyright (c) 2022-2026 Alex Chi Z
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/mini-lsm-starter/src/compact/leveled.rs
+++ b/mini-lsm-starter/src/compact/leveled.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2025 Alex Chi Z
+// Copyright (c) 2022-2026 Alex Chi Z
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/mini-lsm-starter/src/compact/simple_leveled.rs
+++ b/mini-lsm-starter/src/compact/simple_leveled.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2025 Alex Chi Z
+// Copyright (c) 2022-2026 Alex Chi Z
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/mini-lsm-starter/src/compact/tiered.rs
+++ b/mini-lsm-starter/src/compact/tiered.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2025 Alex Chi Z
+// Copyright (c) 2022-2026 Alex Chi Z
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/mini-lsm-starter/src/debug.rs
+++ b/mini-lsm-starter/src/debug.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2025 Alex Chi Z
+// Copyright (c) 2022-2026 Alex Chi Z
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/mini-lsm-starter/src/iterators.rs
+++ b/mini-lsm-starter/src/iterators.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2025 Alex Chi Z
+// Copyright (c) 2022-2026 Alex Chi Z
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/mini-lsm-starter/src/iterators/concat_iterator.rs
+++ b/mini-lsm-starter/src/iterators/concat_iterator.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2025 Alex Chi Z
+// Copyright (c) 2022-2026 Alex Chi Z
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/mini-lsm-starter/src/iterators/merge_iterator.rs
+++ b/mini-lsm-starter/src/iterators/merge_iterator.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2025 Alex Chi Z
+// Copyright (c) 2022-2026 Alex Chi Z
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/mini-lsm-starter/src/iterators/two_merge_iterator.rs
+++ b/mini-lsm-starter/src/iterators/two_merge_iterator.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2025 Alex Chi Z
+// Copyright (c) 2022-2026 Alex Chi Z
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/mini-lsm-starter/src/key.rs
+++ b/mini-lsm-starter/src/key.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2025 Alex Chi Z
+// Copyright (c) 2022-2026 Alex Chi Z
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/mini-lsm-starter/src/lib.rs
+++ b/mini-lsm-starter/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2025 Alex Chi Z
+// Copyright (c) 2022-2026 Alex Chi Z
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/mini-lsm-starter/src/lsm_iterator.rs
+++ b/mini-lsm-starter/src/lsm_iterator.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2025 Alex Chi Z
+// Copyright (c) 2022-2026 Alex Chi Z
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/mini-lsm-starter/src/lsm_storage.rs
+++ b/mini-lsm-starter/src/lsm_storage.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2025 Alex Chi Z
+// Copyright (c) 2022-2026 Alex Chi Z
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/mini-lsm-starter/src/manifest.rs
+++ b/mini-lsm-starter/src/manifest.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2025 Alex Chi Z
+// Copyright (c) 2022-2026 Alex Chi Z
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/mini-lsm-starter/src/mem_table.rs
+++ b/mini-lsm-starter/src/mem_table.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2025 Alex Chi Z
+// Copyright (c) 2022-2026 Alex Chi Z
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/mini-lsm-starter/src/mvcc.rs
+++ b/mini-lsm-starter/src/mvcc.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2025 Alex Chi Z
+// Copyright (c) 2022-2026 Alex Chi Z
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/mini-lsm-starter/src/mvcc/txn.rs
+++ b/mini-lsm-starter/src/mvcc/txn.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2025 Alex Chi Z
+// Copyright (c) 2022-2026 Alex Chi Z
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/mini-lsm-starter/src/mvcc/watermark.rs
+++ b/mini-lsm-starter/src/mvcc/watermark.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2025 Alex Chi Z
+// Copyright (c) 2022-2026 Alex Chi Z
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/mini-lsm-starter/src/table.rs
+++ b/mini-lsm-starter/src/table.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2025 Alex Chi Z
+// Copyright (c) 2022-2026 Alex Chi Z
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/mini-lsm-starter/src/table/bloom.rs
+++ b/mini-lsm-starter/src/table/bloom.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2025 Alex Chi Z
+// Copyright (c) 2022-2026 Alex Chi Z
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/mini-lsm-starter/src/table/builder.rs
+++ b/mini-lsm-starter/src/table/builder.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2025 Alex Chi Z
+// Copyright (c) 2022-2026 Alex Chi Z
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/mini-lsm-starter/src/table/iterator.rs
+++ b/mini-lsm-starter/src/table/iterator.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2025 Alex Chi Z
+// Copyright (c) 2022-2026 Alex Chi Z
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/mini-lsm-starter/src/tests.rs
+++ b/mini-lsm-starter/src/tests.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2025 Alex Chi Z
+// Copyright (c) 2022-2026 Alex Chi Z
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/mini-lsm-starter/src/wal.rs
+++ b/mini-lsm-starter/src/wal.rs
@@ -1,5 +1,5 @@
 // REMOVE THIS LINE after fully implementing this functionality
-// Copyright (c) 2022-2025 Alex Chi Z
+// Copyright (c) 2022-2026 Alex Chi Z
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2025 Alex Chi Z
+// Copyright (c) 2022-2026 Alex Chi Z
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
Fast-forward checkpoints should structure student review without turning `AGENTS.md` into an autonomous syllabus.

This renames review gates to checkpoints throughout the agent track and keeps system-specific checkpoint definitions in the Day 1 course page. `AGENTS.md` now owns only the reusable boundaries and stopping contract: a student-named checkpoint authorizes that checkpoint, and the agent must wait for the student to name the next one.

It also rolls Alex Chi Z copyright ranges forward to 2026 across the book, starter, MVCC teaching workspace, and course tooling.

_AI-assisted: Codex._
