### PR TITLE
fix: tolerate a concurrently drained flush queue

### DIFF
--- a/mini-lsm-book/src/week1-06-write-path.md
+++ b/mini-lsm-book/src/week1-06-write-path.md
@@ -56,6 +56,8 @@ We have not yet discussed level 0 (L0). It contains SST files produced directly 
 
 Creating an SST is computationally expensive and involves I/O. Do not hold the `state` read-write lock throughout this work: doing so could block other operations and cause large latency spikes. The `state_lock` mutex serializes operations that modify the LSM-tree state. Use both locks carefully to prevent races while keeping critical sections short.
 
+A caller can observe a non-empty immutable-memtable list before acquiring `state_lock`, then find that another flush drained the list first. Recheck the list while holding `state_lock` and return successfully when it is already empty.
+
 The test suite does not exercise all concurrent cases, so reason carefully about synchronization. The last memtable in `imm_memtables` is the oldest and therefore the one to flush.
 
 <details>
@@ -68,7 +70,10 @@ fn force_flush_next_imm_memtable(&self) -> Result<()> {
 
     let memtable_to_flush = {
         let guard = self.state.read();
-        guard.imm_memtables.last().unwrap().clone()
+        let Some(memtable) = guard.imm_memtables.last() else {
+            return Ok(());
+        };
+        memtable.clone()
     };
 
     let sst_id = memtable_to_flush.id();

--- a/mini-lsm-mvcc/src/lsm_storage.rs
+++ b/mini-lsm-mvcc/src/lsm_storage.rs
@@ -731,16 +731,13 @@ impl LsmStorageInner {
     pub fn force_flush_next_imm_memtable(&self) -> Result<()> {
         let state_lock = self.state_lock.lock();
 
-        let flush_memtable;
-
-        {
+        let flush_memtable = {
             let guard = self.state.read();
-            flush_memtable = guard
-                .imm_memtables
-                .last()
-                .expect("no imm memtables!")
-                .clone();
-        }
+            let Some(flush_memtable) = guard.imm_memtables.last() else {
+                return Ok(());
+            };
+            flush_memtable.clone()
+        };
 
         let mut builder = SsTableBuilder::new(self.options.block_size);
         flush_memtable.flush(&mut builder)?;

--- a/mini-lsm-mvcc/src/tests/week3_day4.rs
+++ b/mini-lsm-mvcc/src/tests/week3_day4.rs
@@ -28,6 +28,19 @@ use super::harness::{
 };
 
 #[test]
+fn test_force_flush_empty_imm_memtable() {
+    let dir = tempdir().unwrap();
+    let options = LsmStorageOptions::default_for_week2_test(CompactionOptions::NoCompaction);
+    let storage = MiniLsm::open(&dir, options).unwrap();
+
+    storage.inner.force_flush_next_imm_memtable().unwrap();
+
+    let state = storage.inner.state.read();
+    assert!(state.imm_memtables.is_empty());
+    assert!(state.l0_sstables.is_empty());
+}
+
+#[test]
 fn test_task3_compaction_keeps_versions_together() {
     let dir = tempdir().unwrap();
     let mut options = LsmStorageOptions::default_for_week2_test(CompactionOptions::NoCompaction);

--- a/mini-lsm/src/lsm_storage.rs
+++ b/mini-lsm/src/lsm_storage.rs
@@ -673,16 +673,13 @@ impl LsmStorageInner {
     pub fn force_flush_next_imm_memtable(&self) -> Result<()> {
         let state_lock = self.state_lock.lock();
 
-        let flush_memtable;
-
-        {
+        let flush_memtable = {
             let guard = self.state.read();
-            flush_memtable = guard
-                .imm_memtables
-                .last()
-                .expect("no imm memtables!")
-                .clone();
-        }
+            let Some(flush_memtable) = guard.imm_memtables.last() else {
+                return Ok(());
+            };
+            flush_memtable.clone()
+        };
 
         let mut builder = SsTableBuilder::new(self.options.block_size);
         flush_memtable.flush(&mut builder)?;

--- a/mini-lsm/src/tests/week1_day6.rs
+++ b/mini-lsm/src/tests/week1_day6.rs
@@ -26,6 +26,19 @@ use crate::{
 };
 
 #[test]
+fn test_force_flush_empty_imm_memtable() {
+    let dir = tempdir().unwrap();
+    let storage =
+        Arc::new(LsmStorageInner::open(&dir, LsmStorageOptions::default_for_week1_test()).unwrap());
+
+    storage.force_flush_next_imm_memtable().unwrap();
+
+    let state = storage.state.read();
+    assert!(state.imm_memtables.is_empty());
+    assert!(state.l0_sstables.is_empty());
+}
+
+#[test]
 fn test_task1_storage_scan() {
     let dir = tempdir().unwrap();
     let storage =


### PR DESCRIPTION
## Why

Manual and background flush callers check whether immutable memtables exist before `force_flush_next_imm_memtable` acquires `state_lock`. Another flush can drain the queue between those steps, turning a valid concurrent outcome into the `no imm memtables!` panic seen in CI.

## What changed

- Treat an already-drained immutable-memtable queue as a successful no-op after acquiring `state_lock`.
- Apply the behavior consistently to the base and MVCC reference implementations.
- Add deterministic regression coverage for flushing an empty queue.
- Update the Week 1 write-path explanation and pseudocode with the same concurrency rule.

## Validation

All 145 tests across `mini-lsm` and `mini-lsm-mvcc` pass, including the previously failing MVCC compaction test. Formatting, clippy, mdBook, and diff checks also pass.

_AI-assisted: Codex._
