### PR TITLE
Stage coding-agent tests after first-pass implementation

### DIFF
--- a/mini-lsm-book/src/agent-fast-forward-overview.md
+++ b/mini-lsm-book/src/agent-fast-forward-overview.md
@@ -48,7 +48,7 @@ The final component of `pwd` should be `mini-lsm-starter`. This matters because 
 
 Starting there is not a security sandbox: an agent can still traverse to a parent directory if instructed. The local `AGENTS.md` therefore prohibits reading, searching, diffing, or copying `../mini-lsm`, including attempts to reconstruct the solution through Git history or an online copy.
 
-Do not open the whole repository as the agent's workspace if your tool lets you choose a directory. The agent may consult copied tests, starter interfaces, Rust documentation, and course chapters under `../mini-lsm-book/src/`.
+Do not open the whole repository as the agent's workspace if your tool lets you choose a directory. The agent may consult starter interfaces, Rust documentation, and course chapters under `../mini-lsm-book/src/`. It may consult a copied test only after finishing an independent first-pass implementation of that test's checkpoint.
 
 ### 3. Verify the Instructions Before Coding
 
@@ -70,11 +70,12 @@ Repeat this loop:
 
 1. **Agent gives one short stop.** It starts with a concrete example, labels the question **Course rule** or **Your choice**, and asks you to choose or predict in plain English.
 2. **Student reasons.** State a choice and why. A prediction is useful even when you are uncertain.
-3. **Agent checks the reasoning.** It connects the answer to interfaces, prose, or tests. If the answer violates a constraint, it shows the evidence and asks again instead of silently overriding you.
+3. **Agent checks the reasoning.** It connects the answer to interfaces, prose, or already-revealed tests. If the answer violates a constraint, it shows the evidence and asks again instead of silently overriding you.
 4. **Agent records the choice.** The accepted answer enters a short decision ledger.
-5. **Agent implements one slice.** Once enough decisions specify a coherent slice, it previews the files, behavior, and focused test and waits for your authorization.
-6. **Tests produce evidence.** A coding mistake can be fixed directly. A failure that exposes an unsettled or incorrect design returns to the dialogue.
-7. **Student reviews.** Inspect the diff and test output before authorizing the next slice.
+5. **Agent implements one slice independently.** Once enough decisions specify a coherent slice, it previews the files, behavior, and later validation target and waits for your authorization. It completes a compiling first pass without copying or inspecting the supplied tests.
+6. **Reveal tests after the checkpoint.** Once the checkpoint's first pass is complete, copy its test module and run the focused check. The implementation comes from the specification and accepted decisions; the test is new evidence rather than a design source.
+7. **Student diagnoses product failures.** The agent explains the test's setup, expected result, observed result, and implicated invariant, then asks you to identify the likely bad execution path. It does not investigate the implementation or propose a fix before your attempt. Test-harness and environmental failures remain the agent's responsibility.
+8. **Student reviews.** Inspect the diff and test output before authorizing a diagnosed fix or the next slice.
 
 The agent must stop on topics that affect behavior or understanding: representation, ordering, ownership, size and boundary accounting, seek behavior, errors, synchronization, and where an optimization belongs. Some answers are course rules to derive; others are genuine choices. It need not interrupt you over a local variable name, import order, formatting, or an obvious compiler-directed repair.
 
@@ -121,7 +122,11 @@ Before each edit, the agent should state:
 
 - which accepted decisions determine the slice;
 - which files and observable behavior will change; and
-- which focused check it expects to exercise that behavior.
+- which supplied test module will be revealed after the independent first pass.
+
+Non-test compiler and formatter feedback may be used during implementation. Do not run, copy, or inspect the supplied behavioral tests until the checkpoint is implemented end to end. This prevents the agent from reconstructing the implementation one assertion at a time while still making the tests available as independent evidence.
+
+When a newly revealed product-behavior test fails, the agent may read the test and report what it does. It should not trace the implementation, identify the faulty line, propose a patch, or silently repair the failure. First ask the student to connect the failure to the decision ledger and propose a diagnosis. After the student reaches or accepts a diagnosis, the agent may implement an authorized fix and rerun the test. The agent should handle broken test commands, missing tools, dependency problems, and other harness failures directly.
 
 After the edit, require the exact command and result, then ask:
 

