### PR TITLE
docs: expand the Mini-LSM coding-agent track

### DIFF
--- a/.agents/skills/validate-coding-agent-track/SKILL.md
+++ b/.agents/skills/validate-coding-agent-track/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: validate-coding-agent-track
+description: Validate Mini-LSM coding-agent course tracks and checkpoint chapters for technical correctness, executable agent workflow, plain-English learning stops, dependency order, testability, and consistency with the starter interfaces and source chapters. Use when drafting or reviewing agent-fast-forward material, guided coding-agent lessons, related AGENTS.md protocols, or changes to the three-day Mini-LSM agent track.
+---
+
+# Validate Coding-Agent Track
+
+Audit the material as instructions that a student and coding agent must actually execute. Check semantics against allowed repository evidence; do not review prose in isolation.
+
+## Workflow
+
+1. Identify the overview, day chapter, `mini-lsm-starter/AGENTS.md`, linked source chapters, and relevant starter interfaces or copied-test tooling.
+2. Respect the starter boundary: never inspect or reconstruct the reference implementation in `mini-lsm/`. Read `mini-lsm-book/src/`, `mini-lsm-starter/`, `xtask/`, and copied tests when present.
+3. Run `scripts/check_track.py` on the changed overview and day chapters. Resolve structural failures before the semantic audit.
+4. Trace the learner workflow from setup through completion. Verify that every command has the correct working directory, every prerequisite precedes its consumer, and every named test or tool exists.
+5. Audit each checkpoint using the criteria below.
+6. Report findings by severity with exact file and line references. Separate confirmed defects from optional improvements.
+7. Fix confirmed defects when authorized, rerun the script and `mdbook build`, then repeat the affected audit sections.
+
+## Checkpoint Criteria
+
+For every checkpoint, verify:
+
+- **Boundary:** The starting state, intended outcome, permitted files, and stopping point form one coherent slice.
+- **Coverage:** The material includes the consequential representation, ordering, ownership, boundary, error, concurrency, durability, and optimization decisions relevant to that slice.
+- **Classification:** A required course behavior is labeled **Course rule** and derived from evidence. Only genuinely interchangeable implementations are labeled **Your choice**.
+- **Question quality:** Stops begin with a small state, byte layout, crash point, or operation in plain English. Necessary terminology is introduced after the student can reason about the example.
+- **Escape hatches:** The first stop supports `simpler`, `example`, `hint`, and `choose for me` without treating one delegated answer as blanket delegation.
+- **Authorization:** The agent waits until the current slice is specified and authorized, then stops again after implementation and evidence.
+- **Evidence:** Focused checks exist for the slice. Passing tests are not treated as the specification, and at least one plausible adversarial case asks for a prediction.
+- **Teach-back:** Review connects one consequential line or comparison to the student's decision and asks what would break if it changed.
+- **Completion:** The student must explain data flow, invariants, a failure mode, and a test strategy rather than merely obtain a passing suite.
+
+## Cross-Checkpoint Audit
+
+Check the whole day for:
+
+- a default path that does not require unexplained architectural choices at the start;
+- ordering that avoids implementing an obsolete intermediate format;
+- consistent names, links, commands, and day outcomes across `SUMMARY.md` and the overview;
+- explicit handling of concurrent state changes, crashes, or partial failure where relevant;
+- no instructions to weaken tests, change public interfaces for convenience, or inspect the reference solution;
+- enough specification for an agent to proceed without inventing system behavior, but no answer dump that removes the student's reasoning; and
+- a realistic interaction budget: combine facts exposed by one scenario instead of manufacturing a stop for every function or local choice.
+
+## Validation Commands
+
+From the repository root, run:
+
+```shell
+python3 .agents/skills/validate-coding-agent-track/scripts/check_track.py \
+  mini-lsm-book/src/agent-fast-forward-overview.md \
+  mini-lsm-book/src/week1-fast-forward.md
+(cd mini-lsm-book && mdbook build)
+git diff --check
+```
+
+Replace or add day-chapter paths as needed. If `mdbook build` fails only because a serve command cannot bind a port, run the build subcommand directly as shown above.
+
+## Report Format
+
+Lead with a verdict: **ready**, **ready with improvements**, or **not ready**. Then list:
+
+1. blocking correctness or execution defects;
+2. learning-flow defects that could cause one-shotting, confusion, or fake choices;
+3. optional refinements; and
+4. commands run and their outcomes.
+
+Do not claim readiness when an essential step depends on an unstated design decision or nonexistent command. Do not fail content merely because wording differs from earlier days when the same learning contract remains clear.

--- a/.agents/skills/validate-coding-agent-track/agents/openai.yaml
+++ b/.agents/skills/validate-coding-agent-track/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Validate Coding-Agent Track"
+  short_description: "Review coding-agent course tracks for usability"
+  default_prompt: "Use $validate-coding-agent-track to audit this coding-agent course chapter for correctness and agent usability."

