### PR TITLE
simplify Day 1 fast-forward setup

### DIFF
--- a/mini-lsm-book/src/SUMMARY.md
+++ b/mini-lsm-book/src/SUMMARY.md
@@ -37,7 +37,7 @@
 - [The Rest of Your Life (TBD)](./week4-overview.md)
 
 - [Agent Fast Forward in 3 Days](./agent-fast-forward-overview.md)
-  - [Day 1: Week 1 — Mini-LSM](./week1-fast-forward.md)
+  - [Day 1 - Mini-LSM](./week1-fast-forward.md)
 
 ---
 

--- a/mini-lsm-book/src/agent-fast-forward-overview.md
+++ b/mini-lsm-book/src/agent-fast-forward-overview.md
@@ -4,15 +4,15 @@
 
 # Agent Fast Forward in 3 Days (WIP)
 
-This is an alternative course track for students who intend to use a coding agent. Instead of spending seven chapters on each original course week, you will use one focused day to specify, generate, review, and challenge that week's system.
+This is an alternative course track for students who intend to use a coding agent. Instead of following seven chapters for each course phase, you will use one focused day to specify, generate, review, and challenge a complete system.
 
 The agent may write most of the code. Your job is to define what correct means, constrain the work, inspect the result, and leave with a mental model you can use without the agent.
 
 | Fast-forward day | Original course material | Outcome |
 | --- | --- | --- |
-| [Day 1](./week1-fast-forward.md) | Week 1: Mini-LSM | A working storage engine with memtables, SSTs, reads, writes, and flushes. |
-| Day 2 | Week 2: Compaction and persistence | Coming later. |
-| Day 3 | Week 3: MVCC | Coming later. |
+| [Day 1](./week1-fast-forward.md) | Mini-LSM | A working storage engine with memtables, SSTs, reads, writes, and flushes. |
+| Day 2 | Compaction and persistence | Coming later. |
+| Day 3 | MVCC | Coming later. |
 
 The original chapters remain a reference library. This track changes the pacing and the student's role; it does not remove the need to understand ordering, representation, concurrency, and failure modes.
 
@@ -34,20 +34,7 @@ The repository pins its Rust toolchain in `rust-toolchain.toml`, so Cargo will s
 
 If you already have the repository and tools, update your checkout as appropriate and begin from the repository root.
 
-### 2. Copy the Complete Week 1 Test Suite
-
-The normal course reveals tests one chapter at a time. Day 1 of the fast-forward track starts with the complete Week 1 acceptance suite:
-
-```shell
-for day in 1 2 3 4 5 6 7; do
-  cargo x copy-test --week 1 --day "$day"
-done
-cargo x scheck
-```
-
-The initial check should fail because the starter contains unfinished code. Record the first failure; it gives you a reproducible baseline. Do not ask the agent to make this failure disappear by changing the tests.
-
-### 3. Start the Agent from `mini-lsm-starter`
+### 2. Start the Agent from `mini-lsm-starter`
 
 Change into the starter directory before launching your coding agent:
 
@@ -66,7 +53,7 @@ Starting in this directory is not a security sandbox: an agent can still travers
 
 Do not open the whole repository as the agent's workspace if your tool lets you choose a directory. Open `mini-lsm-starter`. The agent may consult the copied tests, starter interfaces, Rust documentation, and course chapters under `../mini-lsm-book/src/`.
 
-### 4. Verify the Instructions Before Coding
+### 3. Verify the Instructions Before Coding
 
 Do not assume the tool discovered `AGENTS.md`. Make the first prompt a handshake that performs no implementation:
 
@@ -106,6 +93,6 @@ Do not let “all tests pass” end the review. Conversely, do not ask the agent
 
 Repeat Prompts 2 and 3 for each checkpoint. The checkpoint stops are where you catch a locally reasonable decision before it spreads across the system.
 
