### PR TITLE
Use stable Rust toolchain

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.97.1"
+channel = "stable"
 components = [ "rustfmt", "clippy" ]
 profile = "minimal"


### PR DESCRIPTION
Use the moving stable Rust channel for local development and CI instead of pinning `rust-toolchain.toml` to a specific compiler patch release. This keeps the repository on the current stable compiler while preserving the existing minimal profile, rustfmt, and clippy components.

_AI-assisted: Codex._