--- a/mini-lsm-book/src/week1-fast-forward.md
+++ b/mini-lsm-book/src/week1-fast-forward.md
@@ -25,16 +25,15 @@ At the end of this path:
 
 The tests are evidence, not the specification. Generated code remains untrusted until you can connect it to a decision and an invariant and try to falsify it.
 
-## Copy the Complete Test Suite
+## Begin Without the Supplied Tests
 
-Complete the repository and agent preparation in the [track overview](./agent-fast-forward-overview.md#prepare-the-repository-and-the-agent). Leave the agent at the instruction-handshake stop, then run these commands from the repository root:
+Complete the repository and agent preparation in the [track overview](./agent-fast-forward-overview.md#prepare-the-repository-and-the-agent). Leave the agent at the instruction-handshake stop. From the repository root, verify that the untouched starter compiles without copying any supplied tests:
 
 ```shell
-cargo x copy-test --week 1
-cargo x scheck
+cargo check -p mini-lsm-starter --lib
 ```
 
-The initial check should fail because the starter contains unfinished code. Record the first failure as a reproducible baseline. Do not ask the agent to make it disappear by changing the tests.
+Do not run `cargo x copy-test --week 1` yet. Each checkpoint begins from the book, starter interfaces, and your accepted decisions. Only after the checkpoint has a compiling first-pass implementation should you reveal its test modules. This gives the tests an independent role: they challenge the implementation instead of quietly specifying it assertion by assertion.
 
 ## Start Day 1
 
@@ -67,7 +66,16 @@ The agent should use concrete examples to help you work out at least these cours
 
 One critical outcome is that an ordinary write retains the `state` read guard until insertion into the mutable memtable completes. Writing through a cloned snapshot after releasing the guard permits a concurrent freeze to make that memtable immutable before the write occurs.
 
-Once the representation and ordering rules are settled, authorize the smallest coherent slice. After its focused test passes, have the agent point to the exact comparison that resolves duplicate keys. Explain in your own words what that line is trying to do and why changing `>` to `>=`, or reversing input order, changes the visible value.
+Once the representation and ordering rules are settled, authorize the checkpoint's coherent implementation slices. After the complete checkpoint has a compiling first pass, reveal and run its tests from the repository root:
+
+```shell
+cargo x copy-test --week 1 --day 1
+cargo x copy-test --week 1 --day 2
+cargo test -p mini-lsm-starter week1_day1
+cargo test -p mini-lsm-starter week1_day2
+```
+
+After they pass, have the agent point to the exact comparison that resolves duplicate keys. Explain in your own words what that line is trying to do and why changing `>` to `>=`, or reversing input order, changes the visible value.
 
 ## Checkpoint 2: Durable Representation
 
@@ -120,7 +128,20 @@ Treat the writer and reader as two parties implementing a protocol. A round-trip
 
 </details>
 
-The example begins with an operation the student can picture and names the concept afterward. A real implementation stop must still preview the files and focused test, wait for authorization, report actual evidence, and stop before beginning the next slice. An unexpected test failure either reveals a mechanical bug or reopens one specific decision.
+The example begins with an operation the student can picture and names the concept afterward. A real implementation stop must still preview the files and later validation target, wait for authorization, complete the checkpoint's first pass before revealing tests, report actual evidence, and stop before beginning the next slice.
+
+After the durable-representation checkpoint has a compiling first pass, reveal and run its tests:
+
+```shell
+cargo x copy-test --week 1 --day 3
+cargo x copy-test --week 1 --day 4
+cargo x copy-test --week 1 --day 7
+cargo test -p mini-lsm-starter week1_day3
+cargo test -p mini-lsm-starter week1_day4
+cargo test -p mini-lsm-starter week1_day7
+```
+
+If a newly revealed test fails, the agent should explain the entries, bounds, or bytes the test supplies, the expected and observed result, and the challenged invariant. It must then ask you to diagnose the implementation. It should not search for the faulty line or suggest a repair before your attempt. Failures in the test command, dependency setup, or harness itself are exceptions that the agent may investigate directly.
 
 Before approving the completed checkpoint, decode three keys by hand: one with no shared prefix, one with a long shared prefix, and one with an empty value. Confirm that a seek returns the first key greater than or equal to its target and that a Bloom-filter negative can never hide a present key.
 
@@ -157,6 +178,15 @@ Expensive SST construction and I/O should happen outside the `state` read-write 
 For Day 1, the lifecycle contract is fixed: `close` stops and joins the existing worker threads and is harmless when called again after their handles have already been taken. It does not implicitly flush the remaining mutable memtable. Treat a different contract as an explicit scope change, not an ordinary implementation preference.
 
 Before approving this checkpoint, construct one key that appears in the mutable memtable, an immutable memtable, and an L0 SST. Predict `get` and `scan` when the newest entry is first a value and then a tombstone. Also exercise included, excluded, and unbounded scan endpoints.
+
+After this checkpoint has a compiling first pass, reveal and run its tests:
+
+```shell
+cargo x copy-test --week 1 --day 5
+cargo x copy-test --week 1 --day 6
+cargo test -p mini-lsm-starter week1_day5
+cargo test -p mini-lsm-starter week1_day6
+```
 
 ## Audit the Finished Engine
 

--- a/mini-lsm-book/src/week2-fast-forward.md
+++ b/mini-lsm-book/src/week2-fast-forward.md
@@ -30,14 +30,13 @@ Tests and simulator output are evidence, not the specification. A plausible file
 
 ## Prepare Day 2
 
-Begin from a Day 1 implementation that passes its complete suite. From the repository root, copy all available Week 2 tests and record the first failure:
+Begin from a Day 1 implementation that passes its complete suite. Verify that it still compiles, but do not copy the Week 2 tests yet:
 
 ```shell
-cargo x copy-test --week 2
-cargo x scheck
+cargo check -p mini-lsm-starter --lib
 ```
 
-Week 2 has supplied tests for its original Days 1 through 6. The checksum work from original Day 7 has no dedicated supplied tests, so you will need your own corruption cases.
+Week 2 has supplied tests for its original Days 1 through 6. Reveal each one only after the corresponding checkpoint or compaction policy has a compiling independent first pass. The checksum work from original Day 7 has no dedicated supplied tests, so you will need your own corruption cases.
 
 With the agent running from `mini-lsm-starter`, send:
 
@@ -79,7 +78,14 @@ Inputs must be presented to the merge iterator from newest to oldest. A tombston
 
 L1 is one sorted run: its SST ranges do not overlap and are ordered by first key. Its concat iterator should open only the active SST rather than eagerly loading one block from every file.
 
-Before approving the checkpoint, use one key that appears in both L0 and L1. Predict the result when L0 contains a value and when it contains a tombstone. After the focused checks pass, explain the line that removes captured L0 IDs without removing a later flush.
+Reveal Week 2 Day 1 only after this checkpoint's first pass is complete:
+
+```shell
+cargo x copy-test --week 2 --day 1
+cargo test -p mini-lsm-starter week2_day1
+```
+
+Before approving the checkpoint, use one key that appears in both L0 and L1. Predict the result when L0 contains a value and when it contains a tombstone. After the focused check passes, explain the line that removes captured L0 IDs without removing a later flush.
 
 ## Checkpoint 2: Decide What to Compact
 
@@ -94,7 +100,24 @@ Follow this default sequence for each policy:
 1. implement task selection and result application against the simulator state;
 2. run a short simulator trace and explain every selected task;
 3. add the policy to compaction dispatch, flushing, and reads; and
-4. stop for review before beginning the next policy.
+4. reveal and run that policy's supplied test only after its first pass is complete; and
+5. stop for review before beginning the next policy.
+
+The policy tests map to commands as follows:
+
+```shell
+# Simple leveled
+cargo x copy-test --week 2 --day 2
+cargo test -p mini-lsm-starter week2_day2
+
+# Tiered
+cargo x copy-test --week 2 --day 3
+cargo test -p mini-lsm-starter week2_day3
+
+# Dynamic leveled
+cargo x copy-test --week 2 --day 4
+cargo test -p mini-lsm-starter week2_day4
+```
 
 Do not treat “which policies should exist?” as a student preference: the completed Week 2 track implements all three. The policy algorithms are course rules; helper structure, allocation, and equivalent search methods may be genuine choices.
 
@@ -186,6 +209,15 @@ Recovery may see the old logical state or the new logical state at some crash bo
 When WALs are enabled, create the WAL, sync its directory entry, and durably record `NewMemtable(id)` before making that memtable available for writes. `sync` must flush the `BufWriter` and then call `sync_all`. A durable flush record retires the WAL logically before its filename is removed. Recovery ignores such stale files, restores live immutable memtables newest to oldest, and sets `next_sst_id` to one greater than every live SST or WAL ID.
 
 Without WALs, `close` flushes every non-empty memtable. With WALs, it synchronizes them instead. In both cases, it stops and joins the background threads and remains harmless when called again.
+
+Reveal the manifest and WAL tests only after this checkpoint's first pass is complete:
+
+```shell
+cargo x copy-test --week 2 --day 5
+cargo x copy-test --week 2 --day 6
+cargo test -p mini-lsm-starter week2_day5
+cargo test -p mini-lsm-starter week2_day6
+```
 
 Before approving the checkpoint, write the event sequence for one flush and place a crash after every event. Then recover a manifest containing interleaved `NewMemtable`, `Flush`, and `Compaction` records by hand. After the focused tests pass, explain the line that prevents a manifest record from becoming durable before its new file.
 

--- a/mini-lsm-starter/AGENTS.md
+++ b/mini-lsm-starter/AGENTS.md
@@ -10,7 +10,7 @@ The student owns the explicit design decisions permitted by the course contract 
 
 - Never read, search, inspect, diff, or copy the reference implementation in `../mini-lsm/`.
 - Never reconstruct the reference implementation from Git history, another branch or tag, a remote repository, generated documentation, build artifacts, or an online copy.
-- Running `cargo x copy-test` is allowed. After it copies tests into this starter directory, you may read those copied tests. Do not directly open the source test files under `../mini-lsm/`.
+- Do not copy, read, search, or otherwise inspect the supplied tests for a checkpoint before completing an independent first-pass implementation of that checkpoint. Running `cargo x copy-test` is allowed only after that implementation is complete. After the command copies the relevant tests into this starter directory, you may read those copied tests. Do not directly open the source test files under `../mini-lsm/`.
 - Do not hand-edit provided tests, the test harness, or `src/tests.rs`; only `cargo x copy-test` may add test modules and rewrite `src/tests.rs`. Do not disable, ignore, weaken, or delete tests or assertions.
 - Do not change expected output, public interfaces, dependencies, or workspace configuration merely to make the implementation easier or make a check pass. If a task genuinely requires one of these changes, explain why and get the student's approval first.
 - Do not add broad lint suppressions, placeholder success values, fake implementations, or catch-all error handling that hides unfinished behavior.
@@ -25,16 +25,16 @@ A request such as “implement block format” starts a design dialogue. It does
 
 Before editing:
 
-1. Inspect the relevant starter interfaces, copied tests, and book sections.
+1. Inspect the relevant starter interfaces and book sections. Do not inspect supplied tests that have not yet been revealed for the checkpoint.
 2. Identify the checkpoint boundary and the decisions required to specify it.
 3. Ask about one consequential design decision, then stop. Begin with a small concrete state or operation, use plain English, and introduce the technical term after the student reasons about the example.
-4. After the student answers, evaluate the answer against the interfaces, tests, and invariants. Correct a misunderstanding with evidence; do not quietly replace the student's choice.
+4. After the student answers, evaluate the answer against the interfaces, book material, and invariants available at that stage. Correct a misunderstanding with evidence; do not quietly replace the student's choice.
 5. Record the accepted choice in a short decision ledger, then ask the next question.
-6. When the decisions needed for the next coherent code slice are settled, summarize that slice and its expected test, then wait for the student to authorize the edit.
+6. When the decisions needed for the next coherent code slice are settled, summarize that slice and the supplied test module that will be revealed later, then wait for the student to authorize the edit.
 
 A consequential decision changes observable behavior, correctness, compatibility, or the student's mental model. Examples include data layout, ordering and duplicate precedence, size accounting, ownership, seek semantics, boundary conditions, error handling, synchronization, and which layer owns an optimization. Mechanical choices such as local variable names, import ordering, formatting, and an obvious compiler-directed type correction do not require a stop.
 
-Stop eliciting decisions when the public contract, supplied tests, and selected adversarial cases determine the next slice. Internal bookkeeping that follows an accepted invariant is mechanical. Do not invent hypothetical policy choices merely to prolong the interview.
+Stop eliciting decisions when the public contract, book material, and selected adversarial cases determine the next slice. Internal bookkeeping that follows an accepted invariant is mechanical. Do not invent hypothetical policy choices merely to prolong the interview.
 
 Ask questions that require reasoning. Mark each stop as one of:
 
@@ -79,14 +79,16 @@ For each authorized slice:
 1. Restate the decisions and invariants that determine the code.
 2. List the files and behavior you expect to change.
 3. Make the smallest coherent diff that expresses those decisions.
-4. Run the narrowest relevant check and show the exact result.
-5. If the check fails, classify the failure as a coding mistake, an unsettled design decision, or evidence that an accepted decision was wrong.
-6. Fix mechanical coding mistakes directly. For either kind of design failure, return to one-question-at-a-time dialogue before changing the design.
-7. Stop for review before beginning another slice or checkpoint.
+4. Complete the independent first pass and run non-test compilation or formatting checks as needed. A first pass is complete when the claimed behavior is implemented throughout the slice, contains no placeholder for that behavior, and compiles; do not use supplied tests to shape it.
+5. Once the checkpoint's first-pass implementation is complete, state which test module will be revealed, run the corresponding `cargo x copy-test` command, and then run the narrowest relevant test command. Show the exact result.
+6. If a product-behavior test fails, explain the concrete scenario the test sets up, the expected and observed behavior, and the invariant it exercises. Do not trace the implementation to locate the defect, propose a patch, or change code yet. Ask the student to explain which execution path or invariant they think is wrong.
+7. Evaluate the student's diagnosis against the test and accepted decisions. Ask another focused question if the diagnosis is incomplete. Change the implementation only after the student has reached or explicitly accepted a diagnosis and authorizes the fix.
+8. Investigate and fix test-harness, build-system, dependency, and environmental failures directly when they do not require reasoning about the student's implementation.
+9. Stop for review before beginning another slice or checkpoint.
 
 During review, select one consequential changed line or comparison and ask two plain-English questions: what is this line trying to do, and what plausible behavior would break if it changed? Do not quiz the student on arbitrary syntax or mechanical code.
 
-Preserve the starter's architecture and naming unless a local design change is necessary and approved. Do not perform unrelated refactors. Make one testable debugging hypothesis at a time. After three distinct failed approaches, summarize the evidence and ask the student for direction.
+Preserve the starter's architecture and naming unless a local design change is necessary and approved. Do not perform unrelated refactors. Once the student has proposed a diagnosis, test one debugging hypothesis at a time. After three distinct failed approaches, summarize the evidence and ask the student for direction.
 
 Never claim a test passed unless you ran it and saw a successful result. Treat a passing supplied suite as necessary but not sufficient. Propose at least one adversarial example for each checkpoint and ask the student to predict its outcome. Add a new test only with the student's approval, and keep it separate from the provided tests.
 
@@ -94,7 +96,7 @@ If demonstrating a deliberate fault, begin from a clean, passing state, state th
 
 ## Validation
 
-Run focused tests after each implementation slice. Before declaring Day 1 complete, run from the repository root:
+Reveal and run focused supplied tests only after the corresponding checkpoint has a complete independent first pass. Tests already revealed for completed checkpoints may be rerun as regression checks. Before declaring Day 1 complete, run from the repository root:
 
 ```shell
 cargo x scheck


### PR DESCRIPTION
## Why

The coding-agent track currently reveals supplied tests before implementation and allows the agent to diagnose implementation failures itself. That encourages assertion-by-assertion reconstruction and removes the student from the most useful debugging step.

## What changed

- Require an independent, compiling checkpoint implementation before its supplied tests are copied or inspected.
- On product-test failures, have the agent explain the scenario, expected and observed behavior, and implicated invariant, then wait for the student's diagnosis before proposing or applying a fix.
- Keep harness, dependency, and environment failures as agent-owned work.
- Stage Week 1 and Week 2 test modules at their matching checkpoints instead of copying each complete week up front.

_AI-assisted: Codex._