--- a/.agents/skills/validate-coding-agent-track/scripts/check_track.py
+++ b/.agents/skills/validate-coding-agent-track/scripts/check_track.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Check local links and balanced Markdown/HTML containers in agent-track chapters."""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+from urllib.parse import unquote
+
+
+LINK_RE = re.compile(r"(?<!!)\[[^\]]*\]\(([^)]+)\)")
+
+
+def check_file(path: Path) -> list[str]:
+    errors: list[str] = []
+    text = path.read_text(encoding="utf-8")
+
+    if text.count("```") % 2:
+        errors.append(f"{path}: unbalanced fenced code block")
+    if text.count("<details>") != text.count("</details>"):
+        errors.append(f"{path}: unbalanced <details> block")
+
+    for line_number, line in enumerate(text.splitlines(), start=1):
+        for raw_target in LINK_RE.findall(line):
+            target = raw_target.split(maxsplit=1)[0].strip("<>")
+            if not target or target.startswith(("#", "http://", "https://", "mailto:")):
+                continue
+            local_part = unquote(target.split("#", 1)[0])
+            if local_part and not (path.parent / local_part).exists():
+                errors.append(f"{path}:{line_number}: missing local link target {target}")
+
+    return errors
+
+
+def main(argv: list[str]) -> int:
+    if not argv:
+        print("usage: check_track.py MARKDOWN_FILE [MARKDOWN_FILE ...]", file=sys.stderr)
+        return 2
+
+    errors: list[str] = []
+    for value in argv:
+        path = Path(value)
+        if not path.is_file():
+            errors.append(f"{path}: file does not exist")
+            continue
+        errors.extend(check_file(path))
+
+    if errors:
+        print("agent-track structural checks failed:", file=sys.stderr)
+        for error in errors:
+            print(f"- {error}", file=sys.stderr)
+        return 1
+
+    print(f"agent-track structural checks passed for {len(argv)} file(s)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/mini-lsm-book/src/SUMMARY.md
+++ b/mini-lsm-book/src/SUMMARY.md
@@ -38,6 +38,7 @@
 
 - [Mini-LSM with Coding Agents](./agent-fast-forward-overview.md)
   - [Day 1 - Build the Storage Engine](./week1-fast-forward.md)
+  - [Day 2 - Compaction and Recovery](./week2-fast-forward.md)
 
 ---
 

--- a/mini-lsm-book/src/SUMMARY.md
+++ b/mini-lsm-book/src/SUMMARY.md
@@ -36,8 +36,8 @@
   - [Snack Time: Compaction Filters](./week3-07-compaction-filter.md)
 - [The Rest of Your Life (TBD)](./week4-overview.md)
 
-- [Agent Fast Forward in 3 Days](./agent-fast-forward-overview.md)
-  - [Day 1 - Mini-LSM](./week1-fast-forward.md)
+- [Mini-LSM with Coding Agents](./agent-fast-forward-overview.md)
+  - [Day 1 - Build the Storage Engine](./week1-fast-forward.md)
 
 ---
 

--- a/mini-lsm-book/src/agent-fast-forward-overview.md
+++ b/mini-lsm-book/src/agent-fast-forward-overview.md
@@ -2,13 +2,13 @@
   mini-lsm-book © 2022-2026 by Alex Chi Z is licensed under CC BY-NC-SA 4.0
 -->
 
-# Agent Fast Forward in 3 Days (WIP)
+# Mini-LSM with Coding Agents (WIP)
 
-This is an alternative course track for students who intend to use a coding agent. The agent will write much of the code, but it must not silently design the system for you. Each day is a dialogue in which you make the consequential decisions, the agent turns a few accepted decisions into a small code change, and tests challenge the shared model.
+This is a three-day guided track for students who intend to use a coding agent. The agent will write much of the code, but it must not silently design the system for you. You will reason about concrete examples, the agent will turn a few accepted decisions into a small code change, and tests will challenge your shared model.
 
-Fast forward means compressing implementation time, not compressing the design into one generated answer.
+The goal is not to finish with the fewest prompts. It is to finish able to explain, test, and change the system the agent helped you build.
 
-| Fast-forward day | Original course material | Outcome |
+| Guided day | Original course material | Outcome |
 | --- | --- | --- |
 | [Day 1](./week1-fast-forward.md) | Mini-LSM | A working storage engine with memtables, SSTs, reads, writes, and flushes. |
 | Day 2 | Compaction and persistence | Coming later. |
@@ -68,7 +68,7 @@ That prompt authorizes the learning process, not a one-shot patch. The agent sho
 
 Repeat this loop:
 
-1. **Agent asks one decision.** It labels the question as a fixed contract to derive or an open design choice, gives the invariant or concrete case, explains real alternatives when they exist, and asks you to choose or predict.
+1. **Agent gives one short stop.** It starts with a concrete example, labels the question **Course rule** or **Your choice**, and asks you to choose or predict in plain English.
 2. **Student reasons.** State a choice and why. A prediction is useful even when you are uncertain.
 3. **Agent checks the reasoning.** It connects the answer to interfaces, prose, or tests. If the answer violates a constraint, it shows the evidence and asks again instead of silently overriding you.
 4. **Agent records the choice.** The accepted answer enters a short decision ledger.
@@ -76,9 +76,28 @@ Repeat this loop:
 6. **Tests produce evidence.** A coding mistake can be fixed directly. A failure that exposes an unsettled or incorrect design returns to the dialogue.
 7. **Student reviews.** Inspect the diff and test output before authorizing the next slice.
 
-The agent must stop on topics that affect behavior or understanding: representation, ordering, ownership, size and boundary accounting, seek semantics, error behavior, synchronization, and optimization placement. Some answers are fixed by the course protocol and must be derived; others are genuine choices. It need not interrupt you over a local variable name, import order, formatting, or an obvious compiler-directed repair.
+The agent must stop on topics that affect behavior or understanding: representation, ordering, ownership, size and boundary accounting, seek behavior, errors, synchronization, and where an optimization belongs. Some answers are course rules to derive; others are genuine choices. It need not interrupt you over a local variable name, import order, formatting, or an obvious compiler-directed repair.
 
 The distinction keeps the conversation educational without turning every keystroke into ceremony.
+
+At any stop, you can answer with one of these commands:
+
+- `simpler` — ask the same question with shorter sentences and less terminology;
+- `example` — show the smallest concrete example that exposes the behavior;
+- `hint` — reveal one useful fact, then let you try again; or
+- `choose for me` — let the agent decide this one, explain why, and record it as delegated.
+
+Here is the intended shape of a stop:
+
+> **Course rule — Which value should be visible?**
+>
+> We write `cat = old`, freeze that memory table, then write `cat = new`.
+>
+> What should `get("cat")` return, and why?
+>
+> You can reply `simpler`, `example`, `hint`, or `choose for me`.
+
+After you answer, the agent can name the general rule—here, newest-value precedence—and connect it to the implementation. A question should teach the terminology, not require you to decode it before you can begin.
 
 ## Keep a Decision Ledger
 
@@ -107,6 +126,8 @@ Before each edit, the agent should state:
 After the edit, require the exact command and result, then ask:
 
 > Treat this slice as untrusted. Connect the changed behavior to the decision ledger and supplied tests. Identify one plausible bug that could still pass, propose the smallest adversarial check, and ask me to predict its outcome before adding it.
+
+The agent should also point to one important changed line and ask: “What is this line trying to do, and what behavior might break if it changed?” The purpose is to connect a decision to code, not to quiz you on arbitrary syntax.
 
 Do not let “all tests pass” end the review. Conversely, once the contract and adversarial checks are satisfied, continue to the next unresolved decision instead of inventing unrelated refactors.
 

--- a/mini-lsm-book/src/agent-fast-forward-overview.md
+++ b/mini-lsm-book/src/agent-fast-forward-overview.md
@@ -11,7 +11,7 @@ The goal is not to finish with the fewest prompts. It is to finish able to expla
 | Guided day | Original course material | Outcome |
 | --- | --- | --- |
 | [Day 1](./week1-fast-forward.md) | Mini-LSM | A working storage engine with memtables, SSTs, reads, writes, and flushes. |
-| Day 2 | Compaction and persistence | Coming later. |
+| [Day 2](./week2-fast-forward.md) | Compaction and persistence | Background compaction, restart recovery, and checksummed disk formats. |
 | Day 3 | MVCC | Coming later. |
 
 The original chapters remain a reference library. This track changes the pacing and the student's role; it does not remove the need to understand ordering, representation, concurrency, and failure modes.

--- a/mini-lsm-book/src/week1-fast-forward.md
+++ b/mini-lsm-book/src/week1-fast-forward.md
@@ -2,18 +2,18 @@
   mini-lsm-book © 2022-2026 by Alex Chi Z is licensed under CC BY-NC-SA 4.0
 -->
 
-# Day 1 - Mini-LSM
+# Day 1 - Build the Storage Engine
 
-This is the first day of [Agent Fast Forward in 3 Days](./agent-fast-forward-overview.md). You will use a coding agent to build and defend one working storage engine from the original Mini-LSM material:
+This is the first day of [Mini-LSM with Coding Agents](./agent-fast-forward-overview.md). You will use a coding agent to build, test, and explain one working storage engine from the original Mini-LSM material:
 
 ```text
 put/delete -> mutable memtable -> immutable memtables -> L0 SSTs
                      \____________ read + merge ____________/
 ```
 
-You decide consequential behavior; the agent handles mechanical implementation. A short request begins a design interview; it must not produce a complete implementation in one turn.
+You decide behavior that affects correctness or the design; the agent handles mechanical implementation. A short request begins a guided dialogue, not a complete implementation in one turn.
 
-## The Completion Contract
+## What You Will Finish
 
 At the end of this path:
 
@@ -40,11 +40,11 @@ The initial check should fail because the starter contains unfinished code. Reco
 
 With the agent running from `mini-lsm-starter`, the instruction handshake complete, and the tests copied, send:
 
-> Implement the Mini-LSM write, read, and flush paths. Follow the student-owned design protocol in `AGENTS.md`. Ask one design decision at a time, record my accepted choices, and do not edit until those choices specify one coherent slice. Never access `../mini-lsm`.
+> Build Day 1 with me, starting with ordered in-memory state. Follow the student-owned design protocol in `AGENTS.md` and never access `../mini-lsm`. Before coding, ask one short question at a time using a concrete example. Use plain English and introduce technical terms after I answer. Mark each question **Course rule** or **Your choice**. I may reply `simpler`, `example`, `hint`, or `choose for me`. Do not edit until my answers specify one small, coherent slice. After each slice, show me one important line and ask what it does and what would break if it changed.
 
-The first useful response is a question, not an architecture essay or a patch. It will usually ask you to choose the first checkpoint. Select one of the three below and explain why it is a useful boundary.
+The first useful response is a concrete question about ordered state, not an architecture essay or a patch. Starting with Checkpoint 1 gives you one predictable path through the day. You may reorder checkpoints if you already understand their dependencies.
 
-For each checkpoint, the tables below are an audit guide for you. Do not paste a whole table back as a ready-made specification. Make the agent elicit one topic at a time, label it as a fixed contract or an open choice, and use the table afterward to check whether the dialogue covered the important ground.
+The tables below are audit guides. Do not paste a whole table back as a ready-made specification. Let the agent elicit one topic at a time, and use the table afterward to check whether the dialogue covered the important ground.
 
 ## Checkpoint 1: Ordered State
 
@@ -54,9 +54,9 @@ Ask:
 
 This checkpoint covers the memtable and iterator layers. Use the [Memtable](./week1-01-memtable.md) and [Merge Iterator](./week1-02-merge-iterator.md) chapters when a question needs more context.
 
-The agent should stop on at least these contract topics and ask you to derive the required behavior:
+The agent should use concrete examples to help you work out at least these course rules:
 
-| Decision | Case that exposes it |
+| Behavior to work out | Small case that exposes it |
 | --- | --- |
 | Memtable ordering | Insert keys out of bytewise order, then scan. |
 | Duplicate precedence inside a memtable | Put two values for one key before reading it. |
@@ -67,7 +67,7 @@ The agent should stop on at least these contract topics and ask you to derive th
 
 One critical outcome is that an ordinary write retains the `state` read guard until insertion into the mutable memtable completes. Writing through a cloned snapshot after releasing the guard permits a concurrent freeze to make that memtable immutable before the write occurs.
 
-Once the representation and precedence choices are settled, authorize the smallest coherent slice. After its focused test passes, ask the agent to identify the exact comparison that resolves duplicate keys. Explain in your own words why changing `>` to `>=`, or reversing input order, changes the visible value.
+Once the representation and ordering rules are settled, authorize the smallest coherent slice. After its focused test passes, have the agent point to the exact comparison that resolves duplicate keys. Explain in your own words what that line is trying to do and why changing `>` to `>=`, or reversing input order, changes the visible value.
 
 ## Checkpoint 2: Durable Representation
 
@@ -79,9 +79,9 @@ This checkpoint covers blocks, block iterators, SST builders, SST readers, SST i
 
 Because this path copies all seven test suites at the start, the accepted design should converge directly on the final Day 7 prefix-compressed block format. Do not first implement the Day 3 layout and silently replace it. The agent should explicitly ask which acceptance target applies and record that choice.
 
-First derive the parts fixed by the course contract:
+First use concrete byte examples to derive the parts fixed by the course:
 
-| Contract | Case that exposes it |
+| Behavior to work out | Small case that exposes it |
 | --- | --- |
 | Integer encoding and exact block layout | Independently decode a three-entry block. |
 | Inclusive target-size accounting | Add an entry that makes the encoded block exactly the target size. |
@@ -91,7 +91,7 @@ First derive the parts fixed by the course contract:
 | SST trailer placement | Locate metadata and Bloom sections from the end of the file. |
 | Bloom-filter authority | Compare a definite negative with a possible positive. |
 
-Then make the genuinely open implementation choices, such as linear versus binary lower-bound search when both satisfy the interface, allocation versus reuse for reconstructed keys, and how much malformed-input checking to add without changing the provided API. Record required protocol facts as constraints and open selections as choices.
+Then make the genuinely open implementation choices, such as scanning versus binary search when looking for the first key at or after a target, allocating versus reusing memory for reconstructed keys, and how much malformed-input checking to add without changing the provided API. Record required course rules separately from choices you made.
 
 The high-level SST trailer grammar is:
 
@@ -103,43 +103,24 @@ The final four bytes contain `bloom_offset`; the metadata offset is the four-byt
 
 Treat the writer and reader as two parties implementing a protocol. A round-trip test alone can miss an encoder and decoder that agree with each other but disagree with the specified bytes. Ask for at least one independently calculated byte layout.
 
-### Illustrative Dialogue: “Implement Block Format”
-
-This is a condensed example of the expected interaction, including representative command output rather than a transcript captured from your machine. It targets the final prefix-compressed format required by fast-forward Day 1.
+<details>
+<summary>Worked example: one plain-English block-format stop</summary>
 
 > **Student:** Implement block format.
 >
-> **Agent:** This can be split into builder/encoding and iterator/seek slices. Which slice should establish the contract first, and why?
+> **Agent:** **Course rule — What must one entry depend on?**
 >
-> **Student:** Builder and encoding first. The iterator consumes that representation, while encoding can be checked independently against exact bytes.
+> A block contains `mini-a`, `mini-b`, and `mini-c`. The iterator is allowed to jump straight to `mini-c`. If `mini-c` stores only what changed from `mini-b`, can the iterator reconstruct it without first reading `mini-b`? Should each compressed key therefore compare itself with the first key or the previous key?
 >
-> **Agent:** Contract derivation: the full Week 1 suite is installed. Should this slice implement the earlier uncompressed Day 3 entry or the final Day 7 prefix-compressed entry? What evidence decides?
+> You can reply `simpler`, `example`, `hint`, or `choose for me`.
 >
-> **Student:** The final Day 7 format. Replacing an intermediate format inside the same checkpoint would be throwaway work, and the installed acceptance target includes prefix compression.
+> **Student:** Compare with the first key. Then the iterator needs only the first key and the selected entry, rather than a chain of earlier entries.
 >
-> **Agent:** Contract derivation: a compressed key can be relative to the previous key or the first key in the block. Which basis does the course require, and what does it permit an iterator to do?
->
-> **Student:** Use the first key. Then any entry can be reconstructed independently once the first key is known; using the previous key would require decoding the chain before it.
->
-> **Agent:** Derive the projected encoded size for a new entry with `rest_key_len` suffix bytes and decide whether an exact fit is admitted.
->
-> **Student:** For `n` existing entries: `data.len() + 2 + 2 + rest_key_len + 2 + value.len() + 2 * (n + 1) + 2`. The fields are overlap length, suffix length, suffix, value length, value, all offsets after the add, and the one final count. Equality fits.
->
-> **Agent:** Open choice: because first-key compression makes an arbitrary entry independently decodable, lower-bound seek can scan linearly or binary-search offsets. Which do you want?
->
-> **Student:** Binary search. The entries are sorted, and independent reconstruction makes each comparison possible without decoding all preceding entries.
->
-> **Agent:** Open choice: `decode` has no error return. Should this checkpoint trust encoder-produced bytes, add assertions that still panic, or request an interface change to return `Result`?
->
-> **Student:** Trust encoder-produced bytes for this checkpoint and document the boundary. A production decoder should return `Result` and validate counts, offsets, and lengths, but changing the interface is outside scope.
->
-> **Agent:** The slice is specified. I will change `src/block/builder.rs`, `src/block.rs`, and `src/block/iterator.rs`, then run `cargo test --lib tests::week1_day7::test_task3_block_key_compression`. Prediction first: with empty values, `mini-a` encodes as an overlap of 0 plus a six-byte suffix, and `mini-b` as an overlap of 5 plus a one-byte suffix. What are the two entry offsets and final encoded size?
->
-> **Student:** The first entry is 12 bytes and starts at 0. The second is 7 bytes and starts at 12. Two offsets and the final count add 6 bytes, so the encoded block is 25 bytes. I authorize this slice.
->
-> **Agent:** Implemented only the authorized block slice. `cargo test --lib tests::week1_day7::test_task3_block_key_compression` exited 0. The entries reconstructed as `mini-a` and `mini-b`, the empty values survived, and the encoded length was 25 bytes. I did not begin the SST layer. One remaining weakness is that the supplied valid-block tests do not establish safe behavior for malformed offsets. Before I add an adversarial test, predict what the current trusted decoder would do with an offset beyond the data section.
+> **Agent:** Correct. This is called the prefix basis. I will record “first key” as a course rule. One consequence is that an iterator can inspect any entry independently, which permits either a linear scan or binary search. That search method is a **Your choice** stop we can discuss next.
 
-The final agent turn contains evidence, a checkpoint stop, and a new question. It does not treat a passing test as permission to continue. In a real session, inspect the diff and actual command output before accepting that report. An unexpected test failure either reveals a mechanical bug or reopens one specific decision.
+</details>
+
+The example begins with an operation the student can picture and names the concept afterward. A real implementation stop must still preview the files and focused test, wait for authorization, report actual evidence, and stop before beginning the next slice. An unexpected test failure either reveals a mechanical bug or reopens one specific decision.
 
 Before approving the completed checkpoint, decode three keys by hand: one with no shared prefix, one with a long shared prefix, and one with an empty value. Confirm that a seek returns the first key greater than or equal to its target and that a Bloom-filter negative can never hide a present key.
 

--- a/mini-lsm-book/src/week2-fast-forward.md
+++ b/mini-lsm-book/src/week2-fast-forward.md
@@ -1,0 +1,262 @@
+<!--
+  mini-lsm-book © 2022-2026 by Alex Chi Z is licensed under CC BY-NC-SA 4.0
+-->
+
+# Day 2 - Compaction and Recovery
+
+This is the second day of [Mini-LSM with Coding Agents](./agent-fast-forward-overview.md). You will turn the Day 1 engine into a storage engine that reorganizes files in the background and reconstructs its state after a restart:
+
+```text
+memtables + WALs -> SSTs -> compaction -> sorted runs
+          \________ manifest records file ownership ________/
+```
+
+The difficult part is not producing more SSTs. It is preserving the newest value, retaining concurrent work, and making every durable record tell the truth after a crash.
+
+## What You Will Finish
+
+At the end of this path:
+
+- full, simple leveled, tiered, and dynamic leveled compaction work;
+- `get` and `scan` preserve newest-value priority across every layout;
+- compaction can run without losing an L0 flush or tier created concurrently;
+- a manifest reconstructs the live SST layout;
+- WAL-backed memtables restore synchronized writes;
+- batch writes preserve the existing `put` and `delete` behavior;
+- checksums protect SST blocks and metadata, Bloom filters, WAL records, and manifest records; and
+- you can predict a compaction task, trace a crash boundary, and identify the bytes protected by each checksum.
+
+Tests and simulator output are evidence, not the specification. A plausible file layout can still return stale data, resurrect a deletion, or reference a file that was never made durable.
+
+## Prepare Day 2
+
+Begin from a Day 1 implementation that passes its complete suite. From the repository root, copy all available Week 2 tests and record the first failure:
+
+```shell
+cargo x copy-test --week 2
+cargo x scheck
+```
+
+Week 2 has supplied tests for its original Days 1 through 6. The checksum work from original Day 7 has no dedicated supplied tests, so you will need your own corruption cases.
+
+With the agent running from `mini-lsm-starter`, send:
+
+> Build Day 2 with me, starting with one safe full compaction. Follow the student-owned design protocol in `AGENTS.md` and never access `../mini-lsm`. Ask one short question at a time using a concrete set of files, keys, or crash points. Mark each question **Course rule** or **Your choice**. I may reply `simpler`, `example`, `hint`, or `choose for me`. Do not edit until my answers specify one small, coherent slice. After each slice, show me one important line and ask what it does and what would break if it changed.
+
+Use the checkpoints in order unless you can explain why a different dependency order is safe. The tables are audit guides, not questionnaires to paste into the agent.
+
+## Checkpoint 1: One Safe Compaction
+
+Ask:
+
+> Implement one full compaction and read from its output.
+
+This checkpoint covers full compaction, the concat iterator, and the two-level read path. Use [Compaction Implementation](./week2-01-compaction.md) when a question needs more context.
+
+The agent should help you work out these course rules from small file states:
+
+| Behavior to work out | Small case that exposes it |
+| --- | --- |
+| Duplicate-key priority | Put a newer value in L0 and an older value in L1. |
+| Tombstone removal | Compare a full bottom-level compaction with a task that leaves an older level untouched. |
+| Concurrent result installation | Flush file 6 after a task captures L0 files 5 and 4. |
+| Empty output | Compact inputs whose newest entries are all tombstones. |
+| Output splitting | Cross the target SST size with one more entry. |
+| Concat-iterator precondition | Swap two non-overlapping SSTs or make their ranges overlap. |
+| Reader lifetime | Unlink an input file while an older state snapshot still owns its open handle. |
+
+The central installation case is:
+
+```text
+task captured:  L0 = [5, 4], L1 = [1, 2]
+while building: L0 file 6 is flushed
+install result: L0 = [6],    L1 = [new sorted outputs]
+```
+
+Merge and write the outputs outside `state_lock`. When the outputs are ready, acquire `state_lock`, apply the task to the latest state, remove exactly the captured input IDs, and retain file 6. Do not replace the current L0 with the task's old snapshot.
+
+Inputs must be presented to the merge iterator from newest to oldest. A tombstone can be discarded only when the task reaches the bottom and therefore includes every possible older version of the key. If every surviving entry is discarded, return no output SST instead of building an empty one.
+
+L1 is one sorted run: its SST ranges do not overlap and are ordered by first key. Its concat iterator should open only the active SST rather than eagerly loading one block from every file.
+
+Before approving the checkpoint, use one key that appears in both L0 and L1. Predict the result when L0 contains a value and when it contains a tombstone. After the focused checks pass, explain the line that removes captured L0 IDs without removing a later flush.
+
+## Checkpoint 2: Decide What to Compact
+
+Ask:
+
+> Implement the compaction schedulers, one policy at a time.
+
+Use [Simple Leveled Compaction](./week2-02-simple.md), [Tiered Compaction](./week2-03-tiered.md), [Leveled Compaction](./week2-04-leveled.md), and the [Week 2 overview](./week2-overview.md) as references.
+
+Follow this default sequence for each policy:
+
+1. implement task selection and result application against the simulator state;
+2. run a short simulator trace and explain every selected task;
+3. add the policy to compaction dispatch, flushing, and reads; and
+4. stop for review before beginning the next policy.
+
+Do not treat “which policies should exist?” as a student preference: the completed Week 2 track implements all three. The policy algorithms are course rules; helper structure, allocation, and equivalent search methods may be genuine choices.
+
+### Simple leveled
+
+```text
+L0: overlapping files, newest to oldest
+L1..Ln: one non-overlapping sorted run per level
+```
+
+L0 reaches its file-count trigger before it compacts into L1. Below L0, let the upper and lower levels contain `U` and `L` files. Trigger when `L / U * 100` is less than `size_ratio_percent`; a task consumes both complete levels. Handle an empty upper level without dividing by zero. The controller must eventually return no task so the simulator and background worker converge. The upper level is newer and wins equal keys. Preserve tombstones unless the lower level is the bottom.
+
+### Tiered
+
+```text
+levels[0] = newest tier
+levels[last] = oldest tier
+```
+
+Tiered compaction does not use L0: every flush creates a one-SST tier at the front. Do not schedule until the number of tiers reaches `num_tiers`. Then consider triggers in this fixed order:
+
+1. compact every tier when `sum(all tiers except bottom) / bottom_size` reaches `max_size_amplification_percent / 100`;
+2. scanning from newest to oldest, compact the newer prefix before the first tier whose size divided by that prefix's total is greater than `(100 + size_ratio) / 100`, provided the prefix has at least `min_merge_width` tiers; and
+3. if neither ratio selects work, merge the first `max_merge_width` tiers—or all tiers when it is unset—to reduce the number of sorted runs.
+
+A task selects a contiguous prefix of newest tiers. If `max_merge_width` leaves an older tier behind, `bottom_tier_included` is false and tombstones must remain. Insert the output after any newer tier flushed while the task was running.
+
+### Dynamic leveled
+
+Compute target sizes from the bottom level upward. The first level with a positive target is the base level; an eligible L0 task goes directly there and takes priority over size-based tasks. For lower levels, compute `current_size / target_size`, choose the highest score greater than 1, select the oldest upper-level SST, and include every lower SST whose inclusive key range overlaps it.
+
+Applying a result removes exactly the selected files and restores first-key ordering among the untouched and output SSTs. During manifest replay the SST objects are not open yet, so defer this sorting until their key ranges are available.
+
+After each controller works in the simulator, integrate it with the engine. The background worker asks for a task every 50 ms, returns successfully when there is no work, compacts outside `state_lock`, and applies the result to the latest state. Extend `get` and `scan` across every lower-level sorted run using one concat iterator per run. Tiered mode instead reads tiers newest to oldest and flushes new SSTs directly into new tiers.
+
+Use these simulator commands without consulting the reference implementation:
+
+```shell
+cargo run --bin compaction-simulator simple
+cargo run --bin compaction-simulator tiered
+cargo run --bin compaction-simulator leveled
+```
+
+For at least one trace per policy, annotate the selected inputs, the reason the task fired, whether it reaches the bottom, the source that wins equal keys, and the files that remain afterward. Change one threshold and predict the next task before rerunning the simulator.
+
+## Checkpoint 3: Recover the Live State
+
+Ask:
+
+> Add the manifest and WAL so synchronized writes survive restart.
+
+This checkpoint covers [Manifest](./week2-05-manifest.md) and [Write-Ahead Log](./week2-06-wal.md). Implement the final framed, checksummed manifest and WAL records from [Batch Write and Checksums](./week2-07-snacks.md) directly; do not first build an unframed format and replace it in the same checkpoint.
+
+First derive the required recovery behavior:
+
+| Behavior to work out | Small case that exposes it |
+| --- | --- |
+| Manifest replay | Replay a flush followed by a compaction from an empty state. |
+| New-file durability order | Crash after the SST is synced but before its manifest record. |
+| Unsafe reference order | Crash after the manifest is synced but before the SST directory entry. |
+| Obsolete-file deletion | Crash after the compaction record but before deleting its inputs. |
+| Live WAL selection | Leave `NewMemtable(7)` without a matching `Flush(7)`. |
+| WAL retirement | Leave an old WAL file after its flush record is durable. |
+| Recovered ordering | Recover several memtables whose IDs were created over time. |
+| ID allocation | Recover SST and WAL IDs with gaps and find the next unused ID. |
+| Durability boundary | Stop before and after `sync` returns. |
+
+Use final record framing so recovery can locate and verify one record at a time:
+
+```text
+manifest: len | JSON record | checksum | len | JSON record | checksum | ...
+WAL:      key_len | key | value_len | value | checksum | ...
+```
+
+The checksum covers the encoded record bytes, not itself. Integer byte order is part of the format. Validate lengths before slicing and verify a checksum before exposing its payload.
+
+For a flush or compaction that creates SSTs, the safe durable order is:
+
+```text
+write and sync new SSTs
+  -> sync the directory entries
+  -> append and sync the manifest record
+  -> delete obsolete inputs
+  -> sync the directory again
+```
+
+Recovery may see the old logical state or the new logical state at some crash boundaries. It must never see a durable manifest record that requires a missing file. An unreferenced new file or an undeleted obsolete file is tolerable because neither belongs to the recovered logical state.
+
+When WALs are enabled, create the WAL, sync its directory entry, and durably record `NewMemtable(id)` before making that memtable available for writes. `sync` must flush the `BufWriter` and then call `sync_all`. A durable flush record retires the WAL logically before its filename is removed. Recovery ignores such stale files, restores live immutable memtables newest to oldest, and sets `next_sst_id` to one greater than every live SST or WAL ID.
+
+Without WALs, `close` flushes every non-empty memtable. With WALs, it synchronizes them instead. In both cases, it stops and joins the background threads and remains harmless when called again.
+
+Before approving the checkpoint, write the event sequence for one flush and place a crash after every event. Then recover a manifest containing interleaved `NewMemtable`, `Flush`, and `Compaction` records by hand. After the focused tests pass, explain the line that prevents a manifest record from becoming durable before its new file.
+
+## Checkpoint 4: Reject Corrupted Data
+
+Ask:
+
+> Add the final write-batch API and checksums to the remaining disk formats.
+
+This checkpoint finishes [Batch Write and Checksums](./week2-07-snacks.md). The supplied suite has no dedicated checksum tests, so an agent report that only says `cargo x scheck` passed is incomplete.
+
+`put` and `delete` should delegate to `write_batch`. At this stage a batch preserves the existing per-record behavior; it does not promise transaction-like atomic visibility or durability for the entire group.
+
+For SST data, keep the earlier block-size contract: the configured target describes block content, and the four-byte checksum is appended after it. Verify the block bytes before decoding them.
+
+For each remaining section, identify its first protected byte, last protected byte, stored checksum, and framing fields:
+
+```text
+data block | checksum
+block metadata | checksum | metadata offset
+Bloom filter | checksum | Bloom offset
+```
+
+`Bloom::encode` appends to a buffer that already contains other SST sections. Record the filter's starting offset and checksum only the bytes added for the filter. The encoder and decoder must agree on the exact range; a round-trip alone cannot detect two matching implementations that protect the wrong bytes.
+
+For every persistent format—data block, block metadata, Bloom filter, WAL, and manifest—add or run a test that:
+
+1. writes a valid value and reads it back;
+2. flips one byte inside the protected payload;
+3. predicts which decoder should reject it; and
+4. checks a truncated length or checksum without silently accepting data.
+
+After implementation, have the agent point to one checksum slice boundary and ask what would happen if it included preceding bytes or excluded the final payload byte.
+
+## Audit the Finished Engine
+
+Run the complete project check from the repository root:
+
+```shell
+cargo x scheck
+```
+
+Also rerun all three compaction simulators and the corruption cases. Then ask for a final evidence report containing:
+
+1. the combined decision ledgers and delegated choices;
+2. the exact commands and outcomes;
+3. one duplicate key traced through each compaction layout;
+4. one task installation interleaved with a concurrent flush;
+5. one manifest/WAL recovery trace with crash points;
+6. the next-ID calculation for that recovered state;
+7. the exact protected byte range for every checksum; and
+8. one weakness not established by the supplied tests.
+
+Inspect the actual diff and outputs. Search for changed supplied tests, removed assertions, broad lint suppressions, unchecked corrupted lengths, and file deletion before the durable manifest transition.
+
+Finally, introduce and immediately revert one deliberate fault you understand. Good examples are reversing upper/lower merge priority, marking a capped tiered task as bottom-reaching, deleting an SST before its compaction record is durable, or excluding one payload byte from a checksum. Predict the failing test or recovery trace before running it.
+
+## Day 2 Completion Checkpoint
+
+You are ready for Day 3 when you can do these without delegating the answer back to the agent:
+
+- predict the next task for simple, tiered, and leveled compaction;
+- explain why the newest version wins in every task layout;
+- decide whether a particular compaction may discard tombstones;
+- show how result installation retains a concurrent flush;
+- compare the read, write, and space costs of leveled and tiered policies;
+- replay the manifest and live WALs into one LSM state;
+- place crashes in a flush sequence and distinguish safe leftovers from missing required files;
+- state what `sync` and `close` guarantee with and without WALs; and
+- mark the exact byte range protected by every checksum and design a corruption test.
+
+If one item is unclear, return to its original Week 2 chapter and ask the agent for a smaller file state, crash timeline, or byte layout. The goal is not merely a persistent engine. It is an engine whose background transitions and recovery story you can defend.
+
+{{#include copyright.md}}

--- a/mini-lsm-starter/AGENTS.md
+++ b/mini-lsm-starter/AGENTS.md
@@ -27,7 +27,7 @@ Before editing:
 
 1. Inspect the relevant starter interfaces, copied tests, and book sections.
 2. Identify the checkpoint boundary and the decisions required to specify it.
-3. Ask about one consequential design decision, then stop.
+3. Ask about one consequential design decision, then stop. Begin with a small concrete state or operation, use plain English, and introduce the technical term after the student reasons about the example.
 4. After the student answers, evaluate the answer against the interfaces, tests, and invariants. Correct a misunderstanding with evidence; do not quietly replace the student's choice.
 5. Record the accepted choice in a short decision ledger, then ask the next question.
 6. When the decisions needed for the next coherent code slice are settled, summarize that slice and its expected test, then wait for the student to authorize the edit.
@@ -36,13 +36,27 @@ A consequential decision changes observable behavior, correctness, compatibility
 
 Stop eliciting decisions when the public contract, supplied tests, and selected adversarial cases determine the next slice. Internal bookkeeping that follows an accepted invariant is mechanical. Do not invent hypothetical policy choices merely to prolong the interview.
 
-Ask questions that require reasoning. A decision question should contain:
+Ask questions that require reasoning. Mark each stop as one of:
 
-- the invariant or concrete case that makes the choice matter;
+- **Course rule:** The interfaces, format, or tests require one behavior. Ask the student to predict or derive it; do not present it as a free preference.
+- **Your choice:** More than one implementation satisfies the course. Give the real alternatives and their relevant tradeoffs.
+
+A decision question should contain:
+
+- a short, concrete case that makes the choice matter;
 - two or more viable choices and their tradeoffs, when alternatives really exist; and
 - one focused question asking the student to choose, predict, or explain.
 
-Do not dump the entire interview as a questionnaire. Ask one decision at a time so the next question can use the student's previous answer. Do not reveal the expected answer before the student attempts it. If only one choice is compatible with a provided interface or format, ask the student to derive it from that evidence and record it as a constraint, not a preference.
+Do not lead with labels such as “duplicate precedence,” “lower-bound seek semantics,” or “write/freeze synchronization” when the behavior can be shown first with keys, values, and operations. Keep the setup and question short enough to scan once. Do not dump the entire interview as a questionnaire. Ask one decision at a time so the next question can use the student's previous answer. Do not reveal the expected answer before the student attempts it. If only one choice is compatible with a provided interface or format, ask the student to derive it from that evidence and record it as a constraint, not a preference.
+
+At every stop, accept these help commands:
+
+- `simpler`: ask the same question again with shorter sentences and less terminology without revealing the answer;
+- `example`: replace the setup with the smallest concrete example that exposes the same behavior;
+- `hint`: provide one relevant fact from an allowed source, then ask the student to try again; and
+- `choose for me`: make the decision, explain it in plain English, and record it as delegated.
+
+Mention these commands in the first question of a checkpoint and whenever the student appears stuck. They are not permission to skip later decisions.
 
 Maintain a compact decision ledger during the checkpoint:
 
@@ -69,6 +83,8 @@ For each authorized slice:
 5. If the check fails, classify the failure as a coding mistake, an unsettled design decision, or evidence that an accepted decision was wrong.
 6. Fix mechanical coding mistakes directly. For either kind of design failure, return to one-question-at-a-time dialogue before changing the design.
 7. Stop for review before beginning another slice or checkpoint.
+
+During review, select one consequential changed line or comparison and ask two plain-English questions: what is this line trying to do, and what plausible behavior would break if it changed? Do not quiz the student on arbitrary syntax or mechanical code.
 
 Preserve the starter's architecture and naming unless a local design change is necessary and approved. Do not perform unrelated refactors. Make one testable debugging hypothesis at a time. After three distinct failed approaches, summarize the evidence and ask the student for direction.
 


### PR DESCRIPTION
## Summary

Rename the fast-forward material to **Mini-LSM with Coding Agents** and make its learning stops start from concrete examples before introducing systems terminology. Add explicit `simpler`, `example`, `hint`, and `choose for me` escape hatches, plus a code-level teach-back after each implementation slice.

Add a repository-local skill that audits agent-track chapters for technical correctness, executable sequencing, meaningful student decisions, and testable evidence. The skill includes a deterministic checker for local links and Markdown structure.

Draft Day 2 as four dependency-ordered checkpoints covering safe compaction, all three compaction schedulers, manifest/WAL recovery, batch writes, and checksummed disk formats. This gives students an agent-guided route through the original Week 2 material without encouraging a one-shot implementation.

## Validation

The new validation skill reports the Day 2 draft as ready after resolving ambiguity in ratio calculations, background/read-path integration, and WAL filename durability. Its structural checker passes for all agent-track chapters. `mdbook build` succeeds, and the xtask test suite confirms that copying all Week 2 tests selects the six available test days.

_AI-assisted: Codex._
