### PR TITLE
strengthen week 1-3 learning scaffolding

### DIFF
--- a/mini-lsm-book/src/00-overview.md
+++ b/mini-lsm-book/src/00-overview.md
@@ -16,6 +16,24 @@ This course has three parts, or weeks. In the first week, you will focus on the 
 
 Follow [Environment Setup](./00-get-started.md) to prepare your development environment.
 
+## From Bitcask to Mini-LSM
+
+If Bitcask is your starting point, you already know the central log-structured idea: do not overwrite an old record in place. Append a new record, let an index identify the newest value, and reclaim obsolete records later. Mini-LSM keeps that idea but changes the index and the shape of the files.
+
+In a Bitcask-style engine, an in-memory hash index maps each key to its newest record on disk. That design is excellent for point lookups, but the hash index does not place keys in order. An ordered range scan therefore needs an additional ordered index or must examine and sort matching keys. The entire key directory must also fit in memory. See the original [Bitcask paper](https://riak.com/assets/bitcask-intro.pdf) for the design and its stated memory requirement.
+
+Mini-LSM instead maintains **sorted** data at every stage:
+
+1. A memtable is an ordered in-memory map. It absorbs small random writes without updating disk pages in place.
+2. Freezing and flushing a memtable turns one sorted memory run into an immutable sorted-string table (SST). Because the input is already sorted, the engine can write the file sequentially.
+3. Reads merge the newest memtables and SSTs into one logical sorted view. Source priority resolves several physical versions of the same key.
+4. Compaction merges sorted runs in the background. It pays sequential rewrite work to bound how many runs a read must consult and to reclaim obsolete values and tombstones.
+5. A write-ahead log protects the mutable part that has not reached an SST. The manifest separately records which immutable files form the current tree.
+
+This is the design bargain behind the course: foreground writes become cheap appends and in-memory updates, while background compaction pays and schedules the work that an in-place index would perform on the write path. Sorted runs also make ordered scans and merge-based maintenance natural. The original [LSM-tree paper](https://www.cs.umb.edu/~poneil/lsmtree.pdf) motivates the structure as a way to maintain a disk index with lower insertion cost.
+
+The three weeks follow the consequences of that bargain. Week 1 establishes one correct logical view over sorted memory and disk structures. Week 2 controls the delayed maintenance work and makes both the file layout and unflushed writes recoverable. Week 3 retains several timestamped versions so concurrent readers can keep stable snapshots while writes continue.
+
 ## Overview of LSM
 
 An LSM storage engine generally has three components:

--- a/mini-lsm-book/src/00-preface.md
+++ b/mini-lsm-book/src/00-preface.md
@@ -23,7 +23,7 @@ an LSM tree, however, writes—including insertions, updates, and deletions—ar
 engine batches these operations into sorted-string table (SST) files and writes them to disk. Once written, SST files are
 immutable. A background process called compaction merges these files and applies their updates and deletions.
 
-This architectural design makes LSM trees easy to work with.
+This architectural design creates several useful engineering properties.
 
 1. Data on persistent storage is immutable, which makes concurrency control more straightforward. Compaction can be offloaded to remote servers, and data can be stored and served directly from cloud-native storage systems such as S3.
 2. Changing the compaction algorithm lets the storage engine balance read, write, and space amplification. By tuning compaction parameters, we can optimize the LSM tree for different workloads.
@@ -32,9 +32,9 @@ This course will teach you how to build an LSM-tree-based storage engine in the 
 
 ## Prerequisites
 
-* You should know the basics of the Rust programming language. Reading [The Rust Programming Language](https://doc.rust-lang.org/book/) is sufficient.
-* You should understand the basic concepts behind key-value storage engines, including why persistence requires a more complex design. If you have no prior experience with database or storage systems, consider implementing Bitcask through the [PingCAP Talent Plan](https://github.com/pingcap/talent-plan/tree/master/courses/rust/projects/project-2).
-* You do not need to know how an LSM tree works, but we recommend reading an introduction, such as an overview of LevelDB. This background will familiarize you with concepts such as mutable and immutable memtables, SSTs, compaction, and write-ahead logs (WALs).
+* You should know the basics of the Rust programming language. Reading [The Rust Programming Language](https://doc.rust-lang.org/book/) is sufficient. The course introduces less common Rust patterns when they appear, but you should be comfortable reading compiler errors and consulting crate documentation.
+* You should understand a small persistent key-value store such as Bitcask: appending updates to a log, keeping an in-memory index that points to the newest record, representing deletion with a marker, reclaiming obsolete records by merging files, and rebuilding state after a restart. If these ideas are unfamiliar, consider implementing Bitcask through the [PingCAP Talent Plan](https://github.com/pingcap/talent-plan/tree/master/courses/rust/projects/project-2).
+* You do **not** need prior knowledge of LSM trees, compaction strategies, MVCC, or transaction isolation. The [course overview](./00-overview.md) bridges the Bitcask model to Mini-LSM, and each week introduces its own storage concepts. An external LevelDB or RocksDB overview is optional enrichment rather than required preparation.
 
 ## What Should You Expect from This Course?
 
@@ -43,6 +43,17 @@ After completing this course, you should have a deep understanding of how an LSM
 ### Structure
 
 The course consists of several parts, or weeks. Each week has seven chapters, and you can complete each chapter in two to three hours. The first six chapters of each week guide you through building a working system. The final chapter is a *snack time* chapter in which you implement a few approachable improvements to what you built over the previous six days. Each chapter includes required tasks, *Test Your Understanding* questions, and bonus tasks.
+
+### How to Use the Learning Checks
+
+The book uses four kinds of checks for different purposes:
+
+1. **Predict before coding** asks you to trace a small state before implementation details distract you. If your code later disagrees, first decide which invariant your prediction or implementation missed.
+2. **Chapter checkpoints** combine tests with cases that the supplied suite may not cover. Record the state, execution, or byte layout that supports your conclusion; passing tests alone is not sufficient evidence.
+3. **Test Your Understanding** begins with questions that have a concrete answer in the chapter's model, then broadens into performance and production-design prompts. For an open-ended prompt, state the workload and system assumptions before defending a tradeoff.
+4. **End-of-week self-checks** provide small integrated scenarios with collapsed answer criteria. Use them as calibration after answering the chapter questions, not as an implementation recipe.
+
+Questions that require an external API detail or paper should link the relevant primary source. If a question still seems underspecified, identify the missing assumption instead of guessing a universal answer.
 
 ### Testing
 

--- a/mini-lsm-book/src/SUMMARY.md
+++ b/mini-lsm-book/src/SUMMARY.md
@@ -31,8 +31,8 @@
   - [Snapshots - Memtables and Timestamps](./week3-02-snapshot-read-part-1.md)
   - [Snapshots - Transaction API](./week3-03-snapshot-read-part-2.md)
   - [Watermark and GC](./week3-04-watermark.md)
-  - [Transaction and OCC](./week3-05-txn-occ.md)
-  - [Serializable Snapshot Isolation](./week3-06-serializable.md)
+  - [Transaction Workspace and Atomic Commit](./week3-05-txn-occ.md)
+  - [Serializable Validation](./week3-06-serializable.md)
   - [Snack Time: Compaction Filters](./week3-07-compaction-filter.md)
 - [The Rest of Your Life (TBD)](./week4-overview.md)
 

--- a/mini-lsm-book/src/week1-01-memtable.md
+++ b/mini-lsm-book/src/week1-01-memtable.md
@@ -219,9 +219,9 @@ Answer the correctness questions with reference to your implementation. For ques
 
 * Could an LSM tree use other data structures for its memtable? What are the advantages and disadvantages of a skiplist?
 * Is the memtable's memory layout efficient? Does it have good data locality? Consider how `Bytes` is implemented and stored in the skiplist. How could you optimize the memtable's layout?
-* This course uses `parking_lot` locks. Is its read-write lock fair? What might happen to readers waiting to acquire the lock when a writer is already waiting for the current readers to release it?
+* **Documentation check:** Read `parking_lot`'s [`RwLock` fairness section](https://docs.rs/parking_lot/latest/parking_lot/type.RwLock.html#fairness). What might happen to readers waiting to acquire the lock when a writer is already waiting for the current readers to release it? How does eventual fairness differ from strict first-in, first-out service?
 
-We do not provide reference answers to these questions, so feel free to discuss them in the Discord community.
+Use the [Week 1 end-of-week self-check](./week1-overview.md#end-of-week-self-check) to calibrate the core invariants. The remaining design questions may have several defensible answers; state your workload and assumptions before comparing tradeoffs. You can also discuss them in the Discord community.
 
 ## Bonus Tasks
 

--- a/mini-lsm-book/src/week1-02-merge-iterator.md
+++ b/mini-lsm-book/src/week1-02-merge-iterator.md
@@ -210,7 +210,7 @@ After the tests pass, trace one key that appears in three memtables through ever
 * What are the time and space complexities of building and advancing your merge iterator in terms of the number of input iterators?
 * Suppose that (1) you create an iterator over the skiplist memtable and (2) another thread inserts keys into that memtable. Will the iterator see the new keys? Design a small experiment rather than relying only on the type signature.
 
-We do not provide reference answers to these questions, so feel free to discuss them in the Discord community.
+Use the [Week 1 end-of-week self-check](./week1-overview.md#end-of-week-self-check) to calibrate the core invariants. The remaining design questions may have several defensible answers; state your workload and assumptions before comparing tradeoffs. You can also discuss them in the Discord community.
 
 ## Bonus Tasks
 

--- a/mini-lsm-book/src/week1-03-block.md
+++ b/mini-lsm-book/src/week1-03-block.md
@@ -81,6 +81,8 @@ At the end of each block, we store the offset of every entry followed by the tot
 
 The block footer then has the layout shown above. Every number in the footer is stored as a `u16`.
 
+The offsets turn variable-length entries into an index. Given entry number `i`, the decoder can jump to its starting byte instead of walking through every preceding key and value. That makes binary search over entry numbers possible while keeping the encoded records compact. The final count tells the decoder how many trailing `u16` values belong to this offset array and therefore where the data section ends.
+
 Each block has a size limit, `target_size`, which corresponds to `block_size` in the provided code. Unless the first key-value pair alone exceeds this limit, ensure that the encoded block is no larger than `target_size`.
 
 When `BlockBuilder::build` is called, it produces the raw data section and the unencoded entry offsets, which are stored in a `Block`. Keeping raw key-value data contiguous and storing offsets separately avoids unnecessary allocations and decoding work. Copy the raw block data into the `data` vector and decode one entry offset every 2 bytes, rather than materializing all entries as a structure such as `Vec<(Vec<u8>, Vec<u8>)>`. This compact layout is efficient.
@@ -140,7 +142,7 @@ Passing the supplied tests demonstrates behavior for valid blocks. It does not p
 
 * Do you love bubble tea? Why or why not?
 
-We do not provide reference answers to these questions. Feel free to discuss them in the Discord community.
+Use the [Week 1 end-of-week self-check](./week1-overview.md#end-of-week-self-check) to calibrate the core invariants. The remaining design questions may have several defensible answers; state your workload and assumptions before comparing tradeoffs. You can also discuss them in the Discord community.
 
 ## Bonus Tasks
 

--- a/mini-lsm-book/src/week1-04-sst.md
+++ b/mini-lsm-book/src/week1-04-sst.md
@@ -126,9 +126,9 @@ Inspect the block-reading path after the tests pass. Explain when a disk read oc
 
 * Can an LSM engine store columnar data, such as a table with 100 integer columns? Would the current SST format still be a good choice?
 * Suppose the LSM engine uses an object-storage service such as S3. How would you adapt the SST format, its parameters, and the block cache to suit that environment?
-* For now, we load the metadata for every SST into memory. If 16 GB of memory is reserved for this metadata, can you estimate the maximum database size the LSM system could support? This limitation motivates an index cache.
+* For now, we load the metadata for every SST into memory. If 16 GB is reserved for this metadata, estimate the maximum database size under explicit assumptions for average key length, block size, metadata bytes per block, and SST utilization. Which assumption dominates? This limitation motivates an index cache.
 
-We do not provide reference answers to these questions. Feel free to discuss them in the Discord community.
+Use the [Week 1 end-of-week self-check](./week1-overview.md#end-of-week-self-check) to calibrate the core invariants. The remaining design questions may have several defensible answers; state your workload and assumptions before comparing tradeoffs. You can also discuss them in the Discord community.
 
 ## Bonus Tasks
 

--- a/mini-lsm-book/src/week1-05-read-path.md
+++ b/mini-lsm-book/src/week1-05-read-path.md
@@ -118,7 +118,7 @@ Exercise all four combinations of included and excluded scan bounds, plus unboun
 * Suppose a user creates an iterator over the entire 1 TB storage engine, and the scan takes about an hour. What problems could this cause? We will revisit this question at several points in the course.
 * Some LSM-tree storage engines provide a multi-get, or vectored-get, interface. The caller supplies a list of keys and receives a value for each one; for example, `multi_get(vec!["a", "b", "c", "d"]) -> a=1,b=2,c=3,d=4`. The simplest implementation performs one `get` per key. How would you implement multi-get, and what could you optimize? Hint: some work in the get path needs to be performed only once for the entire batch. You can also consider an improved disk-I/O interface designed for multi-get.
 
-We do not provide reference answers to these questions. Feel free to discuss them in the Discord community.
+Use the [Week 1 end-of-week self-check](./week1-overview.md#end-of-week-self-check) to calibrate the core invariants. The remaining design questions may have several defensible answers; state your workload and assumptions before comparing tradeoffs. You can also discuss them in the Discord community.
 
 ## Bonus Tasks
 

--- a/mini-lsm-book/src/week1-06-write-path.md
+++ b/mini-lsm-book/src/week1-06-write-path.md
@@ -165,7 +165,7 @@ After the tests pass, record the state before and after a manual flush: the muta
 * Imagine a multitenant LSM system hosting 10,000 databases on one machine with 128 GB of memory. If each memtable has a 256 MB size limit, how much memory would all memtables require?
   * You clearly do not have enough memory for all of them to reach that limit simultaneously. If each tenant still has a separate memtable, how could you design the flush policy to fit within the global memory budget? Would sharing one memtable among tenants—for example, by encoding a tenant ID in each key prefix—make sense?
 
-We do not provide reference answers to these questions. Feel free to discuss them in the Discord community.
+Use the [Week 1 end-of-week self-check](./week1-overview.md#end-of-week-self-check) to calibrate the core invariants. The remaining design questions may have several defensible answers; state your workload and assumptions before comparing tradeoffs. You can also discuss them in the Discord community.
 
 ## Bonus Tasks
 

--- a/mini-lsm-book/src/week1-07-sst-optimizations.md
+++ b/mini-lsm-book/src/week1-07-sst-optimizations.md
@@ -166,6 +166,6 @@ Measure or inspect three things: the encoded size of a block containing keys wit
 * Why must the first key in a block have an overlap length of zero? What malformed or circular representation could result otherwise?
 * Compare the encoded sizes of keys that share a long prefix, keys that share no prefix, and one key larger than the target block size. When does prefix encoding provide little or no benefit?
 
-We do not provide reference answers to these questions. Feel free to discuss them in the Discord community.
+Use the [Week 1 end-of-week self-check](./week1-overview.md#end-of-week-self-check) to calibrate the core invariants. The remaining design questions may have several defensible answers; state your workload and assumptions before comparing tradeoffs. You can also discuss them in the Discord community.
 
 {{#include copyright.md}}

--- a/mini-lsm-book/src/week1-overview.md
+++ b/mini-lsm-book/src/week1-overview.md
@@ -42,4 +42,44 @@ Before moving to Week 2, check that you can explain:
 - which data is in memory, which data is on disk, and which structure owns each piece;
 - how the read and write paths choose the newest visible value for a key.
 
+## End-of-Week Self-Check
+
+Try these scenarios without running the code. Open the answer criteria only after writing down both the result and the invariant that produces it.
+
+### 1. One View from Several Sources
+
+The mutable memtable contains `b -> delete` and `d -> 4`. The newest immutable memtable contains `a -> 1` and `b -> 2`. L0, from newest to oldest, contains one SST with `a -> 0`, `c -> 3`, and `d -> 3`. What do `get(a)`, `get(b)`, and the inclusive scan `[a, d]` return?
+
+<details>
+
+<summary>Answer criteria</summary>
+
+`get(a)` returns `1`, because every memtable is newer than every L0 SST. `get(b)` returns not found: the tombstone wins and must stop the search. The scan returns `a -> 1, c -> 3, d -> 4`. A complete explanation identifies where duplicate keys are resolved before tombstones are hidden and why the final stream is sorted and unique.
+
+</details>
+
+### 2. Freeze and Flush without Changing Results
+
+The immutable-memtable IDs are `[7, 6, 5]` from newest to oldest, and L0 IDs are `[4, 3]` from newest to oldest. After one correct flush, what are the two lists? Which logical read result is allowed to change because of the flush?
+
+<details>
+
+<summary>Answer criteria</summary>
+
+The oldest immutable memtable, ID 5, is flushed, so the lists become `imm_memtables = [7, 6]` and `l0_sstables = [5, 4, 3]`. The SST reuses the memtable ID. No logical read result may change: the state update replaces one physical representation with another at the same recency position.
+
+</details>
+
+### 3. Safe Optimizations
+
+An SST's range contains `k`, but its Bloom filter reports “may contain,” and an SST seek lands on the next key `m`. May `get(k)` return `m`? Would the answer change if the Bloom filter reported “definitely absent”?
+
+<details>
+
+<summary>Answer criteria</summary>
+
+“May contain” is not proof of membership, so the engine must seek and then check exact key equality; it cannot return `m`. A valid “definitely absent” result lets the engine skip the SST entirely. Both optimizations may reduce work but must not change the value returned.
+
+</details>
+
 {{#include copyright.md}}

--- a/mini-lsm-book/src/week2-01-compaction.md
+++ b/mini-lsm-book/src/week2-01-compaction.md
@@ -171,6 +171,6 @@ Answer correctness questions with a concrete LSM state or execution. For amplifi
 * Does it make sense to have a `struct ConcatIterator<I: StorageIterator>` in the system?
 * Some researchers/engineers propose to offload compaction to a remote server or a serverless lambda function. What are the benefits, and what might be the potential challenges and performance impacts of doing remote compaction? (Think of the point when a compaction completes and what happens to the block cache on the next read request...)
 
-We do not provide reference answers to these questions, so feel free to discuss them in the Discord community.
+Use the [Week 2 end-of-week self-check](./week2-overview.md#end-of-week-self-check) to calibrate the core invariants. The remaining design questions may have several defensible answers; state your workload and assumptions before comparing tradeoffs. You can also discuss them in the Discord community.
 
 {{#include copyright.md}}

--- a/mini-lsm-book/src/week2-02-simple.md
+++ b/mini-lsm-book/src/week2-02-simple.md
@@ -202,8 +202,8 @@ Compare a short simulator run with the reference output, then alter one paramete
 
 ### Amplification and Design
 
-* What is the estimated write amplification of leveled compaction?
-* What is the estimated read amplification of leveled compaction?
+* Estimate write amplification for a steady-state overwrite workload. State the level count, size ratio, and how much of each lower level a task rewrites; explain why the chapter's full-level policy differs from partial leveled compaction.
+* Estimate worst-case point-read amplification with no cache or Bloom-filter benefit. State how you count L0 and each non-empty sorted run.
 * Is it correct that a key will only be purged from the LSM tree if the user requests to delete it and it has been compacted in the bottom-most level?
 * Is it a good strategy to periodically do a full compaction on the LSM tree? Why or why not?
 * Actively choosing some old files/levels to compact even if they do not violate the level amplifier would be a good choice, is it true? (Look at the [Lethe](https://disc-projects.bu.edu/lethe/) paper!)
@@ -211,6 +211,6 @@ Compare a short simulator run with the reference output, then alter one paramete
 * So far, SST filenames have used monotonically increasing IDs. What problems might arise from naming a file `<level>_<begin_key>_<end_key>.sst` instead? Revisit this question in Week 3.
 * What is your favorite boba shop in your city? (If you answered yes in week 1 day 3...)
 
-We do not provide reference answers to these questions, so feel free to discuss them in the Discord community.
+Use the [Week 2 end-of-week self-check](./week2-overview.md#end-of-week-self-check) to calibrate the core invariants. The remaining design questions may have several defensible answers; state your workload and assumptions before comparing tradeoffs. You can also discuss them in the Discord community.
 
 {{#include copyright.md}}

--- a/mini-lsm-book/src/week2-03-tiered.md
+++ b/mini-lsm-book/src/week2-03-tiered.md
@@ -318,15 +318,15 @@ For several simulator iterations, annotate each task with the trigger that selec
 
 ### Amplification and Design
 
-* What is the estimated write amplification of tiered compaction? This is difficult in general; begin by ignoring the final *reduce sorted runs* trigger.
-* What is the estimated read amplification of tiered compaction?
+* Estimate write amplification for one concrete tier-size sequence. Begin by ignoring the final *reduce sorted runs* trigger, and count physical SST bytes written divided by flushed bytes.
+* Estimate worst-case point-read amplification for a state with `N` tiers and no cache or Bloom-filter benefit. Which policy parameter bounds that value?
 * What are the advantages and disadvantages of universal compaction compared with leveled compaction?
-* How much free storage space does universal compaction require relative to the logical data size?
+* How much temporary free storage does one universal-compaction task require? Answer for a concrete set of input-tier sizes and distinguish peak task space from steady-state space amplification.
 * What happens if compaction speed cannot keep up with the SST flushes for tiered compaction?
 * What must the system consider before scheduling multiple compaction tasks in parallel?
 * SSDs also write its own logs (basically it is a log-structured storage). If the SSD has a write amplification of 2x, what is the end-to-end write amplification of the whole system? Related: [ZNS: Avoiding the Block Interface Tax for Flash-based SSDs](https://www.usenix.org/conference/atc21/presentation/bjorling).
 * Consider the case that the user chooses to keep a large number of sorted runs (i.e., 300) for tiered compaction. To make the read path faster, is it a good idea to keep some data structure that helps reduce the time complexity (i.e., to `O(log n)`) of finding SSTs to read in each layer for some key ranges? Note that normally, you will need to do a binary search in each sorted run to find the key ranges that you will need to read. (Check out Neon's [layer map](https://neon.tech/blog/persistent-structures-in-neons-wal-indexing) implementation!)
 
-We do not provide reference answers to these questions, so feel free to discuss them in the Discord community.
+Use the [Week 2 end-of-week self-check](./week2-overview.md#end-of-week-self-check) to calibrate the core invariants. The remaining design questions may have several defensible answers; state your workload and assumptions before comparing tradeoffs. You can also discuss them in the Discord community.
 
 {{#include copyright.md}}

--- a/mini-lsm-book/src/week2-04-leveled.md
+++ b/mini-lsm-book/src/week2-04-leveled.md
@@ -202,8 +202,8 @@ For one simulator task, calculate the target sizes and priorities by hand. Verif
 
 ### Amplification and Design
 
-* What is the estimated write amplification of leveled compaction?
-* What is the estimated read amplification of leveled compaction?
+* Estimate write amplification under an explicit level multiplier, overlap fraction, and steady-state workload. Which term changes when compaction selects one upper SST instead of an entire level?
+* Estimate worst-case point-read amplification with no cache or Bloom-filter benefit. How do overlapping L0 files differ from the one candidate file per lower level?
 * Finding a good key split point for compaction may potentially reduce the write amplification, or it does not matter at all? (Consider that case that the user write keys beginning with some prefixes, `00` and `01`. The number of keys under these two prefixes are different and their write patterns are different. If we can always split `00` and `01` into different SSTs...)
 * Imagine that a user was using tiered (universal) compaction before and wants to migrate to leveled compaction. What might be the challenges of this migration? And how to do the migration?
 * And if we do it reversely, what if the user wants to migrate from leveled compaction to tiered compaction?
@@ -215,7 +215,7 @@ For one simulator task, calculate the target sizes and priorities by hand. Verif
 * Some people propose to do intra-L0 compaction (compact L0 tables and still put them in L0) before pushing them to lower layers. What might be the benefits of doing so? (Might be related: [PebblesDB SOSP'17](https://www.cs.utexas.edu/~vijay/papers/sosp17-pebblesdb.pdf))
 * Consider the case that the upper level has two tables of `[100, 200], [201, 300]` and the lower level has `[50, 150], [151, 250], [251, 350]`. In this case, do you still want to compact one file in the upper level at a time? Why?
 
-We do not provide reference answers to these questions, so feel free to discuss them in the Discord community.
+Use the [Week 2 end-of-week self-check](./week2-overview.md#end-of-week-self-check) to calibrate the core invariants. The remaining design questions may have several defensible answers; state your workload and assumptions before comparing tradeoffs. You can also discuss them in the Discord community.
 
 ## Bonus Tasks
 

--- a/mini-lsm-book/src/week2-05-manifest.md
+++ b/mini-lsm-book/src/week2-05-manifest.md
@@ -132,6 +132,8 @@ Write down the durable events for one flush and one compaction. Insert a hypothe
 * Currently, we create all SST/concat iterators before creating the merge iterator, which means that we have to load the first block of the first SST in all levels into memory before starting the scanning process. We have start/end key in the manifest, and is it possible to leverage this information to delay the loading of the data blocks and make the time to return the first key-value pair faster?
 * Is it possible not to store the tier/level information in the manifest? i.e., we only store the list of SSTs we have in the manifest without the level information, and rebuild the tier/level using the key range and timestamp information (SST metadata).
 
+Use the [Week 2 end-of-week self-check](./week2-overview.md#end-of-week-self-check) to calibrate the core invariants. The remaining design questions may have several defensible answers; state your filesystem model and recovery assumptions before comparing tradeoffs.
+
 ## Bonus Tasks
 
 * **Manifest Compaction.** When the number of logs in the manifest file gets too large, you can rewrite the manifest file to only store the current snapshot and append new logs to that file.

--- a/mini-lsm-book/src/week2-06-wal.md
+++ b/mini-lsm-book/src/week2-06-wal.md
@@ -95,7 +95,7 @@ Test more than a clean close: create several memtables, synchronize, reopen, and
 ### Recovery and Durability
 
 * When should you call `fsync` in your engine? What happens if you call `fsync` too often (i.e., on every put key request)?
-* How costly is the `fsync` operation in general on an SSD (solid state drive)?
+* **Experiment:** Measure batched `fsync` latency and throughput on your own storage device. Record the operating system, filesystem, device, queue depth, and batch size; why is there no single hardware-independent answer?
 * When can you tell the user that their modifications (put/delete) have been persisted?
 * Why must a new memtable be recorded in the manifest before a synchronized write to its WAL can be considered recoverable?
 * Why should a flushed memtable's WAL be deleted only after the manifest's flush record is durable?
@@ -106,6 +106,6 @@ Test more than a clean close: create several memtables, synchronize, reopen, and
 
 * Is it possible to design an LSM engine without WAL (i.e., use L0 as WAL)? What will be the implications of this design?
 
-We do not provide reference answers to these questions, so feel free to discuss them in the Discord community.
+Use the [Week 2 end-of-week self-check](./week2-overview.md#end-of-week-self-check) to calibrate the core invariants. The remaining design questions may have several defensible answers; state your workload and assumptions before comparing tradeoffs. You can also discuss them in the Discord community.
 
 {{#include copyright.md}}

--- a/mini-lsm-book/src/week2-07-snacks.md
+++ b/mini-lsm-book/src/week2-07-snacks.md
@@ -145,7 +145,7 @@ Build a small SST and identify every offset, length, payload, and checksum by by
 
 * Consider the case that an LSM storage engine only provides `write_batch` as the write interface (instead of single put + delete). Is it possible to implement it as follows: there is a single write thread with an mpsc channel receiver to get the changes, and all threads send write batches to the write thread. The write thread is the single point to write to the database. What are the pros/cons of this implementation? (Congrats if you do so you get BadgerDB!)
 
-We do not provide reference answers to these questions, so feel free to discuss them in the Discord community.
+Use the [Week 2 end-of-week self-check](./week2-overview.md#end-of-week-self-check) to calibrate the core invariants. The remaining design questions may have several defensible answers; state your workload and assumptions before comparing tradeoffs. You can also discuss them in the Discord community.
 
 ## Bonus Tasks
 

--- a/mini-lsm-book/src/week2-overview.md
+++ b/mini-lsm-book/src/week2-overview.md
@@ -51,7 +51,7 @@ The three SSTs have overlapping key ranges, so a lookup for key 02333 might prob
 ```
 SST 4: key range 00000 - key 03000, 1000 keys
 SST 5: key range 03001 - key 06000, 1000 keys
-SST 6: key range 06000 - key 10010, 1000 keys
+SST 6: key range 06001 - key 10010, 1000 keys
 ```
 
 The engine merges SSTs 1, 2, and 3, resolves duplicate keys, and splits the sorted result to avoid producing one oversized file. The three output SSTs have non-overlapping ranges, so a lookup for key 02333 needs to inspect only SST 4.
@@ -121,5 +121,45 @@ Before moving to Week 3, check that you can explain:
 - which facts belong in the manifest and which bytes belong in a WAL;
 - the required durable-write order for creating and deleting files;
 - what each checksum covers and how a decoder finds that exact byte range.
+
+## End-of-Week Self-Check
+
+Answer with a concrete file set or event order. These scenarios deliberately combine material from several chapters.
+
+### 1. Compaction Priority and Concurrent Flush
+
+A full-compaction task captures L0 files `[5, 4]` and bottom-level files `[1, 2]`. File 6 is flushed while the task writes its output. File 5 contains the newest entry for `k`, a tombstone; file 1 contains `k -> old`. What remains in L0 after installation, and does `k` appear in the compaction output?
+
+<details>
+
+<summary>Answer criteria</summary>
+
+L0 retains `[6]`; result application removes only the captured files. File 5 has priority over file 1. Because the task includes the bottom level and therefore every possible older version, both the tombstone and `k -> old` may disappear. A non-bottom task would need to retain the tombstone.
+
+</details>
+
+### 2. Crash-Safe File Installation
+
+Order these events for a flush: write the SST, synchronize the SST, synchronize the directory entry, append and synchronize the manifest record. When may an obsolete input file be deleted?
+
+<details>
+
+<summary>Answer criteria</summary>
+
+The new SST contents and its directory entry must be durable before the durable manifest may reference the file. Obsolete inputs may be deleted only after the replacement manifest record is durable, followed by another directory synchronization. A crash may leave an unreferenced extra file, but recovery must never be directed to a missing file.
+
+</details>
+
+### 3. Reading Amplification Numbers
+
+Two policies report different amplification. What must you define before deciding which policy is better?
+
+<details>
+
+<summary>Answer criteria</summary>
+
+Define the workload and the numerator and denominator of every metric: physical read work per logical read, total physical bytes written per logical bytes entering the LSM, and physical storage per live logical data. Also state whether the measurement includes temporary compaction space, cache hits, WAL writes, and device-level write amplification. A policy is not universally better: workload latency and resource limits determine which tradeoff matters.
+
+</details>
 
 {{#include copyright.md}}

--- a/mini-lsm-book/src/week3-01-ts-key-refactor.md
+++ b/mini-lsm-book/src/week3-01-ts-key-refactor.md
@@ -68,6 +68,8 @@ In the key+timestamp ordering, the smallest user key appears first, and the larg
 ("a", 233) < ("a", 0) < ("b", 233) < ("b", 0)
 ```
 
+The descending timestamp order makes snapshot lookup a lower-bound seek. Seeking to `(a, read_ts)` skips `a` versions newer than the snapshot and lands on the greatest timestamp less than or equal to `read_ts`, if one exists. All remaining versions of `a` are adjacent, so the iterator can choose one visible version and then skip the rest. Keeping user keys in ascending order preserves ordinary range-scan order.
+
 ## Task 1: Encode Timestamps in Blocks
 
 Replacing the key module makes representation assumptions visible as compiler errors. In this task, update:
@@ -151,6 +153,6 @@ Verify these cases explicitly:
 * During Day 1, why is it acceptable for `LsmIterator` to return repeated user keys, and why must that behavior change on Day 2?
 * Construct a seek target that distinguishes comparing full internal keys from comparing only user keys.
 
-We do not provide reference answers to these questions, so feel free to discuss them in the Discord community.
+Use the [Week 3 end-of-week self-check](./week3-overview.md#end-of-week-self-check) to calibrate the core invariants. The remaining design questions may have several defensible answers; state your workload and assumptions before comparing tradeoffs. You can also discuss them in the Discord community.
 
 {{#include copyright.md}}

--- a/mini-lsm-book/src/week3-02-snapshot-read-part-1.md
+++ b/mini-lsm-book/src/week3-02-snapshot-read-part-1.md
@@ -174,7 +174,7 @@ Verify these cases explicitly:
 * Why does an excluded lower bound use the opposite timestamp sentinel from an included lower bound?
 * What observable failure occurs if compaction splits two versions of one user key across SSTs in the same level?
 
-We do not provide reference answers to these questions, so feel free to discuss them in the Discord community.
+Use the [Week 3 end-of-week self-check](./week3-overview.md#end-of-week-self-check) to calibrate the core invariants. The remaining design questions may have several defensible answers; state your workload and assumptions before comparing tradeoffs. You can also discuss them in the Discord community.
 
 ## Bonus Tasks
 

--- a/mini-lsm-book/src/week3-03-snapshot-read-part-2.md
+++ b/mini-lsm-book/src/week3-03-snapshot-read-part-2.md
@@ -142,6 +142,6 @@ Verify these cases explicitly:
 * Which object owns the lifetime of a scan's read timestamp, and what could compaction reclaim if that object were dropped too early?
 * Is the maximum timestamp among current SST entries always a durable history of every timestamp ever allocated? What additional metadata would be needed if timestamps must never be reused after all records at the maximum timestamp are garbage-collected?
 
-We do not provide reference answers to these questions, so feel free to discuss them in the Discord community.
+Use the [Week 3 end-of-week self-check](./week3-overview.md#end-of-week-self-check) to calibrate the core invariants. The remaining design questions may have several defensible answers; state your workload and assumptions before comparing tradeoffs. You can also discuss them in the Discord community.
 
 {{#include copyright.md}}

--- a/mini-lsm-book/src/week3-04-watermark.md
+++ b/mini-lsm-book/src/week3-04-watermark.md
@@ -115,6 +115,8 @@ Verify these cases explicitly:
 * Why must compaction keep one version at or below the watermark instead of deleting every version below it?
 * What race appears if a transaction reads the latest timestamp before registering itself with the watermark?
 
+Use the [Week 3 end-of-week self-check](./week3-overview.md#end-of-week-self-check) to calibrate the core invariants. The remaining design questions may have several defensible answers; state your workload and assumptions before comparing tradeoffs.
+
 ## Bonus Tasks
 
 * **O(1) Watermark.** You may implement an amortized O(1) watermark structure by using a hash map or a cyclic queue.

--- a/mini-lsm-book/src/week3-05-txn-occ.md
+++ b/mini-lsm-book/src/week3-05-txn-occ.md
@@ -2,7 +2,7 @@
   mini-lsm-book © 2022-2026 by Alex Chi Z is licensed under CC BY-NC-SA 4.0
 -->
 
-# Transaction and Optimistic Concurrency Control
+# Transaction Workspace and Atomic Commit
 
 By the end of this chapter, you will be able to:
 
@@ -107,13 +107,15 @@ Verify these cases explicitly:
 
 ## Test Your Understanding
 
-* With all the things we have implemented up to this point, does the system satisfy snapshot isolation? If not, what else do we need to do to support snapshot isolation? (Note: snapshot isolation is different from serializable snapshot isolation we will talk about in the next chapter)
+* Compare this chapter's guarantees with classic snapshot isolation as defined in the Week 3 overview. Which first-committer-wins rule is not enforced if two concurrent transactions blindly write the same key? Does allowing both commits necessarily make that particular history non-serializable?
 * What if the user wants to batch import data (i.e., 1TB?) If they use the transaction API to do that, will you give them some advice? Is there any opportunity to optimize for this case?
-* What is optimistic concurrency control? What would the system be like if we implement pessimistic concurrency control instead in Mini-LSM?
+* Day 6 uses optimistic concurrency control: it checks for conflicts at commit instead of preventing them while the transaction runs. What locks or blocking behavior would a pessimistic design add, and how would that change abort rates and concurrency?
 * Why are both a shared commit timestamp and WAL framing required for transaction atomicity?
 * Why must WAL append happen before memtable publication? What should the caller observe if either step fails?
 * When can the engine safely check the memtable size and freeze it without splitting the transaction?
 * Should an empty transaction allocate a commit timestamp? What are the tradeoffs? This checkpoint follows the existing batch-write behavior.
+
+Use the [Week 3 end-of-week self-check](./week3-overview.md#end-of-week-self-check) to calibrate the core invariants. The remaining design questions may have several defensible answers; state your workload and assumptions before comparing tradeoffs.
 
 ## Bonus Tasks
 

--- a/mini-lsm-book/src/week3-06-serializable.md
+++ b/mini-lsm-book/src/week3-06-serializable.md
@@ -2,7 +2,7 @@
   mini-lsm-book © 2022-2026 by Alex Chi Z is licensed under CC BY-NC-SA 4.0
 -->
 
-# (A Partial) Serializable Snapshot Isolation
+# Serializable Validation (with a Scan Limitation)
 
 By the end of this chapter, you will be able to:
 
@@ -20,6 +20,8 @@ cargo x scheck
 ## Before You Begin
 
 Day 5 provides stable snapshots and crash-atomic writes, but two transactions can still make decisions from the same old state and produce write skew. Day 6 validates a transaction immediately before commit.
+
+This chapter does not implement the full Serializable Snapshot Isolation (SSI) algorithm from the research literature. For point reads, it uses a simpler and more conservative rule: abort when the current transaction's read set intersects the write set of any transaction committed after its snapshot. Holding one commit lock across validation and publication lets each accepted writing transaction be serialized at its commit position; read-only transactions remain at their snapshot position. The rule may reject some histories that were already serializable. For scans, recording only returned keys misses gaps and therefore cannot provide the same guarantee.
 
 Keep these invariants in mind:
 
@@ -150,14 +152,14 @@ Verify these cases explicitly:
 ## Test Your Understanding
 
 * If you have some experience with building a relational database, you may think about the following question: assume that we build a database based on Mini-LSM where we store each row in the relation table as a key-value pair (key: primary key, value: serialized row) and enable serializable verification, does the database system directly gain ANSI serializable isolation level capability? Why or why not?
-* The thing we implement here is actually write snapshot-isolation (see [A critique of snapshot isolation](https://dl.acm.org/doi/abs/10.1145/2168836.2168853)) that guarantees serializable. Is there any cases where the execution is serializable, but will be rejected by the write snapshot-isolation validation?
+* The point-key rule is related to write snapshot isolation (see [A critique of snapshot isolation](https://dl.acm.org/doi/abs/10.1145/2168836.2168853)): it aborts on any relevant read-after-snapshot write conflict instead of detecting only cycles. Construct a serializable execution that this conservative rule still rejects.
 * There are databases that claim they have serializable snapshot isolation support by only tracking the keys accessed in gets and scans (instead of key range). Do they really prevent write skews caused by phantoms? (Okay... Actually, I'm talking about [BadgerDB](https://dgraph.io/blog/post/badger-txn/).)
 * Why must `commit_lock` cover both validation and publication? Construct an interleaving that fails if the lock is released between them.
 * Why does a `get` miss belong in the read set?
 * Why can two transactions that only write the same key both commit without violating serializability?
 * Which committed transaction records are safe to garbage-collect at a given watermark?
 
-We do not provide reference answers to these questions, so feel free to discuss them in the Discord community.
+Use the [Week 3 end-of-week self-check](./week3-overview.md#end-of-week-self-check) to calibrate the core invariants. The remaining design questions may have several defensible answers; state your workload and assumptions before comparing tradeoffs. You can also discuss them in the Discord community.
 
 ## Bonus Tasks
 

--- a/mini-lsm-book/src/week3-07-compaction-filter.md
+++ b/mini-lsm-book/src/week3-07-compaction-filter.md
@@ -87,6 +87,6 @@ Verify these cases explicitly:
 * How would you report progress for a `DROP TABLE` operation backed by an asynchronous compaction filter?
 * What API or metadata would be needed to remove or supersede a previously installed filter safely?
 
-We do not provide reference answers to these questions, so feel free to discuss them in the Discord community.
+Use the [Week 3 end-of-week self-check](./week3-overview.md#end-of-week-self-check) to calibrate the core invariants. The remaining design questions may have several defensible answers; state your workload and assumptions before comparing tradeoffs. You can also discuss them in the Discord community.
 
 {{#include copyright.md}}

--- a/mini-lsm-book/src/week3-overview.md
+++ b/mini-lsm-book/src/week3-overview.md
@@ -39,6 +39,20 @@ Managed mode requires the caller to provide timestamps. They might come from a c
 
 In unmanaged mode, the engine chooses timestamps. A transaction records the latest committed timestamp when it begins. Later commits remain invisible to that transaction, so every read observes the same logical snapshot.
 
+## Separate the Guarantees
+
+MVCC is a mechanism for storing and selecting versions; by itself, it does not define all transaction guarantees. Keep these questions separate as you work through the week:
+
+1. **Version order:** Which versions exist, and how are they ordered in memtables and SSTs?
+2. **Snapshot visibility:** Given `read_ts`, which committed version may a read observe? A stable snapshot prevents later commits from appearing halfway through a transaction.
+3. **Atomic commit:** Do all writes in one transaction become visible together? Mini-LSM uses one commit timestamp for atomic visibility and one framed WAL batch for all-or-nothing recovery. These are related but distinct guarantees.
+4. **Durability:** After which synchronization point must a successful commit survive a crash? A well-framed WAL record can still be lost if it was not made durable.
+5. **Isolation:** Is the outcome of concurrent transactions equivalent to some serial order? Stable snapshots alone do not ensure this; write skew is a counterexample.
+
+Classic **snapshot isolation** gives each transaction the committed snapshot from its start, includes its own writes, and prevents two concurrent transactions that update the same item from both committing. Even with that write-write rule, transactions that write different items can produce write skew. See the background and write-skew example in [Serializable Isolation for Snapshot Databases](https://www.cs.cornell.edu/~sowell/dbpapers/serializable_isolation.pdf).
+
+Mini-LSM builds these properties incrementally. Days 1–4 implement version ordering, stable snapshots, and safe version reclamation. Day 5 adds a private workspace plus atomic visibility and crash-atomic WAL batches; it does not yet validate concurrent decisions. Day 6 adds conservative commit-time validation for point-key dependencies. Because scans record returned keys rather than the gaps in a range predicate, the completed exercise does **not** provide full serializability for scan-heavy workloads. This scope is part of the lesson, not an implementation detail to hide.
+
 The first three chapters refactor internal formats and finish snapshot reads. The remaining chapters track active snapshots, add transactional writes and validation, and reclaim obsolete data.
 
 | Chapter | Before | After |
@@ -47,8 +61,8 @@ The first three chapters refactor internal formats and finish snapshot reads. Th
 | [Day 2: Memtables and Timestamps](./week3-02-snapshot-read-part-1.md) | Most data still uses timestamp 0. | Writes receive one commit timestamp per batch and all versions survive compaction. |
 | [Day 3: Transaction API](./week3-03-snapshot-read-part-2.md) | Reads return only the newest global state. | Transactions select the newest visible version at a fixed read timestamp, including after recovery. |
 | [Day 4: Watermark and Garbage Collection](./week3-04-watermark.md) | Compaction retains every historical version. | Compaction retains exactly the versions active snapshots can still observe. |
-| [Day 5: Transactional Writes](./week3-05-txn-occ.md) | Transaction writes are neither private nor crash-atomic. | A transaction reads its own workspace and commits one timestamped, framed WAL batch. |
-| [Day 6: Serializable Validation](./week3-06-serializable.md) | Snapshot isolation permits write skew. | Commit-time validation rejects read/write conflicts for tracked keys. |
+| [Day 5: Transaction Workspace and Atomic Commit](./week3-05-txn-occ.md) | Transaction writes are neither private nor crash-atomic. | A transaction reads its own workspace and commits one timestamped, framed WAL batch. |
+| [Day 6: Serializable Validation](./week3-06-serializable.md) | Stable snapshots still permit write skew. | Commit-time validation rejects read/write conflicts for tracked keys. |
 | [Day 7: Compaction Filters](./week3-07-compaction-filter.md) | Garbage collection is based only on version age. | User-installed filters can reclaim a logical key prefix during compaction. |
 
 ## How to Use This Week
@@ -70,5 +84,57 @@ Before finishing Week 3, check that you can explain:
 - why a shared commit timestamp provides atomic visibility while a framed, checksummed WAL batch provides crash atomicity;
 - what anomaly commit-time validation prevents and which scan phantoms it does not prevent; and
 - why a compaction filter cannot blindly remove versions newer than the watermark.
+
+## End-of-Week Self-Check
+
+For each scenario, name the relevant guarantee before answering. This is as important as computing the visible value.
+
+### 1. Snapshot Visibility and Tombstones
+
+The internal stream contains `k@9=delete, k@7=v7, k@3=v3`. What does a read return at timestamps 10, 8, 7, and 2?
+
+<details>
+
+<summary>Answer criteria</summary>
+
+At 10, the newest visible version is the tombstone at 9, so the key is absent. At 8 and 7, `v7` is visible. At 2, no version is visible. A correct iterator skips versions newer than `read_ts`, chooses the first remaining version, and never continues past a chosen tombstone to resurrect an older value.
+
+</details>
+
+### 2. Watermark Garbage Collection
+
+For the same versions and watermark 7, which versions must a non-bottom compaction retain? What may a bottom-level compaction do after the watermark advances to 9?
+
+<details>
+
+<summary>Answer criteria</summary>
+
+At watermark 7, retain every version above it (`k@9`) and the newest version at or below it (`k@7`); `k@3` is obsolete. After the watermark reaches 9, a bottom-level compaction may remove the selected tombstone and all older versions because no active snapshot needs them and no older value can survive below the task.
+
+</details>
+
+### 3. Atomicity Is Not Durability or Serializability
+
+One transaction writes `a` and `b`. Name what one shared commit timestamp guarantees, what one framed and checksummed WAL batch guarantees, and what `sync` adds. Do any of these alone prevent write skew?
+
+<details>
+
+<summary>Answer criteria</summary>
+
+The shared timestamp makes the completed batch visible as one logical version. WAL framing and verification prevent recovery from exposing only a prefix of a torn or corrupt batch. Synchronization establishes the point after which the record must survive a crash. None of these validates dependencies between concurrent transactions, so none alone prevents write skew.
+
+</details>
+
+### 4. Validation Scope
+
+T1 and T2 begin at timestamp 10. T1 reads `b` and writes `a`; T2 reads `a` and writes `b`. T1 commits first. Why should T2 abort? Why can the same key-only scheme miss an insert into an empty scan range?
+
+<details>
+
+<summary>Answer criteria</summary>
+
+T1's committed write set contains `a`, which intersects T2's read set, so T2 must abort to break the write-skew execution. An empty range scan returns no keys to hash; an insertion into the gap therefore has no recorded key intersection. Preventing that phantom requires tracking the predicate or key range, not only returned keys.
+
+</details>
 
 {{#include copyright.md}}


### PR DESCRIPTION
## Why

Weeks 1–3 already teach implementation invariants well, but students entering with the preface's Bitcask-level background still lack a direct bridge to LSM structure. Week 3 also moves among MVCC, atomicity, durability, snapshot isolation, and serializability without first separating those guarantees. The chapter questions are strong prompts but provide little self-calibration.

## What changed

- Clarify the prerequisite boundary and connect Bitcask concepts to sorted runs, merge reads, compaction, WALs, and manifests.
- Add integrated end-of-week self-checks with collapsed answer criteria and point every chapter to them.
- Separate Week 3 transaction guarantees and align the Day 5/6 titles and scope with the implemented validation.
- Make workload- and hardware-dependent questions require explicit assumptions or experiments.
- Add missing rationale for block offsets and timestamp ordering, and fix one overlapping range in a non-overlap example.

## Validation

`mdbook build` passes. `mdbook test` remains unusable because pre-existing unlabeled shell, path, diagram, and pseudocode fences are interpreted as Rust doctests; this change adds no Rust code fences.

_AI-assisted: Codex._