-When the workspace is prepared and the instruction handshake succeeds, continue to [Day 1: Week 1 — Mini-LSM](./week1-fast-forward.md).
+When the workspace is prepared and the instruction handshake succeeds, continue to [Day 1 - Mini-LSM](./week1-fast-forward.md).
 
 {{#include copyright.md}}

--- a/mini-lsm-book/src/week1-fast-forward.md
+++ b/mini-lsm-book/src/week1-fast-forward.md
@@ -2,16 +2,16 @@
   mini-lsm-book © 2022-2026 by Alex Chi Z is licensed under CC BY-NC-SA 4.0
 -->
 
-# Day 1: Week 1 — Mini-LSM
+# Day 1 - Mini-LSM
 
-This is the first day of [Agent Fast Forward in 3 Days](./agent-fast-forward-overview.md). You will use a coding agent to build and defend one working storage engine from the original Week 1 material:
+This is the first day of [Agent Fast Forward in 3 Days](./agent-fast-forward-overview.md). You will use a coding agent to build and defend one working storage engine from the original Mini-LSM material:
 
 ```text
 put/delete -> mutable memtable -> immutable memtables -> L0 SSTs
                      \____________ read + merge ____________/
 ```
 
-Use the existing Week 1 chapters as a reference library when you need a deeper explanation. You do not need to follow them one chapter at a time.
+Use the existing Mini-LSM chapters as a reference library when you need a deeper explanation. You do not need to follow them one chapter at a time.
 
 ## The Completion Contract
 
@@ -20,16 +20,27 @@ At the end of this path:
 - `put`, `delete`, `get`, and bounded `scan` work across memory and disk;
 - a frozen memtable can be flushed into an L0 SST;
 - Bloom filters and prefix encoding improve the implementation without changing its results;
-- the complete Week 1 test suite passes; and
+- the complete supplied test suite passes; and
 - you can trace a key through the engine, explain why the newest value wins, and design a test for a plausible bug.
 
 The tests are evidence, not the specification. Generated code remains untrusted until you can connect it to an invariant and try to falsify it.
 
+## Copy the Complete Test Suite
+
+Complete the repository and agent preparation in the [track overview](./agent-fast-forward-overview.md#prepare-the-repository-and-the-agent). Leave the agent at the instruction-handshake stop, then run these commands from the repository root. The original course reveals tests one chapter at a time; Day 1 starts with the complete acceptance suite:
+
+```shell
+cargo x copy-test --week 1
+cargo x scheck
+```
+
+The initial check should fail because the starter contains unfinished code. Record the first failure; it gives you a reproducible baseline. Do not ask the agent to make this failure disappear by changing the tests.
+
 ## Start Day 1
 
-Complete the repository and agent preparation in the [track overview](./agent-fast-forward-overview.md#prepare-the-repository-and-the-agent). With the agent running from `mini-lsm-starter` and the instruction handshake complete, send this kickoff prompt:
+With the agent running from `mini-lsm-starter`, the instruction handshake complete, and the test suite copied, send this kickoff prompt:
 
-> We are completing Week 1 of Mini-LSM in this starter directory. Use the starter interfaces, copied Week 1 tests, and Week 1 book chapters, but never access `../mini-lsm`. Do not edit yet.
+> We are completing Mini-LSM in this starter directory. Use the starter interfaces, copied acceptance tests, and Mini-LSM book chapters, but never access `../mini-lsm`. Do not edit yet.
 >
 > Return:
 >
@@ -140,7 +151,7 @@ Finally, introduce one small, deliberate fault—for example, reverse equal-key 
 
 ## Day 1 Completion Checkpoint
 
-You are ready for Week 2 when you can do these without delegating the answer back to the agent:
+You are ready for Day 2 when you can do these without delegating the answer back to the agent:
 
 - draw the write, read, and flush paths from memory;
 - explain the ordering rule that selects one value from duplicate keys;
@@ -150,6 +161,6 @@ You are ready for Week 2 when you can do these without delegating the answer bac
 - describe an unsafe flush interleaving and how the implementation prevents it; and
 - turn a suspected invariant violation into a minimal test.
 
-If you cannot yet do one of these, use the corresponding Week 1 chapter and ask the agent to quiz you with concrete states or byte layouts. The measure of success is not whether you typed the implementation. It is whether you can specify, inspect, test, and change the system with confidence.
+If you cannot yet do one of these, use the corresponding Mini-LSM chapter and ask the agent to quiz you with concrete states or byte layouts. The measure of success is not whether you typed the implementation. It is whether you can specify, inspect, test, and change the system with confidence.
 
 {{#include copyright.md}}

--- a/mini-lsm-starter/AGENTS.md
+++ b/mini-lsm-starter/AGENTS.md
@@ -17,7 +17,7 @@ The student owns the specification and the proof of correctness. Treat your code
 - Keep changes inside `mini-lsm-starter` unless the student explicitly asks for a change elsewhere.
 - Do not commit, push, rewrite Git history, or discard existing work unless the student explicitly asks.
 
-You may consult the Week 1 chapters in `../mini-lsm-book/src/`, Rust and dependency documentation, and the starter code's existing interfaces. External documentation is for understanding APIs and concepts, not for locating another Mini-LSM solution.
+You may consult the Mini-LSM chapters in `../mini-lsm-book/src/`, Rust and dependency documentation, and the starter code's existing interfaces. External documentation is for understanding APIs and concepts, not for locating another Mini-LSM solution.
 
 ## Working Agreement
 
@@ -46,7 +46,7 @@ A request that names one checkpoint authorizes work only on that checkpoint. Bef
 
 ## Validation
 
-Run focused tests while working. Before declaring Week 1 complete, run from the repository root:
+Run focused tests while working. Before declaring Day 1 complete, run from the repository root:
 
 ```shell
 cargo x scheck

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -23,8 +23,9 @@ use duct::cmd;
 struct CopyTestAction {
     #[arg(long)]
     week: usize,
+    /// Copy one day; omit to copy all seven days.
     #[arg(long)]
-    day: usize,
+    day: Option<usize>,
 }
 
 #[derive(clap::Subcommand, Debug)]
@@ -72,6 +73,13 @@ fn switch_to_starter_root() -> Result<()> {
             .join("mini-lsm-starter"),
     )?;
     Ok(())
+}
+
+fn days_to_copy(day: Option<usize>) -> Vec<usize> {
+    match day {
+        Some(day) => vec![day],
+        None => (1..=7).collect(),
+    }
 }
 
 fn fmt() -> Result<()> {
@@ -154,10 +162,12 @@ fn copy_test_case(test: CopyTestAction) -> Result<()> {
     if !Path::new(target_dir).exists() {
         std::fs::create_dir(target_dir)?;
     }
-    let test_filename = format!("week{}_day{}.rs", test.week, test.day);
-    let src = format!("{}/{}", src_dir, test_filename);
-    let target = format!("{}/{}", target_dir, test_filename);
-    cmd!("cp", src, target).run()?;
+    for day in days_to_copy(test.day) {
+        let test_filename = format!("week{}_day{}.rs", test.week, day);
+        let src = format!("{}/{}", src_dir, test_filename);
+        let target = format!("{}/{}", target_dir, test_filename);
+        cmd!("cp", src, target).run()?;
+    }
     let test_filename = "harness.rs";
     let src = format!("{}/{}", src_dir, test_filename);
     let target = format!("{}/{}", target_dir, test_filename);
@@ -242,4 +252,19 @@ fn main() -> Result<()> {
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::days_to_copy;
+
+    #[test]
+    fn copy_all_days_when_day_is_omitted() {
+        assert_eq!(days_to_copy(None), (1..=7).collect::<Vec<_>>());
+    }
+
+    #[test]
+    fn copy_only_the_selected_day() {
+        assert_eq!(days_to_copy(Some(3)), vec![3]);
+    }
 }


### PR DESCRIPTION
The fast-forward track should present Day 1 as a complete system-building exercise rather than expose the pacing of the original course.

This makes `cargo x copy-test --week 1` copy all seven test files while preserving `--day` for chapter-by-chapter use. It moves full-suite setup into Day 1, renames the page to `Day 1 - Mini-LSM`, and removes week-based terminology from the agent-track guidance without changing the original course hierarchy.

_AI-assisted: Codex._
