### PR TITLE
Refine fast-forward agent learning loop

### DIFF
--- a/mini-lsm-book/src/agent-fast-forward-overview.md
+++ b/mini-lsm-book/src/agent-fast-forward-overview.md
@@ -4,9 +4,9 @@
 
 # Agent Fast Forward in 3 Days (WIP)
 
-This is an alternative course track for students who intend to use a coding agent. Instead of following seven chapters for each course phase, you will use one focused day to specify, generate, review, and challenge a complete system.
+This is an alternative course track for students who intend to use a coding agent. The agent will write much of the code, but it must not silently design the system for you. Each day is a dialogue in which you make the consequential decisions, the agent turns a few accepted decisions into a small code change, and tests challenge the shared model.
 
-The agent may write most of the code. Your job is to define what correct means, constrain the work, inspect the result, and leave with a mental model you can use without the agent.
+Fast forward means compressing implementation time, not compressing the design into one generated answer.
 
 | Fast-forward day | Original course material | Outcome |
 | --- | --- | --- |
@@ -44,54 +44,71 @@ pwd
 # Start your coding agent here using the command for your tool.
 ```
 
-The final component of `pwd` should be `mini-lsm-starter`. This matters for two reasons:
+The final component of `pwd` should be `mini-lsm-starter`. This matters because repository-aware agents discover the `AGENTS.md` in this directory and begin with the starter as their working scope.
 
-1. repository-aware agents discover the `AGENTS.md` in this directory and apply its learning constraints; and
-2. the agent begins with the starter as its working scope instead of treating the neighboring reference implementation as ordinary project context.
+Starting there is not a security sandbox: an agent can still traverse to a parent directory if instructed. The local `AGENTS.md` therefore prohibits reading, searching, diffing, or copying `../mini-lsm`, including attempts to reconstruct the solution through Git history or an online copy.
 
-Starting in this directory is not a security sandbox: an agent can still traverse to a parent directory if instructed. The local `AGENTS.md` therefore explicitly prohibits reading, searching, diffing, or copying `../mini-lsm/`, including attempts to reconstruct the solution through Git history or an online copy.
-
-Do not open the whole repository as the agent's workspace if your tool lets you choose a directory. Open `mini-lsm-starter`. The agent may consult the copied tests, starter interfaces, Rust documentation, and course chapters under `../mini-lsm-book/src/`.
+Do not open the whole repository as the agent's workspace if your tool lets you choose a directory. The agent may consult copied tests, starter interfaces, Rust documentation, and course chapters under `../mini-lsm-book/src/`.
 
 ### 3. Verify the Instructions Before Coding
 
 Do not assume the tool discovered `AGENTS.md`. Make the first prompt a handshake that performs no implementation:
 
-> Before editing anything, confirm that your working directory is `mini-lsm-starter` and read `./AGENTS.md`. Summarize its hard boundaries and working agreement. You must never inspect or copy the reference solution in `../mini-lsm`, directly or indirectly. Tell me which local sources you are allowed to use, then stop without changing files.
+> Before editing anything, confirm that your working directory is `mini-lsm-starter` and read `./AGENTS.md`. Summarize its reference-solution boundary, test protections, and student-owned design protocol. Explain which choices require a stop and which mechanical coding choices do not. Tell me which local sources you may use, then stop without changing files.
 
-If the response omits the reference-solution boundary, test protection, or checkpoint stops, correct the agent before continuing. If the tool cannot load repository instructions automatically, paste the contents of `AGENTS.md` into its persistent project instructions.
+If the response omits the reference-solution boundary, test protection, or one-decision-at-a-time stop, correct the agent before continuing. If the tool cannot load repository instructions automatically, paste `AGENTS.md` into its persistent project instructions.
 
-## Prompt the Agent in Reviewable Steps
+## The Design-and-Test Loop
 
-A useful prompt states the scope, invariant, evidence, and stopping point. “Implement everything and make the tests pass” gives the agent no reason to expose its assumptions and gives you no natural place to inspect them.
+Begin a checkpoint with an ordinary capability request:
 
-Use three kinds of prompts throughout the fast-forward track.
+> Implement block format.
 
-### Prompt 1: Ask for a Model, Not Code
+That prompt authorizes the learning process, not a one-shot patch. The agent should inspect allowed context and ask its first design question. It should not return a complete design, edit code, or run ahead to a passing suite.
 
-Each day begins with a task-specific kickoff prompt. Ask the agent to map the system, state its invariants, divide the work into checkpoints, identify ambiguities, and ask you to predict a boundary case before it edits anything. The day page provides the concrete prompt.
+Repeat this loop:
 
-Answer the prediction before asking the agent to evaluate it. This turns the first exchange into a check of your current model rather than a generated summary to skim.
+1. **Agent asks one decision.** It labels the question as a fixed contract to derive or an open design choice, gives the invariant or concrete case, explains real alternatives when they exist, and asks you to choose or predict.
+2. **Student reasons.** State a choice and why. A prediction is useful even when you are uncertain.
+3. **Agent checks the reasoning.** It connects the answer to interfaces, prose, or tests. If the answer violates a constraint, it shows the evidence and asks again instead of silently overriding you.
+4. **Agent records the choice.** The accepted answer enters a short decision ledger.
+5. **Agent implements one slice.** Once enough decisions specify a coherent slice, it previews the files, behavior, and focused test and waits for your authorization.
+6. **Tests produce evidence.** A coding mistake can be fixed directly. A failure that exposes an unsettled or incorrect design returns to the dialogue.
+7. **Student reviews.** Inspect the diff and test output before authorizing the next slice.
 
-### Prompt 2: Implement One Checkpoint
+The agent must stop on topics that affect behavior or understanding: representation, ordering, ownership, size and boundary accounting, seek semantics, error behavior, synchronization, and optimization placement. Some answers are fixed by the course protocol and must be derived; others are genuine choices. It need not interrupt you over a local variable name, import order, formatting, or an obvious compiler-directed repair.
 
-Use a fresh prompt for each checkpoint. You choose the checkpoint; the agent must not infer that passing one checkpoint authorizes it to begin the next:
+The distinction keeps the conversation educational without turning every keystroke into ceremony.
 
-> Implement only Checkpoint `<number and name>`. Before editing, restate the invariants for this checkpoint and list the files you expect to change. Keep the diff focused and do not modify supplied tests, public interfaces, or unrelated code.
->
-> Run focused checks while working. When the checkpoint is implemented, stop and report the changed behavior, the exact commands and results, one remaining uncertainty, and one adversarial case that I should predict. Do not continue to the next checkpoint.
+## Keep a Decision Ledger
 
-A checkpoint may require several internal iterations, but it should produce one coherent diff that you can review before the next subsystem depends on it.
+Ask the agent to maintain this table during each checkpoint:
 
-### Prompt 3: Challenge the Result
+| Decision or constraint | Student's conclusion | Invariant or evidence | Consequence |
+| --- | --- | --- | --- |
+| Example: exact-size block | Accept it | The limit is inclusive | Reject only when projected size is greater than the target. |
 
-After inspecting the diff and answering the agent's boundary question, ask for evidence rather than reassurance:
+The ledger makes hidden assumptions reviewable. It also prevents a required course constraint from being presented as a free preference, and lets you distinguish a coding bug from code that faithfully implements a bad decision.
 
-> Review this checkpoint as an untrusted contribution. Connect each changed behavior to an invariant and a supplied test. Identify one plausible bug that could still pass those tests, propose the smallest additional test or manual check that exposes it, and wait for my approval before adding that test. If you find a real problem, explain the failing invariant before changing the implementation.
+You can delegate a decision when it is not where you want to spend learning time:
 
-Do not let “all tests pass” end the review. Conversely, do not ask the agent to invent speculative refactors once the checkpoint's contract and adversarial checks are satisfied.
+> Choose this one for me, explain the tradeoff, and record it as delegated. Continue asking me about the remaining decisions.
 
-Repeat Prompts 2 and 3 for each checkpoint. The checkpoint stops are where you catch a locally reasonable decision before it spreads across the system.
+Delegating one choice is not permission for the agent to decide the rest.
+
+## Review a Code Slice
+
+Before each edit, the agent should state:
+
+- which accepted decisions determine the slice;
+- which files and observable behavior will change; and
+- which focused check it expects to exercise that behavior.
+
+After the edit, require the exact command and result, then ask:
+
+> Treat this slice as untrusted. Connect the changed behavior to the decision ledger and supplied tests. Identify one plausible bug that could still pass, propose the smallest adversarial check, and ask me to predict its outcome before adding it.
+
+Do not let “all tests pass” end the review. Conversely, once the contract and adversarial checks are satisfied, continue to the next unresolved decision instead of inventing unrelated refactors.
 
 When the workspace is prepared and the instruction handshake succeeds, continue to [Day 1 - Mini-LSM](./week1-fast-forward.md).
 

--- a/mini-lsm-book/src/week1-fast-forward.md
+++ b/mini-lsm-book/src/week1-fast-forward.md
@@ -11,7 +11,7 @@ put/delete -> mutable memtable -> immutable memtables -> L0 SSTs
                      \____________ read + merge ____________/
 ```
 
