### PR TITLE
fix typo reference to `LsmIterator` to avoid slight confusion

### DIFF
--- a/mini-lsm-book/src/week2-01-compaction.md
+++ b/mini-lsm-book/src/week2-01-compaction.md
@@ -109,8 +109,8 @@ src/compact.rs
 ```
 
 Now update the two-level read path to use the concat iterator for L1.
-LsmIterator
-Change the inner iterator type of `LsmStorageIterator`. Merge the memtable and L0 iterators first, then use `TwoMergeIterator` to combine that newer stream with the L1 concat iterator.
+
+Change the inner iterator type of `LsmIterator`. Merge the memtable and L0 iterators first, then use `TwoMergeIterator` to combine that newer stream with the L1 concat iterator.
 
 You can also change your compaction implementation to leverage the concat iterator.
 

--- a/mini-lsm-book/src/week2-01-compaction.md
+++ b/mini-lsm-book/src/week2-01-compaction.md
@@ -109,7 +109,7 @@ src/compact.rs
 ```
 
 Now update the two-level read path to use the concat iterator for L1.
-
+LsmIterator
 Change the inner iterator type of `LsmStorageIterator`. Merge the memtable and L0 iterators first, then use `TwoMergeIterator` to combine that newer stream with the L1 concat iterator.
 
 You can also change your compaction implementation to leverage the concat iterator.

--- a/mini-lsm-book/src/week2-02-simple.md
+++ b/mini-lsm-book/src/week2-02-simple.md
@@ -160,7 +160,7 @@ src/lsm_iterator.rs
 src/lsm_storage.rs
 ```
 
-Extend both `get` and `scan` across every level below L1. Change the inner type of `LsmStorageIterator` so that it merges one `SstConcatIterator` per level.
+Extend both `get` and `scan` across every level below L1. Change the inner type of `LsmIterator` so that it merges one `SstConcatIterator` per level.
 
 To test your implementation interactively,
 


### PR DESCRIPTION
Hi, thanks for the great book! It really helps me to learn Rust & LSM store

I found a minor typo on this page
https://skyzh.github.io/mini-lsm/week2-01-compaction.html#task-2-concat-iterator:~:text=Change%20the%20inner%20iterator%20type%20of%20LsmStorageIterator.%20Merge%20the%20memtable%20and%20L0%20iterators%20first%2C%20then%20use%20TwoMergeIterator%20to%20combine%20that%20newer%20stream%20with%20the%20L1%20concat%20iterator.

> Change the inner iterator type of `LsmStorageIterator`. Merge the memtable and L0 iterators first, then use `TwoMergeIterator` to combine that newer stream with the L1 concat iterator.

That may actually refer to this struct, because there's no  `LsmStorageIterator` in the codebase

https://github.com/skyzh/mini-lsm/blob/2efead93f2a5cd3fed90095341b10d0c1e309073/mini-lsm/src/lsm_iterator.rs#L33-L36