-Use the existing Mini-LSM chapters as a reference library when you need a deeper explanation. You do not need to follow them one chapter at a time.
+You decide consequential behavior; the agent handles mechanical implementation. A short request begins a design interview; it must not produce a complete implementation in one turn.
 
 ## The Completion Contract
 
@@ -23,72 +23,77 @@ At the end of this path:
 - the complete supplied test suite passes; and
 - you can trace a key through the engine, explain why the newest value wins, and design a test for a plausible bug.
 
-The tests are evidence, not the specification. Generated code remains untrusted until you can connect it to an invariant and try to falsify it.
+The tests are evidence, not the specification. Generated code remains untrusted until you can connect it to a decision and an invariant and try to falsify it.
 
 ## Copy the Complete Test Suite
 
-Complete the repository and agent preparation in the [track overview](./agent-fast-forward-overview.md#prepare-the-repository-and-the-agent). Leave the agent at the instruction-handshake stop, then run these commands from the repository root. The original course reveals tests one chapter at a time; Day 1 starts with the complete acceptance suite:
+Complete the repository and agent preparation in the [track overview](./agent-fast-forward-overview.md#prepare-the-repository-and-the-agent). Leave the agent at the instruction-handshake stop, then run these commands from the repository root:
 
 ```shell
 cargo x copy-test --week 1
 cargo x scheck
 ```
 
-The initial check should fail because the starter contains unfinished code. Record the first failure; it gives you a reproducible baseline. Do not ask the agent to make this failure disappear by changing the tests.
+The initial check should fail because the starter contains unfinished code. Record the first failure as a reproducible baseline. Do not ask the agent to make it disappear by changing the tests.
 
 ## Start Day 1
 
-With the agent running from `mini-lsm-starter`, the instruction handshake complete, and the test suite copied, send this kickoff prompt:
+With the agent running from `mini-lsm-starter`, the instruction handshake complete, and the tests copied, send:
 
-> We are completing Mini-LSM in this starter directory. Use the starter interfaces, copied acceptance tests, and Mini-LSM book chapters, but never access `../mini-lsm`. Do not edit yet.
->
-> Return:
->
-> 1. a map of the write, read, and flush paths;
-> 2. the ordering, ownership, and file-format invariants that connect their components;
-> 3. an implementation plan divided into the three checkpoints on this page; and
-> 4. any ambiguity you found between the prose, interfaces, and tests.
->
-> Ask me to predict one important boundary case, then stop.
+> Implement the Mini-LSM write, read, and flush paths. Follow the student-owned design protocol in `AGENTS.md`. Ask one design decision at a time, record my accepted choices, and do not edit until those choices specify one coherent slice. Never access `../mini-lsm`.
 
-Answer the prediction before asking the agent to evaluate it. This turns the first exchange into a check of your current model rather than a generated summary to skim.
+The first useful response is a question, not an architecture essay or a patch. It will usually ask you to choose the first checkpoint. Select one of the three below and explain why it is a useful boundary.
 
-When its plan matches the three checkpoints below, choose the first checkpoint and use the overview's implementation and challenge prompts. Begin each later checkpoint only when you explicitly ask the agent to do so.
+For each checkpoint, the tables below are an audit guide for you. Do not paste a whole table back as a ready-made specification. Make the agent elicit one topic at a time, label it as a fixed contract or an open choice, and use the table afterward to check whether the dialogue covered the important ground.
 
 ## Checkpoint 1: Ordered State
 
-Have the agent implement the memtable and iterator layers. Use the [Memtable](./week1-01-memtable.md) and [Merge Iterator](./week1-02-merge-iterator.md) chapters when the code or tests do not explain a decision.
+Ask:
 
-The resulting implementation must preserve these properties:
+> Implement ordered in-memory state.
 
-| Invariant | How to challenge it |
+This checkpoint covers the memtable and iterator layers. Use the [Memtable](./week1-01-memtable.md) and [Merge Iterator](./week1-02-merge-iterator.md) chapters when a question needs more context.
+
+The agent should stop on at least these contract topics and ask you to derive the required behavior:
+
+| Decision | Case that exposes it |
 | --- | --- |
-| A memtable exposes keys in bytewise sorted order. | Insert keys out of order, then scan them. |
-| Rewriting a key leaves only its newest value visible. | Put two values for one key before reading it. |
-| An empty value is a tombstone, not a reason to search older state. | Delete a key that still has a value in an older memtable. |
-| Merge inputs are ordered by recency, and the earlier input wins equal keys. | Reverse two inputs containing the same key and predict the changed result. |
-| Iterators remain fused after exhaustion or error. | Call `next` again and verify that iteration does not resume. |
+| Memtable ordering | Insert keys out of bytewise order, then scan. |
+| Duplicate precedence inside a memtable | Put two values for one key before reading it. |
+| Tombstone representation | Delete a key that still has a value in older state. |
+| Equal-key precedence across merge inputs | Reverse two inputs containing the same key. |
+| Iterator behavior after exhaustion or error | Call `next` again and check that iteration cannot resume. |
+| Write/freeze synchronization | Interleave insertion with a concurrent memtable freeze. |
 
-An ordinary write must retain the `state` read guard until insertion into the mutable memtable completes. Writing through a cloned snapshot after releasing the guard creates a race in which a concurrent freeze can make that memtable immutable before the write occurs.
+One critical outcome is that an ordinary write retains the `state` read guard until insertion into the mutable memtable completes. Writing through a cloned snapshot after releasing the guard permits a concurrent freeze to make that memtable immutable before the write occurs.
 
-Before approving this checkpoint, ask the agent to point to the exact comparison that resolves duplicate keys. Then explain in your own words why changing `>` to `>=`, or reversing the input order, would affect correctness.
+Once the representation and precedence choices are settled, authorize the smallest coherent slice. After its focused test passes, ask the agent to identify the exact comparison that resolves duplicate keys. Explain in your own words why changing `>` to `>=`, or reversing input order, changes the visible value.
 
 ## Checkpoint 2: Durable Representation
 
-Have the agent implement blocks, block iterators, SST builders, SST readers, and SST iterators. Consult [Block](./week1-03-block.md), [Sorted String Table](./week1-04-sst.md), and [SST Optimizations](./week1-07-sst-optimizations.md) as needed.
+Ask:
 
-Because this path copies all seven test suites at the start, implement the final Day 7 prefix-compressed block format directly. There is no learning value in first implementing Day 3's uncompressed key layout only to replace it during the same checkpoint.
+> Implement the durable block and SST representation.
 
-Treat the file format as a protocol between the writer and reader. Check these properties:
+This checkpoint covers blocks, block iterators, SST builders, SST readers, SST iterators, Bloom filters, and final prefix compression. Consult [Block](./week1-03-block.md), [Sorted String Table](./week1-04-sst.md), and [SST Optimizations](./week1-07-sst-optimizations.md) when a question requires deeper context.
 
-- entries and offsets agree on exact byte boundaries;
-- a seek returns the first key greater than or equal to its target;
-- the first and last keys in SST metadata describe the actual key range;
-- an oversized entry still produces a valid block rather than an empty table or loop;
-- every prefix-compressed key decodes to its original bytes; and
-- Bloom filters may return false positives but never false negatives.
+Because this path copies all seven test suites at the start, the accepted design should converge directly on the final Day 7 prefix-compressed block format. Do not first implement the Day 3 layout and silently replace it. The agent should explicitly ask which acceptance target applies and record that choice.
 
-Use this exact high-level SST trailer grammar so the writer and reader agree on where each variable-length section ends:
+First derive the parts fixed by the course contract:
+
+| Contract | Case that exposes it |
+| --- | --- |
+| Integer encoding and exact block layout | Independently decode a three-entry block. |
+| Inclusive target-size accounting | Add an entry that makes the encoded block exactly the target size. |
+| Oversized first entry | Try to add a single representable record larger than the target. |
+| Prefix basis and reconstruction | Mix keys with a long shared prefix and no shared prefix. |
+| Lower-bound seek semantics | Seek before, between, at, and after stored keys. |
+| SST trailer placement | Locate metadata and Bloom sections from the end of the file. |
+| Bloom-filter authority | Compare a definite negative with a possible positive. |
+
+Then make the genuinely open implementation choices, such as linear versus binary lower-bound search when both satisfy the interface, allocation versus reuse for reconstructed keys, and how much malformed-input checking to add without changing the provided API. Record required protocol facts as constraints and open selections as choices.
+
+The high-level SST trailer grammar is:
 
 ```text
 blocks | metadata | metadata_offset:u32 | bloom | bloom_offset:u32
@@ -96,15 +101,59 @@ blocks | metadata | metadata_offset:u32 | bloom | bloom_offset:u32
 
 The final four bytes contain `bloom_offset`; the metadata offset is the four-byte field immediately before the Bloom section, at `bloom_offset - 4`.
 
-Ask the agent to sketch one encoded block, including its entries and offset table, using three short keys. Decode the sketch manually. A convincing explanation of the format is more valuable than a summary of the Rust functions.
+Treat the writer and reader as two parties implementing a protocol. A round-trip test alone can miss an encoder and decoder that agree with each other but disagree with the specified bytes. Ask for at least one independently calculated byte layout.
 
-For an adversarial check, use keys with no shared prefix, a long shared prefix, and an empty value. Confirm that encoding and decoding preserve all three cases.
+### Illustrative Dialogue: “Implement Block Format”
+
+This is a condensed example of the expected interaction, including representative command output rather than a transcript captured from your machine. It targets the final prefix-compressed format required by fast-forward Day 1.
+
+> **Student:** Implement block format.
+>
+> **Agent:** This can be split into builder/encoding and iterator/seek slices. Which slice should establish the contract first, and why?
+>
+> **Student:** Builder and encoding first. The iterator consumes that representation, while encoding can be checked independently against exact bytes.
+>
+> **Agent:** Contract derivation: the full Week 1 suite is installed. Should this slice implement the earlier uncompressed Day 3 entry or the final Day 7 prefix-compressed entry? What evidence decides?
+>
+> **Student:** The final Day 7 format. Replacing an intermediate format inside the same checkpoint would be throwaway work, and the installed acceptance target includes prefix compression.
+>
+> **Agent:** Contract derivation: a compressed key can be relative to the previous key or the first key in the block. Which basis does the course require, and what does it permit an iterator to do?
+>
+> **Student:** Use the first key. Then any entry can be reconstructed independently once the first key is known; using the previous key would require decoding the chain before it.
+>
+> **Agent:** Derive the projected encoded size for a new entry with `rest_key_len` suffix bytes and decide whether an exact fit is admitted.
+>
+> **Student:** For `n` existing entries: `data.len() + 2 + 2 + rest_key_len + 2 + value.len() + 2 * (n + 1) + 2`. The fields are overlap length, suffix length, suffix, value length, value, all offsets after the add, and the one final count. Equality fits.
+>
+> **Agent:** Open choice: because first-key compression makes an arbitrary entry independently decodable, lower-bound seek can scan linearly or binary-search offsets. Which do you want?
+>
+> **Student:** Binary search. The entries are sorted, and independent reconstruction makes each comparison possible without decoding all preceding entries.
+>
+> **Agent:** Open choice: `decode` has no error return. Should this checkpoint trust encoder-produced bytes, add assertions that still panic, or request an interface change to return `Result`?
+>
+> **Student:** Trust encoder-produced bytes for this checkpoint and document the boundary. A production decoder should return `Result` and validate counts, offsets, and lengths, but changing the interface is outside scope.
+>
+> **Agent:** The slice is specified. I will change `src/block/builder.rs`, `src/block.rs`, and `src/block/iterator.rs`, then run `cargo test --lib tests::week1_day7::test_task3_block_key_compression`. Prediction first: with empty values, `mini-a` encodes as an overlap of 0 plus a six-byte suffix, and `mini-b` as an overlap of 5 plus a one-byte suffix. What are the two entry offsets and final encoded size?
+>
+> **Student:** The first entry is 12 bytes and starts at 0. The second is 7 bytes and starts at 12. Two offsets and the final count add 6 bytes, so the encoded block is 25 bytes. I authorize this slice.
+>
+> **Agent:** Implemented only the authorized block slice. `cargo test --lib tests::week1_day7::test_task3_block_key_compression` exited 0. The entries reconstructed as `mini-a` and `mini-b`, the empty values survived, and the encoded length was 25 bytes. I did not begin the SST layer. One remaining weakness is that the supplied valid-block tests do not establish safe behavior for malformed offsets. Before I add an adversarial test, predict what the current trusted decoder would do with an offset beyond the data section.
+
+The final agent turn contains evidence, a checkpoint stop, and a new question. It does not treat a passing test as permission to continue. In a real session, inspect the diff and actual command output before accepting that report. An unexpected test failure either reveals a mechanical bug or reopens one specific decision.
+
+Before approving the completed checkpoint, decode three keys by hand: one with no shared prefix, one with a long shared prefix, and one with an empty value. Confirm that a seek returns the first key greater than or equal to its target and that a Bloom-filter negative can never hide a present key.
 
 ## Checkpoint 3: One Logical Engine
 
-Have the agent connect the read path, write path, freezing, flushing, SST filtering, Bloom-filter lookup, and iterator accounting. Use [Read Path](./week1-05-read-path.md) and [Write Path](./week1-06-write-path.md) when reviewing the integration.
+Ask:
 
-The central rule is:
+> Connect the components into one logical engine.
+
+This checkpoint covers the read path, write path, freezing, flushing, SST filtering, and iterator accounting. Use [Read Path](./week1-05-read-path.md) and [Write Path](./week1-06-write-path.md) when a decision needs more context.
+
+The agent must lead contract derivations for source ordering, tombstone filtering, scan bounds, flush selection, and lifecycle behavior. It should separately ask about open implementation choices such as iterator composition, lock scope that still preserves the synchronization contract, and where to perform expensive SST construction.
+
+The central source-priority rule should emerge from those choices:
 
 ```text
 mutable memtable
@@ -112,9 +161,9 @@ mutable memtable
   > L0 SSTs, newest to oldest
 ```
 
-For a duplicate key, the first visible entry wins. If that entry is a tombstone, the key is absent; an older value must not be resurrected.
+For a duplicate key, the first visible entry wins. If it is a tombstone, the key is absent; an older value must not be resurrected.
 
-Review the following state transition carefully:
+Review the flush transition with concrete state:
 
 ```text
 before: imm = [newest, ..., oldest], L0 = [newest, ..., oldest]
@@ -124,9 +173,9 @@ after:  remove exactly that memtable and insert its SST at the newest side of L0
 
 Expensive SST construction and I/O should happen outside the `state` read-write lock. Structural changes still need `state_lock` so two flushes cannot select and install the same memtable concurrently.
 
-For Day 1, `close` stops and joins the existing worker threads and is harmless when called again after their handles have already been taken. It does not implicitly flush the remaining mutable memtable. If you choose a different lifecycle contract, state it and add tests before changing the implementation.
+For Day 1, the lifecycle contract is fixed: `close` stops and joins the existing worker threads and is harmless when called again after their handles have already been taken. It does not implicitly flush the remaining mutable memtable. Treat a different contract as an explicit scope change, not an ordinary implementation preference.
 
-Before approving this checkpoint, construct one key that appears in the mutable memtable, an immutable memtable, and an L0 SST. Predict `get` and `scan` results when the newest entry is first a value and then a tombstone. Also exercise included, excluded, and unbounded scan endpoints.
+Before approving this checkpoint, construct one key that appears in the mutable memtable, an immutable memtable, and an L0 SST. Predict `get` and `scan` when the newest entry is first a value and then a tombstone. Also exercise included, excluded, and unbounded scan endpoints.
 
 ## Audit the Finished Engine
 
@@ -138,12 +187,13 @@ cargo x scheck
 
 Then ask the agent for a final evidence report containing:
 
-1. the commands it ran and their outcomes;
-2. a data-flow trace for one `put`, one `get`, one bounded `scan`, and one flush;
-3. the source-priority rule used by both point reads and scans;
-4. one concurrency risk around freezing or flushing and the synchronization that prevents it;
-5. one optimization that must not alter logical results; and
-6. one weakness or boundary case not established by the supplied tests.
+1. the combined decision ledgers and any delegated choices;
+2. the commands it ran and their outcomes;
+3. a data-flow trace for one `put`, one `get`, one bounded `scan`, and one flush;
+4. the source-priority rule used by both point reads and scans;
+5. one concurrency risk around freezing or flushing and the synchronization that prevents it;
+6. one optimization that must not alter logical results; and
+7. one weakness or boundary case not established by the supplied tests.
 
 Review actual diffs and test output, not only the report. Search for removed assertions, changed tests, broad lint suppressions, and error paths replaced with `unwrap` without justification.
 

--- a/mini-lsm-starter/AGENTS.md
+++ b/mini-lsm-starter/AGENTS.md
@@ -2,9 +2,9 @@
 
 ## Purpose
 
-This directory is a learning workspace. You may write implementation code, but optimize for the student's understanding and ability to review the system, not for finishing the repository with the fewest interactions.
+This directory is a learning workspace. You may write implementation code, but optimize for the student's understanding and ability to make the system's design decisions, not for finishing the repository with the fewest interactions.
 
-The student owns the specification and the proof of correctness. Treat your code as an untrusted contribution that must be explained, tested, and challenged.
+The student owns the explicit design decisions permitted by the course contract and must be able to defend the resulting specification and proof of correctness. Treat your code as an untrusted contribution that must be explained, tested, and challenged.
 
 ## Hard Boundaries
 
@@ -19,34 +19,66 @@ The student owns the specification and the proof of correctness. Treat your code
 
 You may consult the Mini-LSM chapters in `../mini-lsm-book/src/`, Rust and dependency documentation, and the starter code's existing interfaces. External documentation is for understanding APIs and concepts, not for locating another Mini-LSM solution.
 
-## Working Agreement
+## Student-Owned Design Protocol
 
-Before editing code:
+A request such as “implement block format” starts a design dialogue. It does not authorize you to silently choose the representation, boundary behavior, algorithm, or failure semantics and return a finished patch.
+
+Before editing:
 
 1. Inspect the relevant starter interfaces, copied tests, and book sections.
-2. Describe the data flow affected by the task.
-3. State the correctness invariants that the implementation must preserve.
-4. Propose a small implementation and validation plan.
-5. Ask the student to predict one important boundary case before revealing its result.
+2. Identify the checkpoint boundary and the decisions required to specify it.
+3. Ask about one consequential design decision, then stop.
+4. After the student answers, evaluate the answer against the interfaces, tests, and invariants. Correct a misunderstanding with evidence; do not quietly replace the student's choice.
+5. Record the accepted choice in a short decision ledger, then ask the next question.
+6. When the decisions needed for the next coherent code slice are settled, summarize that slice and its expected test, then wait for the student to authorize the edit.
+
+A consequential decision changes observable behavior, correctness, compatibility, or the student's mental model. Examples include data layout, ordering and duplicate precedence, size accounting, ownership, seek semantics, boundary conditions, error handling, synchronization, and which layer owns an optimization. Mechanical choices such as local variable names, import ordering, formatting, and an obvious compiler-directed type correction do not require a stop.
+
+Stop eliciting decisions when the public contract, supplied tests, and selected adversarial cases determine the next slice. Internal bookkeeping that follows an accepted invariant is mechanical. Do not invent hypothetical policy choices merely to prolong the interview.
+
+Ask questions that require reasoning. A decision question should contain:
+
+- the invariant or concrete case that makes the choice matter;
+- two or more viable choices and their tradeoffs, when alternatives really exist; and
+- one focused question asking the student to choose, predict, or explain.
+
+Do not dump the entire interview as a questionnaire. Ask one decision at a time so the next question can use the student's previous answer. Do not reveal the expected answer before the student attempts it. If only one choice is compatible with a provided interface or format, ask the student to derive it from that evidence and record it as a constraint, not a preference.
+
+Maintain a compact decision ledger during the checkpoint:
+
+```text
+Decision | Student's choice | Invariant/evidence | Consequence
+```
+
+The ledger is not a substitute for the dialogue. Maintain it without reprinting the full table after every answer. Show the consolidated ledger at slice authorization and in the checkpoint handoff.
+
+The student may explicitly delegate a decision. In that case, state your choice and reasoning and record that it was delegated. Do not interpret “use your judgment” for one decision as permission to choose the rest.
+
+## Checkpoints and Implementation
 
 The course material, not this file, defines the checkpoints and their system-specific invariants. The student directs their sequence. Do not choose or begin a checkpoint merely because the preceding checkpoint passed.
 
-A request that names one checkpoint authorizes work only on that checkpoint. Before editing, restate its scope and invariants and list the files you expect to change. If a request spans multiple checkpoints, present the plan and wait for the student to select the first one. Implement one checkpoint at a time, stop after each checkpoint for review, and do not continue until the student explicitly names the next checkpoint.
+A request that names one checkpoint authorizes work only on that checkpoint. If a request spans multiple checkpoints, ask the student to select the first one. Implement one reviewable slice at a time; stop whenever the next step would require an unsettled consequential decision.
 
-## Implementation and Debugging
+For each authorized slice:
 
-- Prefer the smallest coherent diff that satisfies the current checkpoint.
-- Preserve the starter's architecture and naming unless a local design change is necessary and explained.
-- Do not perform unrelated refactors while implementing a task.
-- Make one testable debugging hypothesis at a time. Use the smallest relevant check before stacking speculative fixes.
-- After three distinct failed approaches, summarize the evidence and ask the student for direction.
-- Never claim a test passed unless you ran it and saw a successful result.
-- Treat a passing supplied suite as necessary but not sufficient. Propose at least one adversarial example for each checkpoint and ask the student to predict its outcome. Add a new test only with the student's approval, and keep it separate from the provided tests.
-- If demonstrating a deliberate fault, begin from a clean, passing state, state the expected failure, and revert the fault immediately after the experiment.
+1. Restate the decisions and invariants that determine the code.
+2. List the files and behavior you expect to change.
+3. Make the smallest coherent diff that expresses those decisions.
+4. Run the narrowest relevant check and show the exact result.
+5. If the check fails, classify the failure as a coding mistake, an unsettled design decision, or evidence that an accepted decision was wrong.
+6. Fix mechanical coding mistakes directly. For either kind of design failure, return to one-question-at-a-time dialogue before changing the design.
+7. Stop for review before beginning another slice or checkpoint.
+
+Preserve the starter's architecture and naming unless a local design change is necessary and approved. Do not perform unrelated refactors. Make one testable debugging hypothesis at a time. After three distinct failed approaches, summarize the evidence and ask the student for direction.
+
+Never claim a test passed unless you ran it and saw a successful result. Treat a passing supplied suite as necessary but not sufficient. Propose at least one adversarial example for each checkpoint and ask the student to predict its outcome. Add a new test only with the student's approval, and keep it separate from the provided tests.
+
+If demonstrating a deliberate fault, begin from a clean, passing state, state the expected failure, and revert the fault immediately after the experiment.
 
 ## Validation
 
-Run focused tests while working. Before declaring Day 1 complete, run from the repository root:
+Run focused tests after each implementation slice. Before declaring Day 1 complete, run from the repository root:
 
 ```shell
 cargo x scheck
@@ -56,13 +88,14 @@ Also inspect the final diff for modified tests, removed assertions, new lint sup
 
 ## Handoff to the Student
 
-At each checkpoint stop, report:
+At each slice or checkpoint stop, report:
 
+- the decision ledger for the behavior implemented;
 - the files and behavior changed;
 - the invariants the code relies on;
 - the exact commands run and their outcomes;
 - one boundary case the supplied tests may not establish; and
-- one question the student should be able to answer before continuing.
+- the next unresolved design question, if any.
 
 Do not answer the final understanding question immediately. Let the student make a concrete attempt, then correct or extend their reasoning with evidence from the implementation.
 


### PR DESCRIPTION
## Why

The fast-forward track should compress implementation time without letting the coding agent silently make the system's design decisions. The existing checkpoint flow still encouraged a large upfront plan followed by a mostly one-shot implementation.

## What changes

- Make the student-agent loop one consequential decision at a time, with explicit slice authorization and a compact decision ledger.
- Distinguish fixed course constraints from genuinely open design choices, while giving the interview a clear stopping rule.
- Rework Day 1 around contract derivation, incremental implementation, focused evidence, and an illustrative final prefix-compressed block-format dialogue.

_AI-assisted: Codex._
