### PR TITLE
Experiment: complete Week 1 through delayed-test agent path

### DIFF
--- a/mini-lsm-starter/WEEK1_AGENT_WALKTHROUGH.md
+++ b/mini-lsm-starter/WEEK1_AGENT_WALKTHROUGH.md
@@ -1,0 +1,1358 @@
+# Week 1 Agent Fast-Forward Walkthrough Transcript
+
+> **Experimental stacked PR:** This branch records a learner-agent experiment. It is intended for a stacked draft PR demonstrating the Week 1 agent path and is **not intended to merge**.
+
+## Experiment Scope
+
+The primary agent acted as the student and transcript coordinator. The Week 1 subagent acted as the coding agent inside the isolated starter worktree. The coding agent was prohibited from accessing the reference implementation, from revealing supplied tests before each checkpoint had a complete compiling first pass, and from committing or pushing.
+
+### Exact Initial Spawn Instruction
+
+**Primary agent (student):**
+
+> Act as the coding agent for a real Week 1 fast-forward learner walkthrough. Work exclusively in `/tmp/mini-lsm-week1-agent-walkthrough/mini-lsm-starter` (the isolated worktree on `skyzh/week1-agent-walkthrough`); pass that directory as `workdir` for every shell command. Never inspect or modify the primary checkout at `/Users/skyzh/Work/mini-lsm`, never inspect `../mini-lsm`, and do not commit or push. The primary agent will act as the student and will preserve the transcript.
+>
+> Begin with only the handshake required by `../mini-lsm-book/src/agent-fast-forward-overview.md`: confirm the working directory, read `./AGENTS.md`, summarize the reference-solution boundary, the new implementation-before-test protections, the student-owned design protocol, consequential versus mechanical choices, and allowed local sources. Stop without editing implementation files, copying tests, or inspecting tests. On later turns, follow `../mini-lsm-book/src/week1-fast-forward.md` exactly, ask one decision question at a time, and wait for a student answer or edit authorization. Complete all three Week 1 checkpoints eventually, revealing each supplied test module only after the checkpoint has a compiling first pass. On product-test failures, explain the test evidence and ask the student to diagnose; do not independently trace or fix the implementation. You may diagnose harness/environment failures. When Week 1 is complete, report the implementation, decisions, exact checks, and feedback on the path.
+
+## Handshake
+
+**Week 1 subagent (coding agent):**
+
+> Handshake complete. Working directory is `/private/tmp/mini-lsm-week1-agent-walkthrough/mini-lsm-starter` (the resolved form of the assigned `/tmp/.../mini-lsm-starter`). I read `./AGENTS.md` and `../mini-lsm-book/src/agent-fast-forward-overview.md`.
+>
+> Reference-solution boundary: I must never read/search/inspect/diff/copy `../mini-lsm`, nor reconstruct it through Git history, other refs/remotes, generated artifacts, or online copies.
+>
+> Implementation-before-test protection: for each checkpoint I must first produce an independent, complete, compiling first pass. Only then may I run the named `cargo x copy-test` command; after copying I may inspect tests in this starter, but never open their sources in `../mini-lsm`. I must not edit/disable/weaken supplied tests or the harness. Product-test failures belong first to the student: I explain setup, expected vs. observed behavior, and the implicated invariant, then ask the student to diagnose. I may directly diagnose harness/build/dependency/environment failures.
+>
+> Student-owned design protocol: inspect only allowed interfaces/book material, identify checkpoint decisions, ask exactly one short **Course rule** or **Your choice** question at a time, evaluate the student's reasoning with evidence, maintain a decision ledger, and wait for explicit edit authorization once a coherent slice is specified. Requests to implement a checkpoint start this dialogue; they do not authorize silent design or one-shot coding. `simpler`, `example`, `hint`, and `choose for me` are accepted at each stop.
+>
+> Consequential choices require a stop: representation/layout, ordering and duplicate precedence, ownership, size/boundary accounting, seek behavior, errors, synchronization, and optimization ownership. Mechanical matters do not: local names, imports, formatting, and obvious compiler-directed type repairs.
+>
+> Allowed local sources: starter interfaces/code in this directory, chapters under `../mini-lsm-book/src/`, Rust/dependency documentation, and copied tests only after their checkpoint first pass. No files were edited, no tests were inspected or copied, and no implementation command was run. I am stopped and ready for the student's first checkpoint request.
+
+## Checkpoint 1: Ordered In-Memory State
+
+### Start Instruction
+
+**Primary agent (student):**
+
+> Build Day 1 with me, starting with ordered in-memory state. Follow the student-owned design protocol in `AGENTS.md` and never access `../mini-lsm`. Before coding, ask one short question at a time using a concrete example. Use plain English and introduce technical terms after I answer. Mark each question **Course rule** or **Your choice**. I may reply `simpler`, `example`, `hint`, or `choose for me`. Do not edit until my answers specify one small, coherent slice. After each slice, show me one important line and ask what it does and what would break if it changed.
+>
+> Implement ordered in-memory state.
+
+### Memtable and Cursor Decisions
+
+**Week 1 subagent (coding agent):**
+
+> **Course rule — What order should a scan use?**
+>
+> We insert `pear → 1`, then `ant → 2`, then `cat → 3` into one memtable. A full scan starts immediately afterward.
+>
+> In what order should those three entries appear, and what about the keys determines that order?
+>
+> You can reply `simpler`, `example`, `hint`, or `choose for me`.
+
+**Primary agent (student):**
+
+> The scan should return `ant → 2`, `cat → 3`, then `pear → 1`. The order is ascending lexicographic order of the raw key bytes, not insertion order.
+
+**Week 1 subagent (coding agent):**
+
+> Correct. I’ve recorded the course constraint as **ascending bytewise key order**: insertion order cannot affect a memtable scan.
+>
+> **Course rule — What survives a repeated write?**
+>
+> In the same mutable memtable, we write `cat → old` and then `cat → new`. Before any freeze, `get("cat")` and a scan each encounter that key.
+>
+> Should they expose one entry or two, and which value should be visible?
+
+**Primary agent (student):**
+
+> They should expose one `cat` entry with `new`. A memtable keeps the latest value for each key, so the later write replaces the earlier mapping.
+
+**Week 1 subagent (coding agent):**
+
+> Correct. I’ve recorded **one entry per key within a memtable; a later write replaces the earlier value**.
+>
+> **Course rule — How should deletion survive into newer state?**
+>
+> An older immutable memtable contains `cat → old`. We delete `cat` while writing to the current mutable memtable. If the current memtable simply omits `cat`, a lookup could fall through and find `old`.
+>
+> What entry, if any, should the current memtable store for `cat`, and what should a user-facing lookup report when it sees that entry?
+
+**Primary agent (student):**
+
+> The current memtable must store a tombstone for `cat`, represented by the course's empty value. A lookup that finds it should return `None` and stop; it must not continue into older state and resurrect `old`.
+
+**Week 1 subagent (coding agent):**
+
+> Correct. I’ve recorded **an empty value is a deletion tombstone; it wins over older values, and the user-visible lookup returns absence without probing farther**.
+>
+> **Course rule — What happens at the end of a cursor?**
+>
+> A scan cursor returns its final entry. We call `next()` once and it reaches the end, then call `next()` again.
+>
+> May that cursor ever become valid again or revisit an entry? What should its validity report after exhaustion?
+
+**Primary agent (student):**
+
+> No. Once exhausted, the cursor stays exhausted: `is_valid()` remains false and later `next()` calls cannot make it valid again or revisit an entry.
+
+### Memtable Slice Authorization
+
+**Week 1 subagent (coding agent):**
+
+> Correct. That gives us a coherent first slice: one ordered memtable and its bounded cursor.
+>
+> Decision ledger:
+>
+> | Decision or constraint | Student’s conclusion | Invariant/evidence | Consequence |
+> |---|---|---|---|
+> | Scan order | Ascending lexicographic raw bytes | Ordered-state contract | Insertion order is irrelevant |
+> | Repeated key in one memtable | Keep only the latest value | One current mapping per key | `get` and scan expose one version |
+> | Deletion representation | Empty value tombstone | Older values must not reappear | Internal cursor exposes it; user lookup treats it as absent |
+> | Cursor exhaustion | Permanent invalid state | Cursor API contract | Repeated `next` cannot resume or revisit |
+>
+> Proposed slice: change only `src/mem_table.rs` to implement in-memory creation, point get/put with approximate-size accounting, byte-bounded ordered scan construction, and cursor `key`/`value`/`is_valid`/`next`. WAL, flush, engine-level reads/writes, merging, and LSM tombstone filtering remain untouched. The supplied `week1_day1` and `week1_day2` modules will be revealed only after the entire ordered-state checkpoint has a compiling first pass—not after this partial slice.
+>
+> Authorize this slice?
+
+**Primary agent (student):**
+
+> Authorized. Implement that memtable-and-cursor slice, use only non-test compilation/formatting feedback, and stop for review afterward without copying or inspecting supplied tests.
+
+### Memtable Slice Report and Review
+
+**Week 1 subagent (coding agent):**
+
+> The memtable-and-cursor slice is implemented and compiles. No supplied tests were copied, opened, or run.
+>
+> Changed `src/mem_table.rs`:
+> - `MemTable::create`, `get`, and `put` now provide a concurrent ordered mapping; later writes replace the visible mapping and every write contributes key+value bytes to the soft size estimate.
+> - `scan` converts borrowed bounds into owned bounds, retains the skiplist with `Arc`, and positions the cursor on its first matching item.
+> - cursor access and advancement now maintain a permanently invalid exhausted state.
+>
+> The implementation relies on the ledger’s bytewise ordering, single-version-per-key, empty-value tombstone, and cursor-exhaustion invariants. `crossbeam_skiplist::SkipMap` supplies the ordered map and replacement behavior.
+>
+> Exact checks:
+> - `cargo fmt --check -- src/mem_table.rs` initially reported formatting differences only.
+> - `cargo fmt -- src/mem_table.rs` completed successfully.
+> - `cargo check --lib` passed (`Finished dev profile`).
+> - `git diff --check` passed with no output.
+>
+> Boundary not yet established by supplied tests: a scan holds the memtable alive, but concurrent insertions after cursor creation may or may not become visible depending on skiplist iteration behavior. We should treat that visibility as outside this slice’s logical guarantee unless we explicitly test and specify it.
+>
+> Review `src/mem_table.rs:190`:
+>
+> ```rust
+> !self.borrow_item().0.is_empty()
+> ```
+>
+> What is this line trying to distinguish? What plausible behavior would break if it checked whether the **value** was empty instead of whether the key was empty?
+
+**Primary agent (student):**
+
+> It distinguishes a real positioned entry from the cursor's empty-key exhausted sentinel. Checking the value instead would make a valid tombstone look exhausted, so deletion entries could disappear before the merge/read layers use them to suppress older values.
+
+### Point Operations and Freeze Decisions
+
+**Week 1 subagent (coding agent):**
+
+> Exactly. The key is an exhaustion sentinel; using the value would erase tombstones before they can defeat older data.
+>
+> **Course rule — Which copy wins across memtables?**
+>
+> The mutable memtable has `cat → newest`; the first immutable memtable has `cat → middle`; the last immutable memtable has `cat → oldest`.
+>
+> In what order should `get("cat")` probe these sources, and when should it stop?
+
+**Primary agent (student):**
+
+> Probe the mutable memtable first, then immutable memtables from newest to oldest. Stop at the first entry found, whether it is a value or tombstone, because that entry is the newest version.
+
+**Week 1 subagent (coding agent):**
+
+> Correct. I’ve recorded **mutable first, then immutable memtables newest-to-oldest; the first found entry is authoritative, including a tombstone**.
+>
+> **Course rule — How long must a writer hold the state read guard?**
+>
+> Writer W identifies mutable memtable A. Before W inserts `cat → new`, freezer F replaces A with mutable memtable B and moves A into the immutable list. W then inserts into A.
+>
+> What went wrong, and which part of W’s operation must remain protected by the `state` read guard to prevent it?
+
+**Primary agent (student):**
+
+> W wrote into A after A had been published as immutable, so readers or a concurrent flush could miss or race with a supposedly frozen write. W must retain the `state` read guard from selecting the current mutable memtable through completion of the insertion; the freezer needs the write guard and therefore cannot publish A as immutable until that write finishes.
+
+**Week 1 subagent (coding agent):**
+
+> Correct. I’ve recorded **the state read guard covers both selecting the mutable memtable and completing its insertion**, so freezing cannot publish a memtable while a write is still entering it.
+>
+> **Course rule — What must a second freezer recheck?**
+>
+> Two writers both observe that mutable memtable A reached the soft size limit. Writer 1 acquires `state_lock`, freezes A, and installs a fresh empty B. Writer 2 then acquires `state_lock` based on its earlier observation.
+>
+> Before freezing, what current condition must Writer 2 check, and what should it do in this case?
+
+**Primary agent (student):**
+
+> It must re-read the latest state under `state_lock` and recheck the current mutable memtable's approximate size. Here the current table is fresh B and below the limit, so Writer 2 should do nothing rather than freeze B.
+
+**Week 1 subagent (coding agent):**
+
+> Correct. I’ve recorded **serialize structural changes with `state_lock`, then recheck the current memtable’s size; an obsolete observation must not freeze its replacement**.
+>
+> **Course rule — When does the soft limit trigger?**
+>
+> The target size is 100 bytes. After a write, the current memtable’s accumulated key-plus-value estimate is exactly 100.
+>
+> Should the writer attempt a freeze at 100, only above 100, or before the write—and why?
+
+**Primary agent (student):**
+
+> Attempt the freeze after the write when the estimate is at least 100 bytes. It is a soft capacity limit, so the write is accepted first; equality is enough to trigger maintenance.
+
+### Point/Freeze Slice Authorization
+
+**Week 1 subagent (coding agent):**
+
+> Correct. We now have enough decisions for the engine point-operation and freeze slice.
+>
+> Added ledger entries:
+>
+> | Decision or constraint | Student’s conclusion | Invariant/evidence | Consequence |
+> |---|---|---|---|
+> | Cross-memtable lookup | Mutable, then immutable newest-to-oldest; stop at first hit | Latest version is authoritative | Tombstones prevent resurrection |
+> | Write/freeze guard | Hold `state.read()` through insertion | A published immutable table must never receive another write | Freeze waits for in-flight writes |
+> | Competing freezes | Take `state_lock`, then recheck current size | Earlier observations can become stale | Fresh replacement is not frozen |
+> | Soft limit | Insert first; attempt freeze at `size >= target` | Capacity is best-effort and inclusive | The triggering write is retained |
+>
+> Proposed slice: change only `src/lsm_storage.rs` to implement memtable-only `get`, `put`, `delete`, and `force_freeze_memtable`. Structural freezing will create the replacement before the short state write-lock section, move the old table to the front of the newest-first immutable list, and rely on `state_lock` supplied by the caller. Disk reads, scans/merging, WAL, and flushing stay untouched. `week1_day1` remains unrevealed until the whole ordered-state checkpoint compiles.
+>
+> Authorize this slice?
+
+**Primary agent (student):**
+
+> Authorized. Implement the memtable-only point operations and freeze slice as described. Use no supplied tests and stop for review after non-test checks pass.
+
+### Point/Freeze Slice Report and Review
+
+**Week 1 subagent (coding agent):**
+
+> The point-operation and freeze slice is implemented and compiles. No supplied tests were copied, inspected, or run.
+>
+> Changed `src/lsm_storage.rs`:
+> - `get` probes the mutable table and immutable tables newest-to-oldest, stops at the first hit, and converts an authoritative tombstone to `None`.
+> - `put` holds the state read guard through insertion, checks the post-write soft limit, serializes a possible freeze, and rechecks the current table.
+> - `delete` routes through the same guarded write path using the empty-value tombstone.
+> - `force_freeze_memtable` prepares a replacement, then atomically swaps the structural snapshot and inserts the old table at the newest side of `imm_memtables`.
+>
+> Exact checks:
+> - `cargo fmt --check -- src/lsm_storage.rs` passed.
+> - `cargo check --lib` passed (`Finished dev profile`).
+> - `git diff --check` passed with no output.
+>
+> Boundary not yet established by supplied tests: `force_freeze_memtable` itself will freeze even an empty table when explicitly called; the automatic path’s size check prevents that under normal writes. Callers of the force API therefore own the precondition if empty immutable tables are undesirable.
+>
+> Review `src/lsm_storage.rs:322` inside the scope that begins with the state read guard:
+>
+> ```rust
+> state.memtable.put(key, value)?;
+> ```
+>
+> What is this line trying to guarantee by running before the read guard is dropped? What concrete behavior could break if we first cloned the memtable pointer, dropped the guard, and only then performed this insertion?
+
+**Primary agent (student):**
+
+> It guarantees that the table remains the mutable table until the insertion completes. If we cloned the pointer and dropped the guard first, a freezer could publish that table as immutable or begin flushing it, then this delayed insertion could be missing from the frozen snapshot/SST or race with an object that readers assume no longer changes.
+
+### Merge and Logical Iterator Decisions
+
+**Week 1 subagent (coding agent):**
+
+> Correct. That is the exact unsafe interleaving the read guard prevents.
+>
+> **Course rule — Which equal key does a merge expose?**
+>
+> We construct a merge from two already-sorted cursors. Input 0 contains `cat → new`; input 1 contains `cat → old`. Both currently point at `cat`.
+>
+> Which entry should the merge expose, and what must happen to the other `cat` when the merge advances?
+
+**Primary agent (student):**
+
+> Expose input 0's `cat → new`, because inputs are ordered newest to oldest and the lower input index wins equal keys. When advancing, consume every other cursor currently on `cat` so the merged output contains the key only once and cannot later emit `old`.
+
+**Week 1 subagent (coding agent):**
+
+> Correct. I’ve recorded **lower input index wins equal keys, and advancing consumes every input positioned on that key before selecting the next output**.
+>
+> **Course rule — Can an iterator recover after an error?**
+>
+> A user-visible scan is valid on `cat`, but its next advancement reports an I/O-style error. The caller invokes `is_valid()` and then calls `next()` again.
+>
+> What must those later calls report, and why must the cursor not resume even if an underlying child still has entries?
+
+**Primary agent (student):**
+
+> After the first error, `is_valid()` must remain false and every later `next()` must return an error without advancing the child. Otherwise a caller could continue after a partially failed transition and observe a stream whose position or ordering is no longer trustworthy.
+
+**Week 1 subagent (coding agent):**
+
+> Correct. I’ve recorded **the user-facing fused cursor enters a permanent errored state: invalid thereafter, with every later `next()` returning an error and no child advancement**.
+>
+> **Course rule — At which layer may a tombstone disappear?**
+>
+> Newer input 0 has `cat → tombstone`; older input 1 has `cat → old`. If input 0 drops the tombstone before duplicate resolution, the merge can expose `old`.
+>
+> Should the merge keep or remove the tombstone, and which layer should finally hide it from the user?
+
+**Primary agent (student):**
+
+> The merge must keep the tombstone so it wins duplicate resolution and suppresses `old`. Only the outer `LsmIterator`, after source precedence has been resolved, should skip tombstones from the user-visible stream.
+
+### Merge Slice Authorization
+
+**Week 1 subagent (coding agent):**
+
+> Correct. I’ve recorded **merge tombstones as ordinary precedence-bearing entries; only `LsmIterator`, after duplicate resolution, hides them from callers**.
+>
+> We have enough decisions for the final ordered-scan slice.
+>
+> Added ledger entries:
+>
+> | Decision or constraint | Student’s conclusion | Invariant/evidence | Consequence |
+> |---|---|---|---|
+> | Equal keys across inputs | Lower input index wins | Inputs are constructed newest-to-oldest | One newest version is emitted |
+> | Duplicate advancement | Consume every child on the emitted key | Each logical key appears once | Older copies cannot appear later |
+> | Error behavior | Permanently invalidate and keep returning error | Position after partial failure is untrustworthy | User cannot resume a failed stream |
+> | Tombstone layer | Preserve through merge; hide in `LsmIterator` | Deletion must defeat older values first | No deleted key or resurrected value reaches user |
+>
+> Proposed slice:
+> - `src/iterators/merge_iterator.rs`: heap construction, newest-first equal-key precedence, duplicate consumption, exhaustion/error-safe child removal.
+> - `src/lsm_iterator.rs`: delegate the merged stream, skip tombstones only after resolution, and enforce fused exhaustion/error behavior.
+> - `src/lsm_storage.rs`: build bounded memtable cursors in mutable/newest-immutable order and expose the fused scan.
+>
+> No SST or two-type merging is included. After this compiles, Checkpoint 1 has its independent first pass; only then I will reveal `week1_day1` and `week1_day2` with the prescribed copy commands and run their focused tests.
+>
+> Authorize this slice?
+
+**Primary agent (student):**
+
+> Authorized. Implement the merge, LSM/fused iterator, and memtable-only scan slice. After it compiles, reveal only Week 1 Days 1 and 2 and run their focused tests as prescribed.
+
+### Checkpoint 1 Result and Review
+
+**Week 1 subagent (coding agent):**
+
+> Checkpoint 1’s implementation and supplied validation are complete: all 14 focused tests passed.
+>
+> Final slice behavior:
+> - `MergeIterator` keeps only valid children in a min-key/newest-index heap, exposes one current entry, advances every equal-key child, and removes exhausted or errored heap children safely.
+> - `LsmIterator` filters tombstones only after merge precedence is resolved.
+> - `FusedIterator` forbids access when invalid and permanently records a child error.
+> - engine `scan` constructs bounded inputs in mutable-then-immutable-newest-first order.
+> - `cargo x copy-test` added only the supplied harness, `week1_day1`, `week1_day2`, and rewrote `src/tests.rs`; I did not hand-edit them.
+>
+> Exact commands and results:
+> - `cargo fmt --check -- src/iterators/merge_iterator.rs src/lsm_iterator.rs src/lsm_storage.rs` — passed.
+> - `cargo check --lib` — passed.
+> - `git diff --check` — passed.
+> - `cargo x copy-test --week 1 --day 1` — copied `harness` and `week1_day1`.
+> - `cargo x copy-test --week 1 --day 2` — added `week1_day2`.
+> - `cargo test -p mini-lsm-starter week1_day1` — 6 passed, 0 failed.
+> - `cargo test -p mini-lsm-starter week1_day2` — 8 passed, 0 failed.
+>
+> The consolidated ledger is the accepted ordered byte scan; one latest mapping per memtable; empty-value tombstones; permanent exhaustion/error; mutable then immutable newest-first lookup; read guard through write; serialized/rechecked freeze; post-write `>=` soft limit; lower-index equal-key precedence; consume all duplicate cursors; and hide tombstones only after merge.
+>
+> Boundary not established by these supplied tests: whether a memtable scan created before a concurrent insertion should observe that insertion. The implementation promises ordering of entries it observes, not snapshot isolation for a live skiplist cursor.
+>
+> Review `src/iterators/merge_iterator.rs:99`:
+>
+> ```rust
+> if iter.1.key() != current.1.key() {
+>     break;
+> }
+> ```
+>
+> What is this comparison trying to decide? What plausible output bug would appear if it broke on equality instead, leaving the older cursor positioned on the same key?
+
+**Primary agent (student):**
+
+> It keeps consuming heap children while their current key equals the key just emitted, and stops at the first different key. If it broke on equality, the older cursor would remain on the duplicate and could emit the same logical key again—possibly surfacing an older value immediately after a newer value or tombstone.
+
+**Week 1 subagent (coding agent):**
+
+> Correct. That comparison is the duplicate-elimination gate; reversing it would allow stale versions to re-enter the stream.
+>
+> **Course rule — Adversarial prediction before adding any test**
+>
+> Newer input: `b → tombstone, c → 4`. Older input: `a → 1, b → 2, c → 3`. We scan the full user-visible range.
+>
+> What exact sequence should the caller observe, and which layer removes each hidden entry? I will not add a new test unless you explicitly authorize it.
+
+**Primary agent (student):**
+
+> The caller should observe `a → 1`, then `c → 4`. `MergeIterator` discards the older duplicate `b → 2` behind the newer tombstone and the older `c → 3` behind `c → 4`; `LsmIterator` then hides the winning `b` tombstone. Do not add a test. Proceed to Checkpoint 2: implement the durable block and SST representation.
+
+## Checkpoint 2: Durable Block and SST Representation
+
+### Block Format Decisions
+
+**Week 1 subagent (coding agent):**
+
+> **Course rule — Which block format is this checkpoint targeting?**
+>
+> A block stores `mini-a`, `mini-b`, and `mini-c`. The earlier Day 3 format writes each full key; the final Day 7 format writes the first key in full and later keys as shared-prefix length plus remaining bytes.
+>
+> Because this fast-forward checkpoint will eventually validate Days 3, 4, and 7 together, should the independent first pass implement the earlier full-key layout first, or go directly to the final prefix-compressed layout—and what compatibility goal determines that choice?
+>
+> You can reply `simpler`, `example`, `hint`, or `choose for me`.
+
+**Primary agent (student):**
+
+> Go directly to the final Day 7 prefix-compressed layout. The checkpoint must pass the combined Days 3, 4, and 7 acceptance target, so implementing and then replacing the earlier layout would be wasted work and obscure the final format contract.
+
+**Week 1 subagent (coding agent):**
+
+> Correct. I’ve recorded **the final Day 7 prefix-compressed block layout is the checkpoint’s sole acceptance format**.
+>
+> **Course rule — What should every compressed key depend on?**
+>
+> A block contains `mini-a`, `mini-b`, and `mini-c`. An iterator may jump directly to the third entry using its offset. If `mini-c` stores only its difference from `mini-b`, decoding it would require walking through entry 2 first.
+>
+> Should each later key record its shared prefix with the first key or with the immediately previous key, and why?
+
+**Primary agent (student):**
+
+> Use the first key as the prefix basis for every later key. Then an iterator can reconstruct any entry from the first key plus that entry alone, preserving direct offset access and allowing independent comparisons during seek.
+
+**Week 1 subagent (coding agent):**
+
+> Correct. I’ve recorded **every key is encoded relative to the block’s first key, so any indexed entry is independently reconstructible**.
+>
+> **Course rule — What bytes make one final-format entry?**
+>
+> The first entry is key `a` (`0x61`) with value `X` (`0x58`). Its shared-prefix length is necessarily zero.
+>
+> In field order, which lengths and payload bytes must this entry contain, and how should the fixed-width integers be encoded?
+
+**Primary agent (student):**
+
+> The entry is `overlap_len:u16 = 0`, `rest_key_len:u16 = 1`, the remaining key byte `0x61`, `value_len:u16 = 1`, then value byte `0x58`. Encode every `u16` in big-endian order, so the bytes are `00 00 00 01 61 00 01 58`.
+
+**Week 1 subagent (coding agent):**
+
+> Correct. The one-entry data section is exactly `00 00 00 01 61 00 01 58`.
+>
+> **Course rule — How can a decoder locate entries from the end?**
+>
+> That entry begins at data offset 0 and is the only entry in the block. What footer bytes must follow the data section, and which final field tells the decoder how many preceding offsets belong to the footer?
+
+**Primary agent (student):**
+
+> Append the entry offset `0` as `00 00`, then the entry count `1` as `00 01`. The final `u16` count tells the decoder that the preceding one `u16` belongs to the offset table and where the data section ends.
+
+**Week 1 subagent (coding agent):**
+
+> Correct. The complete one-entry block is the 8-byte entry, then `00 00` offset and final `00 01` count; decoding from the last two bytes locates the offset table and data boundary.
+>
+> **Course rule — Is the target inclusive?**
+>
+> A non-empty builder has room for another record whose projected encoded block size—including its entry bytes, new 2-byte offset, and final 2-byte count—would be exactly the 64-byte target.
+>
+> Should `add` accept or reject that record, and which comparison expresses the rule?
+
+**Primary agent (student):**
+
+> Accept it. The target is inclusive, so a non-first entry is rejected only when the projected encoded size is greater than the target, not when it is equal.
+
+**Week 1 subagent (coding agent):**
+
+> Correct. I’ve recorded **accept projected size equal to the target; reject only when a non-first entry would make it greater**.
+>
+> **Course rule — What if one record is larger than an empty block’s target?**
+>
+> An empty builder has a 16-byte target, but one valid key/value record requires 30 encoded bytes including its offset and the count. Rejecting it would leave the builder empty forever when the SST builder retries it.
+>
+> Should the empty builder accept this first record, and what should happen to later records?
+
+**Primary agent (student):**
+
+> Accept the oversized first record so the builder can make progress and produce a one-entry block. Once non-empty, reject later records whose projected size exceeds the target.
+
+**Week 1 subagent (coding agent):**
+
+> Correct. I’ve recorded **an empty builder accepts one representable oversized record; only subsequent additions are constrained by the target**.
+>
+> **Course rule — Where does a missing-key seek land?**
+>
+> A block contains keys `1`, `3`, and `5`. We seek to `0`, `3`, `4`, and `6` in four fresh iterators.
+>
+> Where should each iterator land, including the case after the block’s last key?
+
+**Primary agent (student):**
+
+> Seek uses lower-bound semantics: `0` lands on `1`, `3` on `3`, `4` on `5`, and `6` makes the iterator invalid because no stored key is greater than or equal to it.
+
+**Week 1 subagent (coding agent):**
+
+> Correct. That is **lower-bound seek**: first stored key greater than or equal to the target, otherwise invalid.
+>
+> **Your choice — How should a block find that lower bound?**
+>
+> For a block with many indexed entries, we can decode entries from the front until one is large enough, or binary-search entry indices and decode only logarithmically many candidates. Linear scan is simpler; binary search is faster for large blocks and is possible because every key uses the first key as its prefix basis.
+>
+> Which approach should this implementation use?
+
+**Primary agent (student):**
+
+> Use binary search over entry indices. The offset table and first-key prefix basis make each candidate independently decodable, so logarithmic comparisons are worthwhile without introducing a dependency chain.
+
+**Week 1 subagent (coding agent):**
+
+> Accepted. I’ve recorded **binary-search entry indices for lower-bound seeks**, using independent reconstruction from the first key.
+>
+> **Your choice — How defensive should `Block::decode` be?**
+>
+> Its API returns `Block`, not `Result<Block>`. For malformed bytes, we can either rely on course-format invariants and let indexing/conversion panic naturally, or add focused assertions for footer length, offset-table bounds, and monotonic/in-range offsets, still panicking but with clearer failures. The latter is safer and clearer but adds code outside behavior exercised by valid-input tests.
+>
+> Which level should we implement?
+
+**Primary agent (student):**
+
+> Add focused assertions for the minimum footer size, computed offset-table bounds, and monotonic in-range offsets. The API cannot return a recoverable error, but explicit invariant failures are clearer and prevent obscure out-of-bounds behavior.
+
+**Week 1 subagent (coding agent):**
+
+> Accepted. I’ve recorded **focused decode assertions at the non-`Result` trust boundary**, covering footer size, offset-table bounds, and monotonic in-range entry offsets.
+>
+> **Course rule — What records are representable?**
+>
+> The format stores overlap length, remaining-key length, value length, and entry offsets as `u16`. A key remainder or value is 65,536 bytes, or the data section’s next offset no longer fits in 16 bits.
+>
+> Should the builder truncate those numbers, reject the addition cleanly, or fail an invariant—and what corruption would truncation cause?
+
+**Primary agent (student):**
+
+> Reject the addition cleanly with `false`, even on an empty builder, when any encoded length or offset cannot fit in `u16`. Truncation would wrap the field and make the decoder slice the wrong key/value bytes or jump to the wrong entry boundary, corrupting the block.
+
+### Block Slice Authorization and Report
+
+**Week 1 subagent (coding agent):**
+
+> Correct. I’ve recorded **return `false` rather than truncate any length/offset that cannot fit in `u16`; oversized-first acceptance applies only to representable records**.
+>
+> We have enough decisions for a coherent block-format slice.
+>
+> Decision ledger:
+>
+> | Decision or constraint | Student’s conclusion | Invariant/evidence | Consequence |
+> |---|---|---|---|
+> | Acceptance format | Final Day 7 prefix layout | Combined Day 3/4/7 target | No temporary full-key format |
+> | Prefix basis | First key in block | Indexed entry must decode independently | Direct seek remains possible |
+> | Entry encoding | BE `overlap:u16`, `rest_len:u16`, rest bytes, `value_len:u16`, value | Course byte protocol | Exact reader/writer agreement |
+> | Footer | BE offset per entry, then BE count | Decoder starts from file end | Data/footer boundary is recoverable |
+> | Target boundary | Equality accepted | Target is inclusive | Reject non-first only if projected size is `>` |
+> | Oversized first | Accept if representable | Builder must make progress | May produce one-entry oversized block |
+> | Seek | First key `>=` target | Lower-bound contract | After-last seek is invalid |
+> | Seek algorithm | Binary search (student choice) | Independently decodable indexed entries | Logarithmic candidate comparisons |
+> | Decoder checks | Focused assertions (student choice) | API cannot return `Result` | Clear invariant failures on malformed bytes |
+> | Representability | Cleanly reject unencodable `u16` fields | Truncation corrupts boundaries | No wrapped lengths or offsets |
+>
+> Proposed slice: implement `src/block/builder.rs`, `src/block.rs`, and `src/block/iterator.rs` end to end for the final compressed representation, including build/encode/decode, bounds-safe indexed entry decoding, iteration, and binary-search lower-bound seek. SSTs and Bloom filters remain untouched. Day 3 tests will not be revealed until the entire durable-representation checkpoint—including SST and Bloom work—has a compiling first pass.
+>
+> Authorize this slice?
+
+**Primary agent (student):**
+
+> Authorized. Implement the complete final-format block builder, codec, and iterator slice. Use only non-test checks and stop for review without revealing Days 3, 4, or 7 yet.
+
+**Week 1 subagent (coding agent):**
+
+> The final-format block slice is implemented and compiles. Days 3, 4, and 7 remain unrevealed.
+>
+> Changed:
+> - `src/block/builder.rs`: first-key prefix compression, clean `u16` representability rejection, inclusive projected-size accounting, oversized-first progress, and raw data/offset construction.
+> - `src/block.rs`: exact big-endian data/offset/count encoding and focused footer/offset assertions on decode.
+> - `src/block/iterator.rs`: independent indexed reconstruction, borrowed value ranges, permanent exhaustion, and binary-search lower-bound seek.
+>
+> Exact checks:
+> - Workspace-wide `cargo fmt --check` reported formatting changes in the three implementation files and also wanted to reorder generated `src/tests.rs`; I did not let it modify supplied tests.
+> - `rustfmt src/block.rs src/block/builder.rs src/block/iterator.rs` formatted only implementation files.
+> - `cargo check --lib` passed.
+> - `git diff --check` passed.
+>
+> Boundary not established by future valid-input tests: `Block::decode` verifies footer location and ordered in-range offsets, while entry-length validation occurs lazily during iteration. It does not prove that one malformed entry’s claimed payload ends before the next entry offset; a production decoder could validate every entry boundary eagerly.
+>
+> Review `src/block/builder.rs:79`:
+>
+> ```rust
+> if !self.is_empty() && projected_size > self.block_size {
+> ```
+>
+> What are the two separate rules expressed by this condition? What plausible behavior would break if `>` changed to `>=` or if the `!self.is_empty()` guard were removed?
+
+**Primary agent (student):**
+
+> The non-empty guard implements progress for one representable oversized first record; the strict `>` makes the target inclusive for later records. Changing it to `>=` would reject an entry that fits exactly, while removing the guard could leave an empty builder unable to accept a large first record and cause the SST builder to retry forever.
+
+### SST and Bloom Decisions
+
+**Week 1 subagent (coding agent):**
+
+> Correct. Those are exactly the two independent boundary rules.
+>
+> **Course rule — How does an SST locate both variable-length trailers?**
+>
+> The final file is `blocks | metadata | meta_offset:u32 | bloom | bloom_offset:u32`. A reader knows only the total file length at open time.
+>
+> Which field does it read first, and once it has that value, where exactly does it find the metadata offset?
+
+**Primary agent (student):**
+
+> Read the final four bytes as `bloom_offset:u32`. That points to the start of the Bloom section; the metadata offset is the four-byte field immediately before it, at byte range `bloom_offset - 4 .. bloom_offset`.
+
+**Week 1 subagent (coding agent):**
+
+> Correct. I’ve recorded **read `bloom_offset` from the final four bytes, then read `meta_offset` from the four bytes immediately preceding the Bloom section**.
+>
+> **Course rule — What must one block’s metadata preserve?**
+>
+> Block 0 begins at file byte 0 and contains keys `a..c`; block 1 begins at byte 120 and contains `e..g`. The reader must seek without loading both blocks and must know each encoded block’s byte span.
+>
+> What three facts should each `BlockMeta` record, and in what order must the metadata records appear?
+
+**Primary agent (student):**
+
+> Each `BlockMeta` records the encoded block's starting byte offset plus its actual first and last keys. Records appear in the same ascending key/block order as the data blocks; the next block's offset, or the metadata-section offset for the last block, gives the current block's byte span.
+
+**Week 1 subagent (coding agent):**
+
+> Correct. I’ve recorded **offset plus actual first/last key for every block, in the same ascending order as encoded blocks**.
+>
+> **Your choice — How should the metadata section delimit records?**
+>
+> The reader already receives the exact metadata byte slice. We can either prefix it with a `u32` record count and encode each record as `offset:u32, first_len:u16, first_key, last_len:u16, last_key`, or omit the count and parse records until the slice ends. A count gives a direct allocation/check and an explicit cardinality; parsing to the end saves four bytes but makes trailing/truncated-data diagnosis less explicit.
+>
+> Which representation should we use?
+
+**Primary agent (student):**
+
+> Prefix the metadata section with a `u32` record count, then encode each record with its `u32` offset and `u16`-length-prefixed first and last keys. The explicit count is worth four bytes for clearer cardinality and truncation checks.
+
+**Week 1 subagent (coding agent):**
+
+> Accepted. I’ve recorded **count-prefixed big-endian metadata records with `u32` offsets and `u16`-length-prefixed boundary keys**.
+>
+> **Course rule — How should an SST seek across a gap?**
+>
+> Block 0 contains `a,b,c`; block 1 contains `e,f,g`. Metadata search by first keys selects block 0 for target `d`, but the block iterator reaches its end because no key in block 0 is `>= d`.
+>
+> What must the SST iterator do next, and where should it finally land?
+
+**Primary agent (student):**
+
+> It must advance to block 1 and seek to that block's first entry, landing on `e`. A lower-bound seek cannot become invalid merely because the initially selected predecessor block ended before the target.
+
+**Week 1 subagent (coding agent):**
+
+> Correct. I’ve recorded **if the candidate block exhausts during seek, advance to the next block’s first entry before declaring the SST iterator invalid**.
+>
+> **Your choice — Which metadata boundary should choose the candidate block?**
+>
+> For target `d` between blocks `a..c` and `e..g`, we can binary-search first keys and initially choose the predecessor block (`a..c`), then advance when its local seek is invalid; or binary-search last keys and directly choose the first block whose last key is `>= d`. First-key search matches the simplest course outline; last-key search avoids the extra candidate read but relies on accurate last-key metadata.
+>
+> Which approach should we use?
+
+**Primary agent (student):**
+
+> Use last-key metadata to choose the first block whose last key is at least the target. We already treat last keys as required accurate metadata, and this avoids reading a predecessor block that cannot satisfy the seek.
+
+**Week 1 subagent (coding agent):**
+
+> Accepted. I’ve recorded **binary-search block last keys and select the first block whose last key is `>=` the target**.
+>
+> **Course rule — What identifies one cached block?**
+>
+> SST 7 and SST 9 both request their block index 0. If the cache key is only `0`, one table could receive the other table’s bytes.
+>
+> What pair must be used as the cache key, and what should concurrent misses for that same pair share?
+
+**Primary agent (student):**
+
+> Use `(sst_id, block_index)` as the cache key. Concurrent misses for the same pair should share one loaded `Arc<Block>`/single cache fill, while equal block indices from different SST IDs remain distinct.
+
+**Week 1 subagent (coding agent):**
+
+> Correct. I’ve recorded **cache identity is `(sst_id, block_index)`, and same-pair concurrent misses share one cached `Arc<Block>` load**.
+>
+> **Course rule — Which Bloom answer is authoritative?**
+>
+> For a lookup of `cat`, the filter can say either “definitely absent” or “may contain.” A false positive is possible; a false negative must not be.
+>
+> Which answer permits skipping the SST, and what lookup work must happen for the other answer?
+
+**Primary agent (student):**
+
+> Only “definitely absent” permits skipping the SST. “May contain” is inconclusive, so the engine must still perform the normal metadata/block seek and compare the actual key.
+
+**Week 1 subagent (coding agent):**
+
+> Correct. I’ve recorded **only a Bloom negative can skip an SST; a positive always falls through to the normal exact lookup**.
+>
+> **Course rule — What must the writer and reader hash?**
+>
+> The builder inserts `cat` into the filter. Later the reader probes for `cat`. Hashing a prefix, an encoded compressed form, or timestamp-decorated bytes on only one side could produce a false negative.
+>
+> Which bytes and hash function must both sides use in this Week 1 format?
+
+**Primary agent (student):**
+
+> Both sides must hash the exact raw Week 1 user-key bytes with `farmhash::fingerprint32`. The builder stores those `u32` fingerprints and lookup computes the same fingerprint from the requested key; neither compressed encoding nor a different key projection may enter one side.
+
+**Week 1 subagent (coding agent):**
+
+> Correct. I’ve recorded **both writer and reader use `farmhash::fingerprint32` over identical raw Week 1 key bytes**.
+>
+> **Course rule — What filter target applies?**
+>
+> The course fixes the Bloom false-positive rate at `0.01`. Should that target be stored as an on-disk setting, exposed as a new option, or used only by the SST builder to compute bits per key while the encoded filter carries the resulting bitset and probe count?
+
+**Primary agent (student):**
+
+> Use `0.01` only in the SST builder to compute bits per key. The on-disk Bloom section needs only the resulting bitset and probe count `k`; do not add a public option or persist the target probability itself.
+
+**Week 1 subagent (coding agent):**
+
+> Correct. I’ve recorded **`0.01` is a builder-only sizing input; the encoded Bloom filter stores only its bitset and `k`**.
+>
+> **Your choice — Should decoded block keys reuse storage?**
+>
+> Each iterator move reconstructs `first_key_prefix + suffix`. We can allocate a fresh key buffer for every entry, which is simple but adds allocation churn, or keep the starter’s `KeyVec`, clear it, and append into reusable capacity.
+>
+> Which approach should we retain?
+
+**Primary agent (student):**
+
+> Reuse the iterator's existing `KeyVec` capacity: clear it and append the first-key prefix plus suffix for each decoded entry. That preserves the same observable behavior while avoiding an allocation per move.
+
+### Bloom Core Slice
+
+**Week 1 subagent (coding agent):**
+
+> Accepted. I’ve recorded **reuse the iterator’s `KeyVec` allocation while reconstructing each key**; the current block slice already follows that choice.
+>
+> We have enough decisions for a small Bloom core slice before SST integration.
+>
+> Relevant ledger:
+>
+> | Decision or constraint | Student’s conclusion | Invariant/evidence | Consequence |
+> |---|---|---|---|
+> | Bloom authority | Only negative skips; positive performs exact lookup | False positives allowed, false negatives forbidden | Optimization cannot change results |
+> | Hash input | `farmhash::fingerprint32` of exact raw key bytes on both sides | Writer/prober identity | Present key cannot be skipped by projection mismatch |
+> | FPR target | Builder-only `0.01` sizing input | Course contract | Disk stores bitset and `k`, not policy |
+>
+> Proposed slice: change only `src/table/bloom.rs` to set the derived `k` bit positions for every supplied hash and probe the same sequence, preserving the starter’s encoded bitset-plus-`k` representation. SST building/opening and engine lookup integration remain untouched. Days 3, 4, and 7 remain unrevealed until all durable representation work compiles.
+>
+> Authorize this Bloom core slice?
+
+**Primary agent (student):**
+
+> Authorized. Implement the Bloom core only, using non-test checks and leaving the durable-representation tests unrevealed.
+
+**Week 1 subagent (coding agent):**
+
+> The Bloom core is implemented and compiles; Days 3, 4, and 7 remain unrevealed.
+>
+> Changed `src/table/bloom.rs`: building and probing now use the same rotate/add sequence, modulo the identical bit count. A build sets all `k` positions for each hash; a probe returns false at the first clear bit and true only when all positions are set.
+>
+> Exact checks:
+> - `rustfmt src/table/bloom.rs` completed.
+> - `cargo check --lib` passed.
+> - `git diff --check` passed.
+>
+> Boundary not established by future valid-input tests: `Bloom::decode` assumes a non-empty encoded section and would panic on an empty slice; the final SST opener must validate trailer boundaries before calling it, but this API still treats filter bytes as trusted.
+>
+> Review `src/table/bloom.rs:120`:
+>
+> ```rust
+> if !self.filter.get_bit(hash as usize % nbits) {
+>     return false;
+> }
+> ```
+>
+> What logical claim does this line make? What correctness failure would become possible if a probe returned false even though all of a present key’s builder-set positions were actually set?
+
+**Primary agent (student):**
+
+> It says that one clear bit among the key's required probe positions proves the key was never inserted, so the filter may return “definitely absent.” Returning false when all builder-set positions are present would be a false negative; the read path could skip an SST containing the key and return stale data or absence.
+
+### Final SST Decisions and Authorization
+
+**Week 1 subagent (coding agent):**
+
+> Correct. That line is safe only because builder and prober use the identical positions; violating that identity creates a result-changing false negative.
+>
+> **Your choice — How defensive should `SsTable::open` be?**
+>
+> Unlike `Block::decode`, this API returns `Result`. We can trust all trailer offsets and let slicing/indexing panic on a truncated file, or validate the minimum trailer, `bloom_offset`, `meta_offset`, and section ordering and return descriptive errors before reading sections. The latter adds checks but keeps malformed disk data from crashing the process.
+>
+> Which approach should we use?
+
+**Primary agent (student):**
+
+> Validate the minimum trailer length, both offsets, and `blocks <= metadata < meta_offset field < bloom < final bloom_offset field` ordering, returning descriptive errors before slicing. Since `open` already returns `Result`, malformed disk bytes should not panic the process.
+
+**Week 1 subagent (coding agent):**
+
+> Accepted. I’ve recorded **`SsTable::open` returns descriptive errors for malformed trailer length, offsets, and section ordering before slicing**.
+>
+> We now have enough decisions for the final durable SST slice.
+>
+> Proposed changes:
+> - `src/table.rs`: count-prefixed block-metadata codec; validated final trailer opening; block reads; `(sst_id, block_index)` cache; last-key candidate search.
+> - `src/table/builder.rs`: split final-format blocks, capture actual boundary keys/offsets, hash raw keys, append metadata + `meta_offset` + Bloom + `bloom_offset`, and build the in-memory table metadata.
+> - `src/table/iterator.rs`: lazy one-block-at-a-time first/lower-bound seek and cross-block advancement using cached reads.
+>
+> This completes Checkpoint 2’s independent first pass. Engine-level Bloom filtering stays for Checkpoint 3, where the SST point-read path exists; the Day 1 guide assigns SST filtering to that logical-engine checkpoint. Once the slice formats and compiles, I will reveal only Days 3, 4, and 7 and run their focused tests.
+>
+> Authorize this final SST slice?
+
+**Primary agent (student):**
+
+> Authorized. Implement the SST codec, builder, cache integration, and iterator slice. Once the checkpoint compiles, reveal Days 3, 4, and 7 and run only their focused tests.
+
+### Checkpoint 2 Result and Review
+
+**Week 1 subagent (coding agent):**
+
+> Checkpoint 2’s implementation and supplied validation are complete: all 19 focused tests passed (9 Day 3, 7 Day 4, 3 Day 7).
+>
+> Final SST slice:
+> - metadata is count-prefixed and stores each block’s offset plus actual first/last keys;
+> - the file layout is `blocks | metadata | meta_offset | bloom | bloom_offset` with validated open-time boundaries;
+> - the builder hashes raw keys, emits the `0.01`-sized Bloom filter, and retains matching in-memory metadata;
+> - block reads use exact adjacent offsets and cache by `(sst_id, block_index)`;
+> - SST iterators hold only the current block, select candidates by last-key lower bound, and cross block boundaries lazily.
+>
+> Exact commands and results:
+> - `rustfmt src/table.rs src/table/builder.rs src/table/iterator.rs` — completed.
+> - `cargo check --lib` — passed before tests were revealed.
+> - `cargo x copy-test --week 1 --day 3` — copied Day 3.
+> - `cargo x copy-test --week 1 --day 4` — copied Day 4.
+> - `cargo x copy-test --week 1 --day 7` — copied Day 7.
+> - `cargo test -p mini-lsm-starter week1_day3` — 9 passed, 0 failed.
+> - `cargo test -p mini-lsm-starter week1_day4` — 7 passed, 0 failed.
+> - `cargo test -p mini-lsm-starter week1_day7` — 3 passed, 0 failed.
+> - final `git diff --check` — passed.
+>
+> The consolidated ledger additionally records final prefix format; first-key prefix basis; big-endian entry/footer protocol; inclusive size target; representable oversized-first progress; lower-bound binary search; focused block checks; count-prefixed SST metadata; final trailer offsets; actual boundary keys; last-key block selection; two-part cache identity; matched raw-key FarmHash; authoritative Bloom negatives only; builder-only `0.01`; reusable decoded-key storage; and descriptive SST trailer errors.
+>
+> Boundary not established by the supplied tests: the SST iterator’s last-key search assumes metadata faithfully describes block contents. The builder establishes that invariant, but an independently corrupted yet structurally decodable last key could make a seek skip the correct block; production integrity checks/checksums belong later.
+>
+> Review `src/table.rs:268`:
+>
+> ```rust
+> .partition_point(|meta| meta.last_key.as_key_slice() < key)
+> ```
+>
+> What is this comparison trying to select? What exact-key behavior would break if `<` changed to `<=`?
+
+**Primary agent (student):**
+
+> It counts blocks whose last key is strictly before the target, so the selected index is the first block with `last_key >= target`. Changing `<` to `<=` would skip a block whose final key exactly equals the target and could miss that exact match.
+
+**Week 1 subagent (coding agent):**
+
+> Correct. Strict `<` preserves a block whose last key is the exact lower bound.
+>
+> **Course rule — Adversarial decode prediction**
+>
+> A block’s first key is encoded as `overlap=0, rest="mini-a"`; its second as `overlap=5, rest="b"`; its third as `overlap=0, rest="z"` with `value_len=0`.
+>
+> What three full keys must the iterator reconstruct, and should the third entry remain a valid block entry or disappear at this layer? I will not add a new test unless you authorize it.
+
+**Primary agent (student):**
+
+> The keys are `mini-a`, `mini-b`, and `z`. The third remains a valid block entry with an empty value; the block/SST layers preserve tombstones, and only the outer logical iterator hides them after precedence resolution. Do not add a test. Proceed to Checkpoint 3: connect the components into one logical engine.
+
+## Checkpoint 3: One Logical Engine
+
+### Read-Path Decisions
+
+**Week 1 subagent (coding agent):**
+
+> **Course rule — Which source owns the logical key?**
+>
+> `cat` appears as `tombstone` in the mutable memtable, `middle` in the newest immutable memtable, and `old` in the newest L0 SST.
+>
+> What should `get("cat")` return, what internal entry should a full scan let win before filtering, and what complete source-priority order produces those answers?
+>
+> You can reply `simpler`, `example`, `hint`, or `choose for me`.
+
+**Primary agent (student):**
+
+> `get("cat")` returns `None`. Internally, the mutable tombstone wins the scan merge and is then filtered from user output. Priority is mutable memtable, immutable memtables newest to oldest, then L0 SSTs newest to oldest; the first entry for a duplicate key is authoritative.
+
+**Week 1 subagent (coding agent):**
+
+> Correct. I’ve recorded **mutable > immutable newest-to-oldest > L0 newest-to-oldest; first duplicate wins, then an authoritative tombstone becomes absence**.
+>
+> **Course rule — What must `get` verify after an SST seek?**
+>
+> The requested key is `b`, but lower-bound seek on the merged L0 stream lands on `c → 3` because `b` is absent.
+>
+> What comparison must `get` make before returning a value, and what should it return here?
+
+**Primary agent (student):**
+
+> After seeking, `get` must require both a valid iterator and `iterator.key() == requested_key`. Here it lands on `c`, so `b` is absent and `get` returns `None` rather than `3`.
+
+**Week 1 subagent (coding agent):**
+
+> Correct. I’ve recorded **an SST lower-bound result is returned only after exact key equality; the next greater key is not a point match**.
+>
+> **Course rule — Where does an upper scan bound stop?**
+>
+> The logical stream is `a,b,c,d`. Compare scans `[b,d)` and `[b,d]` after all sources are merged.
+>
+> Which keys should each return, and which layer should enforce the upper bound given that SST iterators only receive a lower-bound seek?
+
+**Primary agent (student):**
+
+> `[b,d)` returns `b,c`; `[b,d]` returns `b,c,d`. The outer `LsmIterator` should enforce the upper bound on the already merged logical stream, since child iterators are positioned from the lower bound and source merging must happen before the final range cutoff.
+
+**Week 1 subagent (coding agent):**
+
+> Correct. I’ve recorded **`LsmIterator` enforces excluded end with `< end` and included end with `<= end` after merge**.
+>
+> **Course rule — When must the state guard be released on reads?**
+>
+> A scan clones the current structural snapshot, then creating each SST iterator may read a block from disk. Holding `state.read()` through those reads can block a freeze or flush from publishing a new snapshot for milliseconds.
+>
+> What should remain alive for consistency, and what must be dropped before SST iterator creation begins?
+
+**Primary agent (student):**
+
+> Keep the cloned `Arc<LsmStorageState>` snapshot alive so the scan sees one coherent set of memtables/SST handles. Drop the `state.read()` guard immediately after cloning that snapshot, before any SST block I/O or iterator creation.
+
+**Week 1 subagent (coding agent):**
+
+> Correct. I’ve recorded **retain the cloned state `Arc`, but release the read guard before constructing/ seeking SST iterators or doing I/O**.
+>
+> **Your choice — How should memory and disk streams be composed?**
+>
+> We can wrap memtable and SST iterators in a common dynamic enum/trait object and feed one large merge, or keep a homogeneous memtable merge and homogeneous L0 merge, then combine those two different types with `TwoMergeIterator` where the memory side wins ties. The second preserves static dispatch and the starter architecture; the first is conceptually flatter but adds dispatch/boxing complexity.
+>
+> Which composition should we use?
+
+**Primary agent (student):**
+
+> Keep homogeneous memtable and L0 `MergeIterator`s, then combine them with `TwoMergeIterator` so the memory side wins equal keys. This fits the starter's static-dispatch architecture without boxing heterogeneous children.
+
+**Week 1 subagent (coding agent):**
+
+> Accepted. I’ve recorded **merge memory and L0 separately, then use `TwoMergeIterator` with memory as side A so it wins equal keys**.
+>
+> **Course rule — When can range filtering skip an SST?**
+>
+> An SST’s key range is `[b,d]`. Compare scan ranges `(d,f]` and `[d,f]`.
+>
+> May the engine exclude this SST for each scan, and which endpoint equality makes the answers differ?
+
+**Primary agent (student):**
+
+> For `(d,f]`, the SST may be skipped because its largest key equals the excluded lower bound, so it contains nothing greater than `d`. For `[d,f]`, it must remain because key `d` is included. Thus an excluded lower bound skips when `sst.last_key <= bound`, while an included lower bound skips only when `sst.last_key < bound`.
+
+**Week 1 subagent (coding agent):**
+
+> Correct. I’ve recorded the lower-side overlap rule exactly.
+>
+> **Course rule — What is the symmetric upper-side rule?**
+>
+> The same SST spans `[b,d]`. Compare scans `[a,b)` and `[a,b]`.
+>
+> May the SST be skipped for each range, and how do excluded versus included upper bounds compare against the SST’s first key?
+
+**Primary agent (student):**
+
+> For `[a,b)`, skip the SST because its first key equals the excluded upper bound. For `[a,b]`, keep it because `b` is included. An excluded upper bound skips when `sst.first_key >= bound`; an included upper bound skips only when `sst.first_key > bound`.
+
+**Week 1 subagent (coding agent):**
+
+> Correct. I’ve recorded the symmetric upper-side overlap rule.
+>
+> **Course rule — What should active-iterator accounting count?**
+>
+> A memtable merge has one current child and two children still in its heap; an L0 merge has one current child and one heap child. They are combined by `TwoMergeIterator`.
+>
+> What should `num_active_iterators()` report for the combined logical iterator, and why must the merge’s current child be included?
+
+**Primary agent (student):**
+
+> It should report `3 + 2 = 5`. Each merge's current child is temporarily outside its heap but still live and able to produce data, so omitting it would undercount actual active iterators and make filtering/accounting results misleading.
+
+### Read-Path Slice Authorization and Report
+
+**Week 1 subagent (coding agent):**
+
+> Correct. I’ve recorded **active counts sum all live children, including each merge’s current child outside its heap**.
+>
+> We have enough decisions for a coherent read-path slice.
+>
+> Proposed changes:
+> - `src/iterators/two_merge_iterator.rs`: merge two iterator types, prefer side A on equality, consume side B’s duplicate, and sum active counts.
+> - `src/iterators/merge_iterator.rs`: include current plus heap children in active counts.
+> - `src/lsm_iterator.rs`: compose memory and L0 merges, enforce included/excluded upper bounds after merge, retain tombstone filtering, and delegate active counts.
+> - `src/lsm_storage.rs`: clone/release the state snapshot before SST I/O; implement exact `get` across memtables and range/Bloom-filtered L0; implement bounded scan with precise SST overlap filtering and newest-first sources.
+>
+> No flush, lifecycle, or background-trigger behavior changes yet. Days 5 and 6 remain unrevealed until the full logical-engine checkpoint compiles.
+>
+> Authorize this read-path slice?
+
+**Primary agent (student):**
+
+> Authorized. Implement the complete memory-plus-L0 read path and iterator accounting slice, using non-test checks and leaving Days 5 and 6 unrevealed.
+
+**Week 1 subagent (coding agent):**
+
+> The memory-plus-L0 read-path slice is implemented and compiles. Days 5 and 6 remain unrevealed.
+>
+> Changed:
+> - `TwoMergeIterator` now merges different child types, gives side A equality precedence, removes side B’s duplicate, and sums active counts.
+> - `MergeIterator`, `LsmIterator`, and `FusedIterator` now propagate accurate active counts.
+> - `LsmIterator` owns the final upper bound and stops correctly for included/excluded endpoints after merging and tombstone filtering.
+> - `get` and `scan` retain a cloned state snapshot but release the lock before SST I/O; they use newest-first L0 order, exact point equality, Bloom/key-range filtering, precise scan overlap, and excluded-lower handling.
+>
+> Exact checks:
+> - `rustfmt src/iterators/two_merge_iterator.rs src/iterators/merge_iterator.rs src/lsm_iterator.rs src/lsm_storage.rs` — completed.
+> - `cargo check --lib` — passed.
+> - `git diff --check` — passed.
+>
+> Boundary not yet established by supplied tests: the public scan path assumes a sensible range (lower not logically after upper). The implementation precisely handles endpoint inclusion, but it does not define a special error contract for reversed bounds; that remains an API precondition inherited from the child range implementation.
+>
+> Review `src/iterators/two_merge_iterator.rs:42`:
+>
+> ```rust
+> self.use_a = self.a.is_valid() && (!self.b.is_valid() || self.a.key() <= self.b.key());
+> ```
+>
+> What is this comparison trying to choose? What visible behavior would break if `<=` changed to `<` when side A is memory and side B is L0?
+
+**Primary agent (student):**
+
+> It selects the smaller current key and deliberately selects side A on equality. If `<=` became `<`, an equal key from L0 would win over the newer memory entry, exposing stale data or even resurrecting a value hidden by a memory tombstone.
+
+### Flush and Lifecycle Decisions
+
+**Week 1 subagent (coding agent):**
+
+> Correct. Equality is the cross-layer recency rule; changing it would invert memory-over-disk precedence.
+>
+> **Course rule — Which immutable memtable is flushed?**
+>
+> `imm_memtables` is `[7,6,5]` from newest to oldest, and L0 is `[4,3]` from newest to oldest. One flush completes successfully.
+>
+> Which memtable ID should be selected, and what should both vectors contain afterward?
+
+**Primary agent (student):**
+
+> Select the oldest immutable memtable, ID 5. After installing its SST, `imm_memtables` is `[7,6]` and L0 is `[5,4,3]`, with the newly flushed SST inserted at the newest side.
+
+**Week 1 subagent (coding agent):**
+
+> Correct. I’ve recorded **flush the last/oldest immutable table and install its SST ID at the front/newest side of L0**.
+>
+> **Course rule — What must the install transaction verify?**
+>
+> The SST was built from immutable memtable 5 outside the state read-write lock. Before installation, the code reacquires the write lock and removes one immutable entry.
+>
+> Which identity must it assert, and which three structural updates must be published together in the replacement snapshot?
+
+**Primary agent (student):**
+
+> Assert that the current oldest/last immutable memtable is still ID 5—the exact source used to build the SST. Publish removal of that memtable, insertion of the new `SsTable` into the `sstables` map, and insertion of ID 5 at the front of `l0_sstables` in one replacement state snapshot.
+
+**Week 1 subagent (coding agent):**
+
+> Correct. I’ve recorded **verify the popped ID matches the built SST and atomically remove that memtable, add the table object, and prepend its ID to L0**.
+>
+> **Your choice — How should the flush serialize without holding the state write lock during I/O?**
+>
+> We can hold `state_lock` across selection, SST construction/file I/O, and the short install transaction while releasing `state.read()` after cloning the selected memtable. This is simple and prevents two flushers selecting the same table, but other structural changes wait. Or we can add an explicit in-flight reservation to release `state_lock` during I/O, which increases concurrency but adds new failure/recovery state.
+>
+> Which Week 1 design should we use?
+
+**Primary agent (student):**
+
+> For Week 1, hold `state_lock` across selection, SST construction/I/O, and installation, while releasing the `state` read-write guard during the expensive build. This prevents duplicate flush selection without introducing an in-flight reservation protocol.
+
+**Week 1 subagent (coding agent):**
+
+> Accepted. I’ve recorded **hold `state_lock` for the whole flush operation, but hold the state read/write guard only for selection and final installation—not during SST construction or file I/O**.
+>
+> **Course rule — What if the flush observation is stale?**
+>
+> A caller observes a non-empty immutable list, waits for `state_lock`, and another flush drains the list first. Once this caller acquires `state_lock`, the latest state has no immutable memtable.
+>
+> Should it fail, build anything, or return successfully without work?
+
+**Primary agent (student):**
+
+> Recheck after acquiring `state_lock` and return `Ok(())` without building anything when the immutable list is empty. The earlier observation was only a hint; an already-completed flush is not an error.
+
+**Week 1 subagent (coding agent):**
+
+> Correct. I’ve recorded **recheck under `state_lock`; an already-drained immutable list is a successful no-op**.
+>
+> **Course rule — When should the background worker flush?**
+>
+> `num_memtable_limit` is 2. On a worker tick, there are exactly two immutable memtables waiting.
+>
+> Should it flush at equality or only above the limit, and which end of the list does that triggered flush remove?
+
+**Primary agent (student):**
+
+> Flush at equality: trigger when `imm_memtables.len() >= num_memtable_limit`. The flush still removes the oldest entry at the end of the newest-first immutable list.
+
+**Week 1 subagent (coding agent):**
+
+> Correct. I’ve recorded **background flush triggers at `len >= limit` and still selects the oldest immutable table**.
+>
+> **Course rule — What does `close()` guarantee in Day 1?**
+>
+> The engine still has data in its mutable memtable. The user calls `close()` twice.
+>
+> Which worker actions must the first call perform, what should the second call do, and should either call implicitly freeze/flush the remaining mutable data?
+
+**Primary agent (student):**
+
+> The first call signals the existing background workers to stop and joins their handles. The second is harmless because those handles have already been taken. Day 1 `close()` does not implicitly freeze or flush the remaining mutable memtable.
+
+**Week 1 subagent (coding agent):**
+
+> Correct. I’ve recorded **`close` signals and joins each existing worker once, is idempotent after handles are taken, and does not implicitly flush mutable state**.
+>
+> **Course rule — What should opening a new path do?**
+>
+> The requested database directory does not exist yet, and the first eventual flush needs to create `00001.sst` inside it.
+>
+> Should `open` reject the path, defer directory creation until flush, or create the directory before constructing the engine—and why?
+
+**Primary agent (student):**
+
+> Create the directory during `open` before constructing the engine. Then later SST creation has a valid parent path, and opening a fresh database path works without deferring an avoidable filesystem failure to the first flush.
+
+### Final Slice Authorization
+
+**Week 1 subagent (coding agent):**
+
+> Correct. I’ve recorded **`open` creates the database directory up front so SST writes have a valid parent**.
+>
+> We have enough decisions for the final write/flush/lifecycle slice.
+>
+> Added ledger entries:
+>
+> | Decision or constraint | Student’s conclusion | Invariant/evidence | Consequence |
+> |---|---|---|---|
+> | Flush selection | Oldest/last immutable table | Immutable list is newest-first | `[7,6,5] → [7,6]` |
+> | SST install | Verify built ID equals popped ID; map insert + L0 prepend atomically | One source transitions memory→disk | No loss/duplication/wrong table |
+> | Lock scope | Hold `state_lock` across whole flush; release state RW guard during build/I/O | Prevent duplicate selection without long global RW lock | Structural changes serialize |
+> | Stale request | Recheck and return `Ok(())` if empty | Earlier observation is only a hint | Concurrently completed work is no-op |
+> | Trigger | Flush at immutable count `>= limit` | Limit is inclusive | Oldest backlog entry drains |
+> | Close | Signal/join handles once; no implicit mutable flush | Fixed Day 1 lifecycle | Repeated close is harmless |
+> | New path | Create directory in `open` | Flush needs a valid parent | Fresh database opens cleanly |
+>
+> Proposed changes:
+> - `src/mem_table.rs`: stream the sorted memtable, including tombstones, into `SsTableBuilder`.
+> - `src/lsm_storage.rs`: create the directory, perform oldest immutable flush with I/O outside the state RW lock and atomic verified install, sync the directory entry, and implement idempotent worker shutdown.
+> - `src/compact.rs`: trigger background flushing at the configured inclusive limit.
+>
+> After this compiles, Checkpoint 3’s first pass is complete; I will then reveal only Days 5 and 6 and run their focused tests.
+>
+> Authorize this final slice?
+
+**Primary agent (student):**
+
+> Authorized. Implement the memtable-to-SST flush, background trigger, directory setup, and idempotent Day 1 lifecycle slice. After non-test compilation succeeds, reveal Days 5 and 6 and run only their focused tests.
+
+### Checkpoint 3 Result and Review
+
+**Week 1 subagent (coding agent):**
+
+> Checkpoint 3’s implementation and supplied validation are complete: Day 5 passed 8/8 and Day 6 passed 5/5.
+>
+> Final slice behavior:
+> - memtable flush preserves sorted entries and tombstones in a final-format SST;
+> - flush holds `state_lock`, releases state RW guards during build/I/O, rechecks empty state, verifies the installed source ID, and atomically moves it to newest L0;
+> - `open` creates the directory and flush syncs its directory entry;
+> - the background worker triggers at `imm_memtables.len() >= num_memtable_limit`;
+> - `close` signals and joins existing handles once without flushing mutable state.
+>
+> Exact validation:
+> - `rustfmt src/mem_table.rs src/compact.rs src/lsm_storage.rs` — completed.
+> - `cargo check --lib` and `git diff --check` — passed before revealing tests.
+> - `cargo x copy-test --week 1 --day 5` and `--day 6` — copied the two supplied modules.
+> - `cargo test -p mini-lsm-starter week1_day5` — 8 passed, 0 failed.
+> - `cargo test -p mini-lsm-starter week1_day6` — 5 passed, 0 failed.
+> - First `cargo x scheck` — 46/46 tests passed; Clippy reported one collapsible conditional.
+> - I applied only that mechanical cleanup. A direct `let`-chain form was rejected by this repository’s pre-2024 formatter, so I used an edition-compatible `matches!` guard.
+> - Final `cargo x scheck` — formatting, check, 46/46 nextest tests, and Clippy all passed with no warnings.
+>
+> Audit: no assertions or supplied test bodies were removed/changed; test modules were added through `cargo x copy-test`, and `src/tests.rs` contains only their module declarations. No new lint suppressions or unresolved Week 1 placeholders were added. Remaining `unimplemented!` calls are explicitly later-week WAL, batch, compaction, or sync work. New `unwrap`/assert sites protect already-checked decoder lengths, valid-iterator access, non-empty builder metadata, or internal state-ID invariants; none masks a recoverable Week 1 operation.
+>
+> Boundary not established by the supplied tests: a filesystem failure after the SST file is created/synced but before the state snapshot is installed can leave an orphan file. Recovery/manifest cleanup is a later durability concern; the in-memory state remains unchanged.
+>
+> Review `src/lsm_storage.rs:442-446`:
+>
+> ```rust
+> assert_eq!(removed.id(), sst_id, "installed SST must match flushed memtable");
+> ```
+>
+> What is this assertion trying to prove about the transition? What corruption could follow if installation silently removed a different immutable memtable than the one used to build the SST?
+
+**Primary agent (student):**
+
+> It proves the atomic transition removes exactly the immutable memtable whose contents produced the installed SST. If a different memtable were removed, one table's data could be lost while the flushed source remained visible alongside its SST, creating both a missing source and duplicate/stale state.
+
+### Final Adversarial Prediction
+
+**Week 1 subagent (coding agent):**
+
+> Correct. The assertion ties the removed in-memory source to the exact durable replacement; without it, one transition could simultaneously lose unrelated data and duplicate the flushed data.
+>
+> **Course rule — Final adversarial state prediction**
+>
+> Mutable: `b → tombstone, d → 4`
+>
+> Newest immutable: `a → 1, b → 2`
+>
+> Newest L0: `a → 0, c → 3, d → 3`
+>
+> What should `get(a)`, `get(b)`, and scan `[a,d]` return? Name the winning source for each visible or deleted key. I will not add a new permanent test unless you authorize it.
+
+**Primary agent (student):**
+
+> `get(a)` returns `1` from the newest immutable memtable; `get(b)` returns `None` because the mutable tombstone wins over immutable `b → 2`. Scan `[a,d]` returns `a → 1`, `c → 3`, `d → 4`: `a` wins from the immutable memtable over L0, `b` is deleted by mutable state, `c` comes from L0, and mutable `d → 4` wins over L0 `d → 3`. Do not add a permanent test. Complete the remaining Day 1 audit and deliberate-fault experiment from the guide, reverting the fault immediately, then provide the final evidence report and your candid feedback on this agent path.
+
+## Deliberate-Fault Experiment
+
+**Week 1 subagent (coding agent):**
+
+> Deliberate-fault prediction: I will temporarily change `LsmIterator`’s excluded upper-bound comparison from `<` to `<=`. I expect `tests::week1_day5::test_task2_storage_scan_end_bound_at_seek_position` to fail because a key exactly at the excluded endpoint becomes visible. I am starting from the clean 46/46 passing state and will revert immediately after the one narrow run.
+
+The predicted test failed at the supplied assertion that the iterator must be invalid at the excluded endpoint. The coding agent immediately restored `<`, reran the exact test, and observed it pass. No deliberate-fault code remained in the final tree.
+
+## Final Evidence Report
+
+**Week 1 subagent (coding agent):**
+
+> Day 1 is complete in `/tmp/mini-lsm-week1-agent-walkthrough/mini-lsm-starter`. I did not commit, push, or access `../mini-lsm`.
+>
+> Implementation
+>
+> - Ordered memtables, point operations, tombstones, freezing, bounded cursors, merge iterators, and fused error behavior.
+> - Final prefix-compressed block codec with inclusive sizing, oversized-first progress, indexed binary-search seeking, and decoder checks.
+> - SST metadata/trailer codec, Bloom filters, block cache, lazy SST iteration, and validated opening.
+> - Unified memory/L0 `get` and `scan`, exact bounds, source precedence, Bloom/range filtering, and active-iterator accounting.
+> - Oldest-memtable flush to newest L0, atomic verified installation, automatic flush triggering, directory setup/sync, and idempotent worker shutdown.
+> - Supplied Week 1 Days 1–7 tests copied only after each checkpoint’s compiling first pass.
+>
+> Key decisions
+>
+> No decisions were delegated.
+>
+> - Raw bytewise ordering; latest mapping wins.
+> - Empty values are tombstones preserved until the outer logical iterator.
+> - Priority: mutable > immutable newest-to-oldest > L0 newest-to-oldest.
+> - Writers retain the state read guard through insertion.
+> - Final Day 7 first-key prefix format, big-endian fields, inclusive target.
+> - Binary-search block seeks and last-key SST candidate selection.
+> - Count-prefixed block metadata and validated SST trailers.
+> - Bloom writer/reader use identical FarmHash input; only negatives skip.
+> - Static memtable/L0 merges joined by `TwoMergeIterator`.
+> - `state_lock` spans flush selection/build/install, while state RW guards do not span I/O.
+> - `close` joins workers but does not implicitly flush mutable state.
+>
+> Validation
+>
+> - Week 1 Day 1: 6 passed.
+> - Day 2: 8 passed.
+> - Day 3: 9 passed.
+> - Day 4: 7 passed.
+> - Day 7: 3 passed.
+> - Day 5: 8 passed.
+> - Day 6: 5 passed.
+> - Final `cargo x scheck`: formatting, compilation, 46/46 tests, and Clippy passed without warnings.
+> - `git diff --check` passed.
+>
+> The deliberate-fault experiment changed excluded upper-bound handling from `<` to `<=`. As predicted, `test_task2_storage_scan_end_bound_at_seek_position` failed at `assertion failed: !iter.is_valid()`. The fault was immediately reverted, and the same test passed.
+>
+> Data flow
+>
+> - `put`: hold the state read guard through memtable insertion, update approximate size, then serialize/recheck a possible freeze.
+> - `get`: clone the state snapshot, probe memory by recency, then range/Bloom-filter L0, lower-bound seek, and require exact equality.
+> - bounded `scan`: construct bounded memory cursors and filtered L0 cursors after releasing the state guard; merge by recency, remove duplicates/tombstones, and enforce the final upper bound.
+> - flush: hold `state_lock`, select the oldest immutable table, release state RW guards during SST creation, then verify and atomically replace that source with its SST in newest L0.
+>
+> The main concurrency risk is writing into a memtable after it has been published immutable; retaining the state read guard through insertion prevents the freezer from acquiring its write guard during that interval. The main correctness-preserving optimization is SST range/Bloom filtering: it changes iterator and I/O counts, never logical results.
+>
+> A remaining weakness is crash cleanup between SST creation and snapshot installation, which can leave an orphan file. Manifest recovery belongs to later course work. Live skiplist scans also do not promise snapshot isolation from concurrent insertions.
+>
+> Candid path feedback
+>
+> The implementation-before-test boundary worked very well: every newly revealed suite passed on its first run, showing that the book plus student-owned decisions were sufficient without assertion-by-assertion test reconstruction.
+>
+> The main drawback is interaction volume. One-question-at-a-time plus separate slice authorization is pedagogically strong but made “fast-forward” quite turn-heavy. A progress marker and a documented mastery shortcut would help experienced students without weakening the default protocol.
+>
+> There are two instruction rough edges worth fixing:
+>
+> - The Day 1 text says both not to copy tests before checkpoints and, elsewhere, to begin with tests copied.
+> - `AGENTS.md` says only `cargo x copy-test` may rewrite `src/tests.rs`, while required `cargo x scheck` runs `cargo fmt`, which also reorders that generated file. `copy-test` should emit deterministic rustfmt-ready ordering or the formatter should be explicitly exempted.
+>
+> One flaw in my own walkthrough: the first memtable slice included approximate-size accounting before we had explicitly reasoned through the freeze threshold. The slice preview disclosed it and was authorized, but a cleaner dialogue would defer that field to the freeze slice.
+>
+> Finally, because every product suite passed immediately, this walkthrough did not exercise the newly specified failure-coaching behavior—explaining test evidence and waiting for the student’s diagnosis. A separate intentional learner-bug scenario would be useful for validating that part of the path.
+
+## Appendix: Final Implementation and Results
+
+### Implementation Files
+
+- `src/block.rs`
+- `src/block/builder.rs`
+- `src/block/iterator.rs`
+- `src/compact.rs`
+- `src/iterators/merge_iterator.rs`
+- `src/iterators/two_merge_iterator.rs`
+- `src/lsm_iterator.rs`
+- `src/lsm_storage.rs`
+- `src/mem_table.rs`
+- `src/table.rs`
+- `src/table/bloom.rs`
+- `src/table/builder.rs`
+- `src/table/iterator.rs`
+
+The supplied harness and Week 1 Day 1–7 modules were added only through the course's `cargo x copy-test` commands after their checkpoint implementations compiled.
+
+### Result Summary
+
+| Validation target | Result |
+|---|---:|
+| Week 1 Day 1 | 6 passed |
+| Week 1 Day 2 | 8 passed |
+| Week 1 Day 3 | 9 passed |
+| Week 1 Day 4 | 7 passed |
+| Week 1 Day 5 | 8 passed |
+| Week 1 Day 6 | 5 passed |
+| Week 1 Day 7 | 3 passed |
+| Full `cargo x scheck` | 46 passed, Clippy clean |
+| Deliberate-fault narrow test | Failed as predicted, then passed after immediate revert |
+
+### Feedback Summary
+
+- The implementation-before-test protection successfully prevented test-shaped development.
+- Concrete questions led to correct independent implementations across all three checkpoints.
+- The student demonstrated the ordering, representation, bounds, concurrency, flush, and optimization invariants without delegating any decision.
+- The path is educational but interaction-heavy; progress markers and a mastery shortcut would make the “fast-forward” framing more accurate.
+- The book's test-copy wording and the `copy-test`/`cargo fmt` ownership of `src/tests.rs` should be reconciled.
+- A future trial should intentionally begin with a student-owned product bug so the failure-explanation-and-student-diagnosis protocol is exercised directly.

--- a/mini-lsm-starter/src/block.rs
+++ b/mini-lsm-starter/src/block.rs
@@ -19,7 +19,7 @@ mod builder;
 mod iterator;
 
 pub use builder::BlockBuilder;
-use bytes::Bytes;
+use bytes::{BufMut, Bytes};
 pub use iterator::BlockIterator;
 
 /// A block is the smallest unit of read and caching in LSM tree. It is a collection of sorted key-value pairs.
@@ -32,11 +32,48 @@ impl Block {
     /// Encode the internal data to the data layout illustrated in the course
     /// Note: You may want to recheck if any of the expected field is missing from your output
     pub fn encode(&self) -> Bytes {
-        unimplemented!()
+        assert!(self.offsets.len() <= u16::MAX as usize);
+        let mut encoded =
+            Vec::with_capacity(self.data.len() + (self.offsets.len() + 1) * size_of::<u16>());
+        encoded.extend_from_slice(&self.data);
+        for offset in &self.offsets {
+            encoded.put_u16(*offset);
+        }
+        encoded.put_u16(self.offsets.len() as u16);
+        encoded.into()
     }
 
     /// Decode from the data layout, transform the input `data` to a single `Block`
     pub fn decode(data: &[u8]) -> Self {
-        unimplemented!()
+        assert!(data.len() >= size_of::<u16>(), "block footer is missing");
+        let count = u16::from_be_bytes(data[data.len() - 2..].try_into().unwrap()) as usize;
+        let footer_len = (count + 1)
+            .checked_mul(size_of::<u16>())
+            .expect("block footer length overflow");
+        assert!(
+            footer_len <= data.len(),
+            "block offset table is out of bounds"
+        );
+        let data_end = data.len() - footer_len;
+        let mut offsets = Vec::with_capacity(count);
+        for chunk in data[data_end..data.len() - 2].chunks_exact(2) {
+            offsets.push(u16::from_be_bytes(chunk.try_into().unwrap()));
+        }
+        assert_eq!(offsets.len(), count);
+        if let Some(first) = offsets.first() {
+            assert_eq!(*first, 0, "first block entry must start at offset zero");
+        }
+        assert!(
+            offsets.windows(2).all(|pair| pair[0] < pair[1]),
+            "block offsets must be strictly increasing"
+        );
+        assert!(
+            offsets.iter().all(|offset| (*offset as usize) < data_end),
+            "block entry offset is outside the data section"
+        );
+        Self {
+            data: data[..data_end].to_vec(),
+            offsets,
+        }
     }
 }

--- a/mini-lsm-starter/src/block/builder.rs
+++ b/mini-lsm-starter/src/block/builder.rs
@@ -15,6 +15,8 @@
 #![allow(unused_variables)] // TODO(you): remove this lint after implementing this mod
 #![allow(dead_code)] // TODO(you): remove this lint after implementing this mod
 
+use bytes::BufMut;
+
 use crate::key::{KeySlice, KeyVec};
 
 use super::Block;
@@ -34,23 +36,73 @@ pub struct BlockBuilder {
 impl BlockBuilder {
     /// Creates a new block builder.
     pub fn new(block_size: usize) -> Self {
-        unimplemented!()
+        Self {
+            offsets: Vec::new(),
+            data: Vec::new(),
+            block_size,
+            first_key: KeyVec::new(),
+        }
     }
 
     /// Adds a key-value pair to the block. Returns false when the block is full.
     /// You may find the `bytes::BufMut` trait useful for manipulating binary data.
     #[must_use]
     pub fn add(&mut self, key: KeySlice, value: &[u8]) -> bool {
-        unimplemented!()
+        if key.is_empty() || self.offsets.len() == u16::MAX as usize {
+            return false;
+        }
+
+        let overlap = if self.is_empty() {
+            0
+        } else {
+            self.first_key
+                .raw_ref()
+                .iter()
+                .zip(key.raw_ref())
+                .take_while(|(a, b)| a == b)
+                .count()
+        };
+        let rest = &key.raw_ref()[overlap..];
+        if overlap > u16::MAX as usize
+            || rest.len() > u16::MAX as usize
+            || value.len() > u16::MAX as usize
+            || self.data.len() > u16::MAX as usize
+        {
+            return false;
+        }
+
+        let entry_size = 2 + 2 + rest.len() + 2 + value.len();
+        let projected_size = self.data.len()
+            + entry_size
+            + (self.offsets.len() + 1) * size_of::<u16>()
+            + size_of::<u16>();
+        if !self.is_empty() && projected_size > self.block_size {
+            return false;
+        }
+
+        self.offsets.push(self.data.len() as u16);
+        self.data.put_u16(overlap as u16);
+        self.data.put_u16(rest.len() as u16);
+        self.data.extend_from_slice(rest);
+        self.data.put_u16(value.len() as u16);
+        self.data.extend_from_slice(value);
+        if self.first_key.is_empty() {
+            self.first_key.set_from_slice(key);
+        }
+        true
     }
 
     /// Check if there is no key-value pair in the block.
     pub fn is_empty(&self) -> bool {
-        unimplemented!()
+        self.offsets.is_empty()
     }
 
     /// Finalize the block.
     pub fn build(self) -> Block {
-        unimplemented!()
+        assert!(!self.is_empty(), "cannot build an empty block");
+        Block {
+            data: self.data,
+            offsets: self.offsets,
+        }
     }
 }

--- a/mini-lsm-starter/src/block/iterator.rs
+++ b/mini-lsm-starter/src/block/iterator.rs
@@ -48,44 +48,103 @@ impl BlockIterator {
 
     /// Creates a block iterator and seek to the first entry.
     pub fn create_and_seek_to_first(block: Arc<Block>) -> Self {
-        unimplemented!()
+        let mut iter = Self::new(block);
+        iter.seek_to_first();
+        iter
     }
 
     /// Creates a block iterator and seek to the first key that >= `key`.
     pub fn create_and_seek_to_key(block: Arc<Block>, key: KeySlice) -> Self {
-        unimplemented!()
+        let mut iter = Self::new(block);
+        iter.seek_to_key(key);
+        iter
     }
 
     /// Returns the key of the current entry.
     pub fn key(&self) -> KeySlice<'_> {
-        unimplemented!()
+        self.key.as_key_slice()
     }
 
     /// Returns the value of the current entry.
     pub fn value(&self) -> &[u8] {
-        unimplemented!()
+        &self.block.data[self.value_range.0..self.value_range.1]
     }
 
     /// Returns true if the iterator is valid.
     /// Note: You may want to make use of `key`
     pub fn is_valid(&self) -> bool {
-        unimplemented!()
+        !self.key.is_empty()
     }
 
     /// Seeks to the first key in the block.
     pub fn seek_to_first(&mut self) {
-        unimplemented!()
+        self.first_key.clear();
+        self.seek_to_idx(0);
     }
 
     /// Move to the next key in the block.
     pub fn next(&mut self) {
-        unimplemented!()
+        self.seek_to_idx(self.idx.saturating_add(1));
     }
 
     /// Seek to the first key that >= `key`.
     /// Note: You should assume the key-value pairs in the block are sorted when being added by
     /// callers.
     pub fn seek_to_key(&mut self, key: KeySlice) {
-        unimplemented!()
+        self.seek_to_first();
+        let mut low = 0;
+        let mut high = self.block.offsets.len();
+        while low < high {
+            let mid = low + (high - low) / 2;
+            self.seek_to_idx(mid);
+            if self.key() < key {
+                low = mid + 1;
+            } else {
+                high = mid;
+            }
+        }
+        self.seek_to_idx(low);
+    }
+
+    fn seek_to_idx(&mut self, idx: usize) {
+        self.idx = idx;
+        if idx >= self.block.offsets.len() {
+            self.key.clear();
+            self.value_range = (0, 0);
+            return;
+        }
+
+        let data = &self.block.data;
+        let entry_start = self.block.offsets[idx] as usize;
+        assert!(entry_start + 4 <= data.len(), "truncated block key header");
+        let overlap =
+            u16::from_be_bytes(data[entry_start..entry_start + 2].try_into().unwrap()) as usize;
+        let rest_len =
+            u16::from_be_bytes(data[entry_start + 2..entry_start + 4].try_into().unwrap()) as usize;
+        let rest_start = entry_start + 4;
+        let rest_end = rest_start
+            .checked_add(rest_len)
+            .expect("block key length overflow");
+        assert!(rest_end + 2 <= data.len(), "truncated block key");
+        assert!(
+            overlap <= self.first_key.len(),
+            "key overlap exceeds first key"
+        );
+        let value_len =
+            u16::from_be_bytes(data[rest_end..rest_end + 2].try_into().unwrap()) as usize;
+        let value_start = rest_end + 2;
+        let value_end = value_start
+            .checked_add(value_len)
+            .expect("block value length overflow");
+        assert!(value_end <= data.len(), "truncated block value");
+
+        self.key.clear();
+        self.key.append(&self.first_key.raw_ref()[..overlap]);
+        self.key.append(&data[rest_start..rest_end]);
+        if idx == 0 {
+            assert_eq!(overlap, 0, "first block key must have zero overlap");
+            self.first_key.set_from_slice(self.key.as_key_slice());
+        }
+        self.value_range = (value_start, value_end);
     }
 }

--- a/mini-lsm-starter/src/compact.rs
+++ b/mini-lsm-starter/src/compact.rs
@@ -161,6 +161,10 @@ impl LsmStorageInner {
     }
 
     fn trigger_flush(&self) -> Result<()> {
+        let should_flush = self.state.read().imm_memtables.len() >= self.options.num_memtable_limit;
+        if should_flush {
+            self.force_flush_next_imm_memtable()?;
+        }
         Ok(())
     }
 

--- a/mini-lsm-starter/src/iterators/merge_iterator.rs
+++ b/mini-lsm-starter/src/iterators/merge_iterator.rs
@@ -16,7 +16,7 @@
 #![allow(dead_code)] // TODO(you): remove this lint after implementing this mod
 
 use std::cmp::{self};
-use std::collections::BinaryHeap;
+use std::collections::{BinaryHeap, binary_heap::PeekMut};
 
 use anyhow::Result;
 
@@ -59,7 +59,17 @@ pub struct MergeIterator<I: StorageIterator> {
 
 impl<I: StorageIterator> MergeIterator<I> {
     pub fn create(iters: Vec<Box<I>>) -> Self {
-        unimplemented!()
+        let mut heap = BinaryHeap::new();
+        for (index, iter) in iters.into_iter().enumerate() {
+            if iter.is_valid() {
+                heap.push(HeapWrapper(index, iter));
+            }
+        }
+        let current = heap.pop();
+        Self {
+            iters: heap,
+            current,
+        }
     }
 }
 
@@ -69,18 +79,53 @@ impl<I: 'static + for<'a> StorageIterator<KeyType<'a> = KeySlice<'a>>> StorageIt
     type KeyType<'a> = KeySlice<'a>;
 
     fn key(&self) -> KeySlice<'_> {
-        unimplemented!()
+        self.current.as_ref().unwrap().1.key()
     }
 
     fn value(&self) -> &[u8] {
-        unimplemented!()
+        self.current.as_ref().unwrap().1.value()
     }
 
     fn is_valid(&self) -> bool {
-        unimplemented!()
+        self.current.is_some()
     }
 
     fn next(&mut self) -> Result<()> {
-        unimplemented!()
+        let Some(mut current) = self.current.take() else {
+            return Ok(());
+        };
+
+        while let Some(mut iter) = self.iters.peek_mut() {
+            if iter.1.key() != current.1.key() {
+                break;
+            }
+            if let Err(error) = iter.1.next() {
+                PeekMut::pop(iter);
+                return Err(error);
+            }
+            if !iter.1.is_valid() {
+                PeekMut::pop(iter);
+            }
+        }
+
+        current.1.next()?;
+        if current.1.is_valid() {
+            self.iters.push(current);
+        }
+        self.current = self.iters.pop();
+        Ok(())
+    }
+
+    fn num_active_iterators(&self) -> usize {
+        let current = self
+            .current
+            .as_ref()
+            .map_or(0, |iter| iter.1.num_active_iterators());
+        current
+            + self
+                .iters
+                .iter()
+                .map(|iter| iter.1.num_active_iterators())
+                .sum::<usize>()
     }
 }

--- a/mini-lsm-starter/src/iterators/two_merge_iterator.rs
+++ b/mini-lsm-starter/src/iterators/two_merge_iterator.rs
@@ -24,7 +24,7 @@ use super::StorageIterator;
 pub struct TwoMergeIterator<A: StorageIterator, B: StorageIterator> {
     a: A,
     b: B,
-    // Add fields as need
+    use_a: bool,
 }
 
 impl<
@@ -33,7 +33,13 @@ impl<
 > TwoMergeIterator<A, B>
 {
     pub fn create(a: A, b: B) -> Result<Self> {
-        unimplemented!()
+        let mut this = Self { a, b, use_a: false };
+        this.update_current();
+        Ok(this)
+    }
+
+    fn update_current(&mut self) {
+        self.use_a = self.a.is_valid() && (!self.b.is_valid() || self.a.key() <= self.b.key());
     }
 }
 
@@ -45,18 +51,42 @@ impl<
     type KeyType<'a> = A::KeyType<'a>;
 
     fn key(&self) -> Self::KeyType<'_> {
-        unimplemented!()
+        if self.use_a {
+            self.a.key()
+        } else {
+            self.b.key()
+        }
     }
 
     fn value(&self) -> &[u8] {
-        unimplemented!()
+        if self.use_a {
+            self.a.value()
+        } else {
+            self.b.value()
+        }
     }
 
     fn is_valid(&self) -> bool {
-        unimplemented!()
+        self.a.is_valid() || self.b.is_valid()
     }
 
     fn next(&mut self) -> Result<()> {
-        unimplemented!()
+        if !self.is_valid() {
+            return Ok(());
+        }
+        if self.use_a {
+            if self.b.is_valid() && self.a.key() == self.b.key() {
+                self.b.next()?;
+            }
+            self.a.next()?;
+        } else {
+            self.b.next()?;
+        }
+        self.update_current();
+        Ok(())
+    }
+
+    fn num_active_iterators(&self) -> usize {
+        self.a.num_active_iterators() + self.b.num_active_iterators()
     }
 }

--- a/mini-lsm-starter/src/lsm_iterator.rs
+++ b/mini-lsm-starter/src/lsm_iterator.rs
@@ -15,23 +15,51 @@
 #![allow(unused_variables)] // TODO(you): remove this lint after implementing this mod
 #![allow(dead_code)] // TODO(you): remove this lint after implementing this mod
 
+use std::ops::Bound;
+
 use anyhow::Result;
+use bytes::Bytes;
 
 use crate::{
-    iterators::{StorageIterator, merge_iterator::MergeIterator},
+    iterators::{
+        StorageIterator, merge_iterator::MergeIterator, two_merge_iterator::TwoMergeIterator,
+    },
     mem_table::MemTableIterator,
+    table::SsTableIterator,
 };
 
 /// Represents the internal type for an LSM iterator. This type will be changed across the course for multiple times.
-type LsmIteratorInner = MergeIterator<MemTableIterator>;
+type LsmIteratorInner =
+    TwoMergeIterator<MergeIterator<MemTableIterator>, MergeIterator<SsTableIterator>>;
 
 pub struct LsmIterator {
     inner: LsmIteratorInner,
+    end_bound: Bound<Bytes>,
 }
 
 impl LsmIterator {
-    pub(crate) fn new(iter: LsmIteratorInner) -> Result<Self> {
-        Ok(Self { inner: iter })
+    pub(crate) fn new(iter: LsmIteratorInner, end_bound: Bound<Bytes>) -> Result<Self> {
+        let mut this = Self {
+            inner: iter,
+            end_bound,
+        };
+        this.skip_tombstones()?;
+        Ok(this)
+    }
+
+    fn skip_tombstones(&mut self) -> Result<()> {
+        while self.inner.is_valid() && self.within_end_bound() && self.inner.value().is_empty() {
+            self.inner.next()?;
+        }
+        Ok(())
+    }
+
+    fn within_end_bound(&self) -> bool {
+        match &self.end_bound {
+            Bound::Included(end) => self.inner.key().raw_ref() <= end.as_ref(),
+            Bound::Excluded(end) => self.inner.key().raw_ref() < end.as_ref(),
+            Bound::Unbounded => true,
+        }
     }
 }
 
@@ -39,19 +67,24 @@ impl StorageIterator for LsmIterator {
     type KeyType<'a> = &'a [u8];
 
     fn is_valid(&self) -> bool {
-        unimplemented!()
+        self.inner.is_valid() && self.within_end_bound()
     }
 
     fn key(&self) -> &[u8] {
-        unimplemented!()
+        self.inner.key().raw_ref()
     }
 
     fn value(&self) -> &[u8] {
-        unimplemented!()
+        self.inner.value()
     }
 
     fn next(&mut self) -> Result<()> {
-        unimplemented!()
+        self.inner.next()?;
+        self.skip_tombstones()
+    }
+
+    fn num_active_iterators(&self) -> usize {
+        self.inner.num_active_iterators()
     }
 }
 
@@ -79,18 +112,34 @@ impl<I: StorageIterator> StorageIterator for FusedIterator<I> {
         Self: 'a;
 
     fn is_valid(&self) -> bool {
-        unimplemented!()
+        !self.has_errored && self.iter.is_valid()
     }
 
     fn key(&self) -> Self::KeyType<'_> {
-        unimplemented!()
+        assert!(self.is_valid());
+        self.iter.key()
     }
 
     fn value(&self) -> &[u8] {
-        unimplemented!()
+        assert!(self.is_valid());
+        self.iter.value()
     }
 
     fn next(&mut self) -> Result<()> {
-        unimplemented!()
+        if self.has_errored {
+            anyhow::bail!("iterator has previously errored");
+        }
+        if !self.iter.is_valid() {
+            return Ok(());
+        }
+        if let Err(error) = self.iter.next() {
+            self.has_errored = true;
+            return Err(error);
+        }
+        Ok(())
+    }
+
+    fn num_active_iterators(&self) -> usize {
+        self.iter.num_active_iterators()
     }
 }

--- a/mini-lsm-starter/src/lsm_storage.rs
+++ b/mini-lsm-starter/src/lsm_storage.rs
@@ -16,6 +16,7 @@
 #![allow(dead_code)] // TODO(you): remove this lint after implementing this mod
 
 use std::collections::HashMap;
+use std::fs::File;
 use std::ops::Bound;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -30,11 +31,14 @@ use crate::compact::{
     CompactionController, CompactionOptions, LeveledCompactionController, LeveledCompactionOptions,
     SimpleLeveledCompactionController, SimpleLeveledCompactionOptions, TieredCompactionController,
 };
+use crate::iterators::StorageIterator;
+use crate::iterators::merge_iterator::MergeIterator;
+use crate::iterators::two_merge_iterator::TwoMergeIterator;
 use crate::lsm_iterator::{FusedIterator, LsmIterator};
 use crate::manifest::Manifest;
-use crate::mem_table::MemTable;
+use crate::mem_table::{MemTable, map_bound};
 use crate::mvcc::LsmMvccInner;
-use crate::table::SsTable;
+use crate::table::{SsTable, SsTableIterator};
 
 pub type BlockCache = moka::sync::Cache<(usize, usize), Arc<Block>>;
 
@@ -169,7 +173,19 @@ impl Drop for MiniLsm {
 
 impl MiniLsm {
     pub fn close(&self) -> Result<()> {
-        unimplemented!()
+        self.compaction_notifier.send(()).ok();
+        self.flush_notifier.send(()).ok();
+        if let Some(handle) = self.compaction_thread.lock().take() {
+            handle
+                .join()
+                .map_err(|_| anyhow::anyhow!("compaction thread panicked"))?;
+        }
+        if let Some(handle) = self.flush_thread.lock().take() {
+            handle
+                .join()
+                .map_err(|_| anyhow::anyhow!("flush thread panicked"))?;
+        }
+        Ok(())
     }
 
     /// Start the storage engine by either loading an existing directory or creating a new one if the directory does
@@ -256,6 +272,7 @@ impl LsmStorageInner {
     /// not exist.
     pub(crate) fn open(path: impl AsRef<Path>, options: LsmStorageOptions) -> Result<Self> {
         let path = path.as_ref();
+        std::fs::create_dir_all(path)?;
         let state = LsmStorageState::create(&options);
 
         let compaction_controller = match &options.compaction_options {
@@ -297,8 +314,46 @@ impl LsmStorageInner {
     }
 
     /// Get a key from the storage. In day 7, this can be further optimized by using a bloom filter.
-    pub fn get(&self, _key: &[u8]) -> Result<Option<Bytes>> {
-        unimplemented!()
+    pub fn get(&self, key: &[u8]) -> Result<Option<Bytes>> {
+        let snapshot = {
+            let guard = self.state.read();
+            guard.clone()
+        };
+        if let Some(value) = snapshot.memtable.get(key) {
+            return Ok((!value.is_empty()).then_some(value));
+        }
+        for memtable in &snapshot.imm_memtables {
+            if let Some(value) = memtable.get(key) {
+                return Ok((!value.is_empty()).then_some(value));
+            }
+        }
+
+        let key_hash = farmhash::fingerprint32(key);
+        let mut sst_iters = Vec::new();
+        for sst_id in &snapshot.l0_sstables {
+            let sst = snapshot.sstables.get(sst_id).unwrap().clone();
+            if key < sst.first_key().raw_ref() || key > sst.last_key().raw_ref() {
+                continue;
+            }
+            if sst
+                .bloom
+                .as_ref()
+                .is_some_and(|bloom| !bloom.may_contain(key_hash))
+            {
+                continue;
+            }
+            sst_iters.push(Box::new(SsTableIterator::create_and_seek_to_key(
+                sst,
+                crate::key::KeySlice::from_slice(key),
+            )?));
+        }
+        let sst_iter = MergeIterator::create(sst_iters);
+        if sst_iter.is_valid() && sst_iter.key().raw_ref() == key {
+            return Ok(
+                (!sst_iter.value().is_empty()).then(|| Bytes::copy_from_slice(sst_iter.value()))
+            );
+        }
+        Ok(None)
     }
 
     /// Write a batch of data into the storage. Implement in week 2 day 7.
@@ -307,13 +362,25 @@ impl LsmStorageInner {
     }
 
     /// Put a key-value pair into the storage by writing into the current memtable.
-    pub fn put(&self, _key: &[u8], _value: &[u8]) -> Result<()> {
-        unimplemented!()
+    pub fn put(&self, key: &[u8], value: &[u8]) -> Result<()> {
+        let size = {
+            let state = self.state.read();
+            state.memtable.put(key, value)?;
+            state.memtable.approximate_size()
+        };
+
+        if size >= self.options.target_sst_size {
+            let state_lock = self.state_lock.lock();
+            if self.state.read().memtable.approximate_size() >= self.options.target_sst_size {
+                self.force_freeze_memtable(&state_lock)?;
+            }
+        }
+        Ok(())
     }
 
     /// Remove a key from the storage by writing an empty value.
-    pub fn delete(&self, _key: &[u8]) -> Result<()> {
-        unimplemented!()
+    pub fn delete(&self, key: &[u8]) -> Result<()> {
+        self.put(key, &[])
     }
 
     pub(crate) fn path_of_sst_static(path: impl AsRef<Path>, id: usize) -> PathBuf {
@@ -333,17 +400,54 @@ impl LsmStorageInner {
     }
 
     pub(super) fn sync_dir(&self) -> Result<()> {
-        unimplemented!()
+        File::open(&self.path)?.sync_all()?;
+        Ok(())
     }
 
     /// Force freeze the current memtable to an immutable memtable
     pub fn force_freeze_memtable(&self, _state_lock_observer: &MutexGuard<'_, ()>) -> Result<()> {
-        unimplemented!()
+        let new_memtable = Arc::new(MemTable::create(self.next_sst_id()));
+        let mut state_guard = self.state.write();
+        let mut snapshot = state_guard.as_ref().clone();
+        let old_memtable = std::mem::replace(&mut snapshot.memtable, new_memtable);
+        snapshot.imm_memtables.insert(0, old_memtable);
+        *state_guard = Arc::new(snapshot);
+        Ok(())
     }
 
     /// Force flush the earliest-created immutable memtable to disk
     pub fn force_flush_next_imm_memtable(&self) -> Result<()> {
-        unimplemented!()
+        let _state_lock = self.state_lock.lock();
+        let memtable = {
+            let state = self.state.read();
+            let Some(memtable) = state.imm_memtables.last() else {
+                return Ok(());
+            };
+            memtable.clone()
+        };
+
+        let sst_id = memtable.id();
+        let mut builder = crate::table::SsTableBuilder::new(self.options.block_size);
+        memtable.flush(&mut builder)?;
+        let sst = Arc::new(builder.build(
+            sst_id,
+            Some(self.block_cache.clone()),
+            self.path_of_sst(sst_id),
+        )?);
+        self.sync_dir()?;
+
+        let mut state_guard = self.state.write();
+        let mut snapshot = state_guard.as_ref().clone();
+        let removed = snapshot.imm_memtables.pop().unwrap();
+        assert_eq!(
+            removed.id(),
+            sst_id,
+            "installed SST must match flushed memtable"
+        );
+        snapshot.sstables.insert(sst_id, sst);
+        snapshot.l0_sstables.insert(0, sst_id);
+        *state_guard = Arc::new(snapshot);
+        Ok(())
     }
 
     pub fn new_txn(&self) -> Result<()> {
@@ -354,9 +458,60 @@ impl LsmStorageInner {
     /// Create an iterator over a range of keys.
     pub fn scan(
         &self,
-        _lower: Bound<&[u8]>,
-        _upper: Bound<&[u8]>,
+        lower: Bound<&[u8]>,
+        upper: Bound<&[u8]>,
     ) -> Result<FusedIterator<LsmIterator>> {
-        unimplemented!()
+        let snapshot = {
+            let guard = self.state.read();
+            guard.clone()
+        };
+        let mut memtable_iters = Vec::with_capacity(1 + snapshot.imm_memtables.len());
+        memtable_iters.push(Box::new(snapshot.memtable.scan(lower, upper)));
+        for memtable in &snapshot.imm_memtables {
+            memtable_iters.push(Box::new(memtable.scan(lower, upper)));
+        }
+        let memtable_iter = MergeIterator::create(memtable_iters);
+
+        let mut sst_iters: Vec<Box<SsTableIterator>> = Vec::new();
+        for sst_id in &snapshot.l0_sstables {
+            let sst = snapshot.sstables.get(sst_id).unwrap().clone();
+            if !range_overlaps_sst(lower, upper, &sst) {
+                continue;
+            }
+            let mut iter = match lower {
+                Bound::Included(key) | Bound::Excluded(key) => {
+                    SsTableIterator::create_and_seek_to_key(
+                        sst,
+                        crate::key::KeySlice::from_slice(key),
+                    )?
+                }
+                Bound::Unbounded => SsTableIterator::create_and_seek_to_first(sst)?,
+            };
+            if matches!(
+                lower,
+                Bound::Excluded(key) if iter.is_valid() && iter.key().raw_ref() == key
+            ) {
+                iter.next()?;
+            }
+            sst_iters.push(Box::new(iter));
+        }
+        let sst_iter = MergeIterator::create(sst_iters);
+        let inner = TwoMergeIterator::create(memtable_iter, sst_iter)?;
+        let lsm_iter = LsmIterator::new(inner, map_bound(upper))?;
+        Ok(FusedIterator::new(lsm_iter))
     }
+}
+
+fn range_overlaps_sst(lower: Bound<&[u8]>, upper: Bound<&[u8]>, sst: &SsTable) -> bool {
+    let after_lower = match lower {
+        Bound::Included(key) => sst.last_key().raw_ref() >= key,
+        Bound::Excluded(key) => sst.last_key().raw_ref() > key,
+        Bound::Unbounded => true,
+    };
+    let before_upper = match upper {
+        Bound::Included(key) => sst.first_key().raw_ref() <= key,
+        Bound::Excluded(key) => sst.first_key().raw_ref() < key,
+        Bound::Unbounded => true,
+    };
+    after_lower && before_upper
 }

--- a/mini-lsm-starter/src/mem_table.rs
+++ b/mini-lsm-starter/src/mem_table.rs
@@ -52,8 +52,13 @@ pub(crate) fn map_bound(bound: Bound<&[u8]>) -> Bound<Bytes> {
 
 impl MemTable {
     /// Create a new mem-table.
-    pub fn create(_id: usize) -> Self {
-        unimplemented!()
+    pub fn create(id: usize) -> Self {
+        Self {
+            map: Arc::new(SkipMap::new()),
+            wal: None,
+            id,
+            approximate_size: Arc::new(AtomicUsize::new(0)),
+        }
     }
 
     /// Create a new mem-table with WAL
@@ -86,8 +91,8 @@ impl MemTable {
     }
 
     /// Get a value by key.
-    pub fn get(&self, _key: &[u8]) -> Option<Bytes> {
-        unimplemented!()
+    pub fn get(&self, key: &[u8]) -> Option<Bytes> {
+        self.map.get(key).map(|entry| entry.value().clone())
     }
 
     /// Put a key-value pair into the mem-table.
@@ -95,8 +100,14 @@ impl MemTable {
     /// In week 1, day 1, simply put the key-value pair into the skipmap.
     /// In week 2, day 6, also flush the data to WAL.
     /// In week 3, day 5, route this through the batch WAL implementation.
-    pub fn put(&self, _key: &[u8], _value: &[u8]) -> Result<()> {
-        unimplemented!()
+    pub fn put(&self, key: &[u8], value: &[u8]) -> Result<()> {
+        self.map
+            .insert(Bytes::copy_from_slice(key), Bytes::copy_from_slice(value));
+        self.approximate_size.fetch_add(
+            key.len() + value.len(),
+            std::sync::atomic::Ordering::Relaxed,
+        );
+        Ok(())
     }
 
     /// Implement this in week 3, day 5.
@@ -112,13 +123,25 @@ impl MemTable {
     }
 
     /// Get an iterator over a range of keys.
-    pub fn scan(&self, _lower: Bound<&[u8]>, _upper: Bound<&[u8]>) -> MemTableIterator {
-        unimplemented!()
+    pub fn scan(&self, lower: Bound<&[u8]>, upper: Bound<&[u8]>) -> MemTableIterator {
+        let lower = map_bound(lower);
+        let upper = map_bound(upper);
+        let mut iter = MemTableIteratorBuilder {
+            map: self.map.clone(),
+            iter_builder: move |map| map.range((lower, upper)),
+            item: (Bytes::new(), Bytes::new()),
+        }
+        .build();
+        iter.next().expect("memtable iteration is infallible");
+        iter
     }
 
     /// Flush the mem-table to SSTable. Implement in week 1 day 6.
-    pub fn flush(&self, _builder: &mut SsTableBuilder) -> Result<()> {
-        unimplemented!()
+    pub fn flush(&self, builder: &mut SsTableBuilder) -> Result<()> {
+        for entry in self.map.iter() {
+            builder.add(KeySlice::from_slice(entry.key()), entry.value());
+        }
+        Ok(())
     }
 
     pub fn id(&self) -> usize {
@@ -159,18 +182,24 @@ impl StorageIterator for MemTableIterator {
     type KeyType<'a> = KeySlice<'a>;
 
     fn value(&self) -> &[u8] {
-        unimplemented!()
+        &self.borrow_item().1
     }
 
     fn key(&self) -> KeySlice<'_> {
-        unimplemented!()
+        KeySlice::from_slice(&self.borrow_item().0)
     }
 
     fn is_valid(&self) -> bool {
-        unimplemented!()
+        !self.borrow_item().0.is_empty()
     }
 
     fn next(&mut self) -> Result<()> {
-        unimplemented!()
+        let item = self.with_iter_mut(|iter| {
+            iter.next()
+                .map(|entry| (entry.key().clone(), entry.value().clone()))
+                .unwrap_or_default()
+        });
+        self.with_item_mut(|current| *current = item);
+        Ok(())
     }
 }

--- a/mini-lsm-starter/src/table.rs
+++ b/mini-lsm-starter/src/table.rs
@@ -23,9 +23,9 @@ use std::fs::File;
 use std::path::Path;
 use std::sync::Arc;
 
-use anyhow::Result;
+use anyhow::{Result, ensure};
 pub use builder::SsTableBuilder;
-use bytes::Buf;
+use bytes::{Buf, BufMut};
 pub use iterator::SsTableIterator;
 
 use crate::block::Block;
@@ -48,17 +48,57 @@ impl BlockMeta {
     /// Encode block meta to a buffer.
     /// You may add extra fields to the buffer,
     /// in order to help keep track of `first_key` when decoding from the same buffer in the future.
-    pub fn encode_block_meta(
-        block_meta: &[BlockMeta],
-        #[allow(clippy::ptr_arg)] // remove this allow after you finish
-        buf: &mut Vec<u8>,
-    ) {
-        unimplemented!()
+    pub fn encode_block_meta(block_meta: &[BlockMeta], buf: &mut Vec<u8>) {
+        assert!(block_meta.len() <= u32::MAX as usize);
+        buf.put_u32(block_meta.len() as u32);
+        for meta in block_meta {
+            assert!(meta.offset <= u32::MAX as usize);
+            assert!(meta.first_key.len() <= u16::MAX as usize);
+            assert!(meta.last_key.len() <= u16::MAX as usize);
+            buf.put_u32(meta.offset as u32);
+            buf.put_u16(meta.first_key.len() as u16);
+            buf.extend_from_slice(meta.first_key.raw_ref());
+            buf.put_u16(meta.last_key.len() as u16);
+            buf.extend_from_slice(meta.last_key.raw_ref());
+        }
     }
 
     /// Decode block meta from a buffer.
     pub fn decode_block_meta(buf: impl Buf) -> Vec<BlockMeta> {
-        unimplemented!()
+        Self::decode_block_meta_checked(buf).expect("invalid block metadata")
+    }
+
+    fn decode_block_meta_checked(mut buf: impl Buf) -> Result<Vec<BlockMeta>> {
+        ensure!(buf.remaining() >= 4, "block metadata count is missing");
+        let count = buf.get_u32() as usize;
+        ensure!(
+            count <= buf.remaining() / 8,
+            "block metadata count exceeds the available bytes"
+        );
+        let mut block_meta = Vec::with_capacity(count);
+        for _ in 0..count {
+            ensure!(buf.remaining() >= 6, "truncated block metadata record");
+            let offset = buf.get_u32() as usize;
+            let first_key_len = buf.get_u16() as usize;
+            ensure!(
+                buf.remaining() >= first_key_len + 2,
+                "truncated first key in block metadata"
+            );
+            let first_key = KeyBytes::from_bytes(buf.copy_to_bytes(first_key_len));
+            let last_key_len = buf.get_u16() as usize;
+            ensure!(
+                buf.remaining() >= last_key_len,
+                "truncated last key in block metadata"
+            );
+            let last_key = KeyBytes::from_bytes(buf.copy_to_bytes(last_key_len));
+            block_meta.push(BlockMeta {
+                offset,
+                first_key,
+                last_key,
+            });
+        }
+        ensure!(buf.remaining() == 0, "trailing block metadata bytes");
+        Ok(block_meta)
     }
 }
 
@@ -122,7 +162,55 @@ impl SsTable {
 
     /// Open SSTable from a file.
     pub fn open(id: usize, block_cache: Option<Arc<BlockCache>>, file: FileObject) -> Result<Self> {
-        unimplemented!()
+        let file_size = usize::try_from(file.size())?;
+        ensure!(file_size >= 8, "SST is too short for its trailer");
+
+        let bloom_offset_bytes = file.read((file_size - 4) as u64, 4)?;
+        let bloom_offset = u32::from_be_bytes(bloom_offset_bytes.try_into().unwrap()) as usize;
+        ensure!(
+            bloom_offset >= 4 && bloom_offset < file_size - 4,
+            "invalid Bloom section offset"
+        );
+
+        let meta_offset_bytes = file.read((bloom_offset - 4) as u64, 4)?;
+        let block_meta_offset = u32::from_be_bytes(meta_offset_bytes.try_into().unwrap()) as usize;
+        ensure!(
+            block_meta_offset < bloom_offset - 4,
+            "invalid metadata section ordering"
+        );
+
+        let meta_len = bloom_offset - 4 - block_meta_offset;
+        let meta_bytes = file.read(block_meta_offset as u64, meta_len as u64)?;
+        let block_meta = BlockMeta::decode_block_meta_checked(meta_bytes.as_slice())?;
+        ensure!(!block_meta.is_empty(), "SST contains no block metadata");
+        ensure!(
+            block_meta[0].offset == 0
+                && block_meta
+                    .windows(2)
+                    .all(|pair| pair[0].offset < pair[1].offset)
+                && block_meta
+                    .iter()
+                    .all(|meta| meta.offset < block_meta_offset),
+            "invalid data block offsets"
+        );
+
+        let bloom_bytes = file.read(bloom_offset as u64, (file_size - 4 - bloom_offset) as u64)?;
+        ensure!(!bloom_bytes.is_empty(), "Bloom section is empty");
+        let bloom = Bloom::decode(&bloom_bytes)?;
+        let first_key = block_meta.first().unwrap().first_key.clone();
+        let last_key = block_meta.last().unwrap().last_key.clone();
+
+        Ok(Self {
+            file,
+            block_meta,
+            block_meta_offset,
+            id,
+            block_cache,
+            first_key,
+            last_key,
+            bloom: Some(bloom),
+            max_ts: 0,
+        })
     }
 
     /// Create a mock SST with only first key + last key metadata
@@ -147,19 +235,37 @@ impl SsTable {
 
     /// Read a block from the disk.
     pub fn read_block(&self, block_idx: usize) -> Result<Arc<Block>> {
-        unimplemented!()
+        ensure!(
+            block_idx < self.block_meta.len(),
+            "block index out of bounds"
+        );
+        let offset = self.block_meta[block_idx].offset;
+        let end = if block_idx + 1 < self.block_meta.len() {
+            self.block_meta[block_idx + 1].offset
+        } else {
+            self.block_meta_offset
+        };
+        ensure!(offset < end, "invalid block byte range");
+        let encoded = self.file.read(offset as u64, (end - offset) as u64)?;
+        Ok(Arc::new(Block::decode(&encoded)))
     }
 
     /// Read a block from disk, with block cache. (Day 4)
     pub fn read_block_cached(&self, block_idx: usize) -> Result<Arc<Block>> {
-        unimplemented!()
+        let Some(cache) = &self.block_cache else {
+            return self.read_block(block_idx);
+        };
+        cache
+            .try_get_with((self.id, block_idx), || self.read_block(block_idx))
+            .map_err(|error| anyhow::anyhow!(error.to_string()))
     }
 
     /// Find the block that may contain `key`.
     /// Note: You may want to make use of the `first_key` stored in `BlockMeta`.
     /// You may also assume the key-value pairs stored in each consecutive block are sorted.
     pub fn find_block_idx(&self, key: KeySlice) -> usize {
-        unimplemented!()
+        self.block_meta
+            .partition_point(|meta| meta.last_key.as_key_slice() < key)
     }
 
     /// Get number of data blocks.

--- a/mini-lsm-starter/src/table/bloom.rs
+++ b/mini-lsm-starter/src/table/bloom.rs
@@ -92,7 +92,14 @@ impl Bloom {
         let mut filter = BytesMut::with_capacity(nbytes);
         filter.resize(nbytes, 0);
 
-        // TODO: build the bloom filter
+        for hash in keys {
+            let mut hash = *hash;
+            let delta = hash.rotate_left(15);
+            for _ in 0..k {
+                filter.set_bit(hash as usize % nbits, true);
+                hash = hash.wrapping_add(delta);
+            }
+        }
 
         Self {
             filter: filter.freeze(),
@@ -107,10 +114,14 @@ impl Bloom {
             true
         } else {
             let nbits = self.filter.bit_len();
-            let delta = h.rotate_left(15);
-
-            // TODO: probe the bloom filter
-
+            let mut hash = h;
+            let delta = hash.rotate_left(15);
+            for _ in 0..self.k {
+                if !self.filter.get_bit(hash as usize % nbits) {
+                    return false;
+                }
+                hash = hash.wrapping_add(delta);
+            }
             true
         }
     }

--- a/mini-lsm-starter/src/table/builder.rs
+++ b/mini-lsm-starter/src/table/builder.rs
@@ -19,8 +19,9 @@ use std::path::Path;
 use std::sync::Arc;
 
 use anyhow::Result;
+use bytes::BufMut;
 
-use super::{BlockMeta, SsTable};
+use super::{BlockMeta, FileObject, SsTable, bloom::Bloom};
 use crate::{block::BlockBuilder, key::KeySlice, lsm_storage::BlockCache};
 
 /// Builds an SSTable from key-value pairs.
@@ -31,12 +32,21 @@ pub struct SsTableBuilder {
     data: Vec<u8>,
     pub(crate) meta: Vec<BlockMeta>,
     block_size: usize,
+    key_hashes: Vec<u32>,
 }
 
 impl SsTableBuilder {
     /// Create a builder based on target block size.
     pub fn new(block_size: usize) -> Self {
-        unimplemented!()
+        Self {
+            builder: BlockBuilder::new(block_size),
+            first_key: Vec::new(),
+            last_key: Vec::new(),
+            data: Vec::new(),
+            meta: Vec::new(),
+            block_size,
+            key_hashes: Vec::new(),
+        }
     }
 
     /// Adds a key-value pair to SSTable.
@@ -44,7 +54,23 @@ impl SsTableBuilder {
     /// Note: You should split a new block when the current block is full.(`std::mem::replace` may
     /// be helpful here)
     pub fn add(&mut self, key: KeySlice, value: &[u8]) {
-        unimplemented!()
+        if !self.builder.add(key, value) {
+            assert!(
+                !self.builder.is_empty(),
+                "key-value pair is not representable in a block"
+            );
+            self.finish_block();
+            assert!(
+                self.builder.add(key, value),
+                "key-value pair is not representable in a block"
+            );
+        }
+        if self.first_key.is_empty() {
+            self.first_key.extend_from_slice(key.raw_ref());
+        }
+        self.last_key.clear();
+        self.last_key.extend_from_slice(key.raw_ref());
+        self.key_hashes.push(farmhash::fingerprint32(key.raw_ref()));
     }
 
     /// Get the estimated size of the SSTable.
@@ -52,21 +78,60 @@ impl SsTableBuilder {
     /// Since the data blocks contain much more data than meta blocks, just return the size of data
     /// blocks here.
     pub fn estimated_size(&self) -> usize {
-        unimplemented!()
+        self.data.len()
     }
 
     /// Builds the SSTable and writes it to the given path. Use the `FileObject` structure to manipulate the disk objects.
     pub fn build(
-        #[allow(unused_mut)] mut self,
+        mut self,
         id: usize,
         block_cache: Option<Arc<BlockCache>>,
         path: impl AsRef<Path>,
     ) -> Result<SsTable> {
-        unimplemented!()
+        assert!(!self.builder.is_empty(), "cannot build an empty SST");
+        self.finish_block();
+
+        let block_meta_offset = self.data.len();
+        BlockMeta::encode_block_meta(&self.meta, &mut self.data);
+        self.data.put_u32(block_meta_offset as u32);
+
+        let bits_per_key = Bloom::bloom_bits_per_key(self.key_hashes.len(), 0.01);
+        let bloom = Bloom::build_from_key_hashes(&self.key_hashes, bits_per_key);
+        let bloom_offset = self.data.len();
+        bloom.encode(&mut self.data);
+        self.data.put_u32(bloom_offset as u32);
+
+        let first_key = self.meta.first().unwrap().first_key.clone();
+        let last_key = self.meta.last().unwrap().last_key.clone();
+        let file = FileObject::create(path.as_ref(), self.data)?;
+        Ok(SsTable {
+            file,
+            block_meta: self.meta,
+            block_meta_offset,
+            id,
+            block_cache,
+            first_key,
+            last_key,
+            bloom: Some(bloom),
+            max_ts: 0,
+        })
     }
 
     #[cfg(test)]
     pub(crate) fn build_for_test(self, path: impl AsRef<Path>) -> Result<SsTable> {
         self.build(0, None, path)
+    }
+
+    fn finish_block(&mut self) {
+        let builder = std::mem::replace(&mut self.builder, BlockBuilder::new(self.block_size));
+        let encoded = builder.build().encode();
+        self.meta.push(BlockMeta {
+            offset: self.data.len(),
+            first_key: crate::key::KeyBytes::from_bytes(self.first_key.clone().into()),
+            last_key: crate::key::KeyBytes::from_bytes(self.last_key.clone().into()),
+        });
+        self.data.extend_from_slice(&encoded);
+        self.first_key.clear();
+        self.last_key.clear();
     }
 }

--- a/mini-lsm-starter/src/table/iterator.rs
+++ b/mini-lsm-starter/src/table/iterator.rs
@@ -25,31 +25,61 @@ use crate::{block::BlockIterator, iterators::StorageIterator, key::KeySlice};
 /// An iterator over the contents of an SSTable.
 pub struct SsTableIterator {
     table: Arc<SsTable>,
-    blk_iter: BlockIterator,
+    blk_iter: Option<BlockIterator>,
     blk_idx: usize,
 }
 
 impl SsTableIterator {
     /// Create a new iterator and seek to the first key-value pair in the first data block.
     pub fn create_and_seek_to_first(table: Arc<SsTable>) -> Result<Self> {
-        unimplemented!()
+        let mut iter = Self {
+            table,
+            blk_iter: None,
+            blk_idx: 0,
+        };
+        iter.seek_to_first()?;
+        Ok(iter)
     }
 
     /// Seek to the first key-value pair in the first data block.
     pub fn seek_to_first(&mut self) -> Result<()> {
-        unimplemented!()
+        self.blk_idx = 0;
+        if self.table.num_of_blocks() == 0 {
+            self.blk_iter = None;
+            return Ok(());
+        }
+        let block = self.table.read_block_cached(0)?;
+        self.blk_iter = Some(BlockIterator::create_and_seek_to_first(block));
+        Ok(())
     }
 
     /// Create a new iterator and seek to the first key-value pair which >= `key`.
     pub fn create_and_seek_to_key(table: Arc<SsTable>, key: KeySlice) -> Result<Self> {
-        unimplemented!()
+        let mut iter = Self {
+            table,
+            blk_iter: None,
+            blk_idx: 0,
+        };
+        iter.seek_to_key(key)?;
+        Ok(iter)
     }
 
     /// Seek to the first key-value pair which >= `key`.
     /// Note: You probably want to review the handout for detailed explanation when implementing
     /// this function.
     pub fn seek_to_key(&mut self, key: KeySlice) -> Result<()> {
-        unimplemented!()
+        self.blk_idx = self.table.find_block_idx(key);
+        if self.blk_idx >= self.table.num_of_blocks() {
+            self.blk_iter = None;
+            return Ok(());
+        }
+        let block = self.table.read_block_cached(self.blk_idx)?;
+        let block_iter = BlockIterator::create_and_seek_to_key(block, key);
+        self.blk_iter = Some(block_iter);
+        if !self.is_valid() {
+            self.move_to_next_block()?;
+        }
+        Ok(())
     }
 }
 
@@ -58,22 +88,42 @@ impl StorageIterator for SsTableIterator {
 
     /// Return the `key` that's held by the underlying block iterator.
     fn key(&self) -> KeySlice<'_> {
-        unimplemented!()
+        self.blk_iter.as_ref().unwrap().key()
     }
 
     /// Return the `value` that's held by the underlying block iterator.
     fn value(&self) -> &[u8] {
-        unimplemented!()
+        self.blk_iter.as_ref().unwrap().value()
     }
 
     /// Return whether the current block iterator is valid or not.
     fn is_valid(&self) -> bool {
-        unimplemented!()
+        self.blk_iter.as_ref().is_some_and(BlockIterator::is_valid)
     }
 
     /// Move to the next `key` in the block.
     /// Note: You may want to check if the current block iterator is valid after the move.
     fn next(&mut self) -> Result<()> {
-        unimplemented!()
+        let Some(block_iter) = &mut self.blk_iter else {
+            return Ok(());
+        };
+        block_iter.next();
+        if !block_iter.is_valid() {
+            self.move_to_next_block()?;
+        }
+        Ok(())
+    }
+}
+
+impl SsTableIterator {
+    fn move_to_next_block(&mut self) -> Result<()> {
+        self.blk_idx += 1;
+        if self.blk_idx >= self.table.num_of_blocks() {
+            self.blk_iter = None;
+            return Ok(());
+        }
+        let block = self.table.read_block_cached(self.blk_idx)?;
+        self.blk_iter = Some(BlockIterator::create_and_seek_to_first(block));
+        Ok(())
     }
 }

--- a/mini-lsm-starter/src/tests.rs
+++ b/mini-lsm-starter/src/tests.rs
@@ -1,16 +1,11 @@
-// Copyright (c) 2022-2026 Alex Chi Z
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
 //! DO NOT MODIFY -- Mini-LSM tests modules
 //! This file will be automatically rewritten by the copy-test command.
+
+mod harness;
+mod week1_day1;
+mod week1_day2;
+mod week1_day3;
+mod week1_day4;
+mod week1_day5;
+mod week1_day6;
+mod week1_day7;

--- a/mini-lsm-starter/src/tests/harness.rs
+++ b/mini-lsm-starter/src/tests/harness.rs
@@ -1,0 +1,462 @@
+#![allow(dead_code)] // REMOVE THIS LINE once all modules are complete
+
+// Copyright (c) 2022-2025 Alex Chi Z
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::{
+    collections::BTreeMap, ops::Bound, os::unix::fs::MetadataExt, path::Path, sync::Arc,
+    time::Duration,
+};
+
+use anyhow::{Result, bail};
+use bytes::Bytes;
+
+use crate::{
+    compact::{
+        CompactionOptions, LeveledCompactionOptions, SimpleLeveledCompactionOptions,
+        TieredCompactionOptions,
+    },
+    iterators::{StorageIterator, merge_iterator::MergeIterator},
+    key::{KeySlice, TS_ENABLED},
+    lsm_storage::{BlockCache, LsmStorageInner, LsmStorageState, MiniLsm},
+    table::{SsTable, SsTableBuilder, SsTableIterator},
+};
+
+#[derive(Clone)]
+pub struct MockIterator {
+    pub data: Vec<(Bytes, Bytes)>,
+    pub error_when: Option<usize>,
+    pub index: usize,
+}
+
+impl MockIterator {
+    pub fn new(data: Vec<(Bytes, Bytes)>) -> Self {
+        Self {
+            data,
+            index: 0,
+            error_when: None,
+        }
+    }
+
+    pub fn new_with_error(data: Vec<(Bytes, Bytes)>, error_when: usize) -> Self {
+        Self {
+            data,
+            index: 0,
+            error_when: Some(error_when),
+        }
+    }
+}
+
+impl StorageIterator for MockIterator {
+    type KeyType<'a> = KeySlice<'a>;
+
+    fn next(&mut self) -> Result<()> {
+        if self.index < self.data.len() {
+            self.index += 1;
+        }
+        if let Some(error_when) = self.error_when
+            && self.index == error_when
+        {
+            bail!("fake error!");
+        }
+        Ok(())
+    }
+
+    fn key(&self) -> KeySlice<'_> {
+        if let Some(error_when) = self.error_when
+            && self.index >= error_when
+        {
+            panic!("invalid access after next returns an error!");
+        }
+        KeySlice::for_testing_from_slice_no_ts(self.data[self.index].0.as_ref())
+    }
+
+    fn value(&self) -> &[u8] {
+        if let Some(error_when) = self.error_when
+            && self.index >= error_when
+        {
+            panic!("invalid access after next returns an error!");
+        }
+        self.data[self.index].1.as_ref()
+    }
+
+    fn is_valid(&self) -> bool {
+        if let Some(error_when) = self.error_when
+            && self.index >= error_when
+        {
+            panic!("invalid access after next returns an error!");
+        }
+        self.index < self.data.len()
+    }
+}
+
+pub fn as_bytes(x: &[u8]) -> Bytes {
+    Bytes::copy_from_slice(x)
+}
+
+pub fn check_iter_result_by_key<I>(iter: &mut I, expected: Vec<(Bytes, Bytes)>)
+where
+    I: for<'a> StorageIterator<KeyType<'a> = KeySlice<'a>>,
+{
+    for (k, v) in expected {
+        assert!(iter.is_valid());
+        assert_eq!(
+            k,
+            iter.key().for_testing_key_ref(),
+            "expected key: {:?}, actual key: {:?}",
+            k,
+            as_bytes(iter.key().for_testing_key_ref()),
+        );
+        assert_eq!(
+            v,
+            iter.value(),
+            "expected value: {:?}, actual value: {:?}",
+            v,
+            as_bytes(iter.value()),
+        );
+        iter.next().unwrap();
+    }
+    assert!(
+        !iter.is_valid(),
+        "iterator should not be valid at the end of the check"
+    );
+}
+
+pub fn check_iter_result_by_key_and_ts<I>(iter: &mut I, expected: Vec<((Bytes, u64), Bytes)>)
+where
+    I: for<'a> StorageIterator<KeyType<'a> = KeySlice<'a>>,
+{
+    for ((k, ts), v) in expected {
+        assert!(iter.is_valid());
+        assert_eq!(
+            (&k[..], ts),
+            (
+                iter.key().for_testing_key_ref(),
+                iter.key().for_testing_ts()
+            ),
+            "expected key: {:?}@{}, actual key: {:?}@{}",
+            k,
+            ts,
+            as_bytes(iter.key().for_testing_key_ref()),
+            iter.key().for_testing_ts(),
+        );
+        assert_eq!(
+            v,
+            iter.value(),
+            "expected value: {:?}, actual value: {:?}",
+            v,
+            as_bytes(iter.value()),
+        );
+        iter.next().unwrap();
+    }
+    assert!(!iter.is_valid());
+}
+
+pub fn check_lsm_iter_result_by_key<I>(iter: &mut I, expected: Vec<(Bytes, Bytes)>)
+where
+    I: for<'a> StorageIterator<KeyType<'a> = &'a [u8]>,
+{
+    for (k, v) in expected {
+        assert!(iter.is_valid());
+        assert_eq!(
+            k,
+            iter.key(),
+            "expected key: {:?}, actual key: {:?}",
+            k,
+            as_bytes(iter.key()),
+        );
+        assert_eq!(
+            v,
+            iter.value(),
+            "expected value: {:?}, actual value: {:?}",
+            v,
+            as_bytes(iter.value()),
+        );
+        iter.next().unwrap();
+    }
+    assert!(!iter.is_valid());
+}
+
+pub fn expect_iter_error(mut iter: impl StorageIterator) {
+    loop {
+        match iter.next() {
+            Ok(_) if iter.is_valid() => continue,
+            Ok(_) => panic!("expect an error"),
+            Err(_) => break,
+        }
+    }
+}
+
+pub fn generate_sst(
+    id: usize,
+    path: impl AsRef<Path>,
+    data: Vec<(Bytes, Bytes)>,
+    block_cache: Option<Arc<BlockCache>>,
+) -> SsTable {
+    let mut builder = SsTableBuilder::new(128);
+    for (key, value) in data {
+        builder.add(KeySlice::for_testing_from_slice_no_ts(&key[..]), &value[..]);
+    }
+    builder.build(id, block_cache, path.as_ref()).unwrap()
+}
+
+pub fn generate_sst_with_ts(
+    id: usize,
+    path: impl AsRef<Path>,
+    data: Vec<((Bytes, u64), Bytes)>,
+    block_cache: Option<Arc<BlockCache>>,
+) -> SsTable {
+    let mut builder = SsTableBuilder::new(128);
+    for ((key, ts), value) in data {
+        builder.add(
+            KeySlice::for_testing_from_slice_with_ts(&key[..], ts),
+            &value[..],
+        );
+    }
+    builder.build(id, block_cache, path.as_ref()).unwrap()
+}
+
+pub fn sync(storage: &LsmStorageInner) {
+    storage
+        .force_freeze_memtable(&storage.state_lock.lock())
+        .unwrap();
+    storage.force_flush_next_imm_memtable().unwrap();
+}
+
+pub fn compaction_bench(storage: Arc<MiniLsm>) {
+    let mut key_map = BTreeMap::<usize, usize>::new();
+    let gen_key = |i| format!("{:010}", i); // 10B
+    let gen_value = |i| format!("{:0110}", i); // 110B
+    let mut max_key = 0;
+    let overlaps = if TS_ENABLED { 10000 } else { 20000 };
+    for iter in 0..10 {
+        let range_begin = iter * 5000;
+        for i in range_begin..(range_begin + overlaps) {
+            // 120B per key, 4MB data populated
+            let key: String = gen_key(i);
+            let version = key_map.get(&i).copied().unwrap_or_default() + 1;
+            let value = gen_value(version);
+            key_map.insert(i, version);
+            storage.put(key.as_bytes(), value.as_bytes()).unwrap();
+            max_key = max_key.max(i);
+        }
+    }
+
+    std::thread::sleep(Duration::from_secs(1)); // wait until all memtables flush
+    while {
+        let snapshot = storage.inner.state.read();
+        !snapshot.imm_memtables.is_empty()
+    } {
+        storage.inner.force_flush_next_imm_memtable().unwrap();
+    }
+
+    let mut prev_snapshot = storage.inner.state.read().clone();
+    while {
+        std::thread::sleep(Duration::from_secs(1));
+        let snapshot = storage.inner.state.read().clone();
+        let to_cont = prev_snapshot.levels != snapshot.levels
+            || prev_snapshot.l0_sstables != snapshot.l0_sstables;
+        prev_snapshot = snapshot;
+        to_cont
+    } {
+        println!("waiting for compaction to converge");
+    }
+
+    let mut expected_key_value_pairs = Vec::new();
+    for i in 0..(max_key + 40000) {
+        let key = gen_key(i);
+        let value = storage.get(key.as_bytes()).unwrap();
+        if let Some(val) = key_map.get(&i) {
+            let expected_value = gen_value(*val);
+            assert_eq!(value, Some(Bytes::from(expected_value.clone())));
+            expected_key_value_pairs.push((Bytes::from(key), Bytes::from(expected_value)));
+        } else {
+            assert!(value.is_none());
+        }
+    }
+
+    check_lsm_iter_result_by_key(
+        &mut storage.scan(Bound::Unbounded, Bound::Unbounded).unwrap(),
+        expected_key_value_pairs,
+    );
+
+    storage.dump_structure();
+
+    println!(
+        "This test case does not guarantee your compaction algorithm produces a LSM state as expected. It only does minimal checks on the size of the levels. Please use the compaction simulator to check if the compaction is correctly going on."
+    );
+}
+
+pub fn check_compaction_ratio(storage: Arc<MiniLsm>) {
+    let state = storage.inner.state.read().clone();
+    let compaction_options = storage.inner.options.compaction_options.clone();
+    let mut level_size = Vec::new();
+    let l0_sst_num = state.l0_sstables.len();
+    for (_, files) in &state.levels {
+        let size = match &compaction_options {
+            CompactionOptions::Leveled(_) => files
+                .iter()
+                .map(|x| state.sstables.get(x).as_ref().unwrap().table_size())
+                .sum::<u64>(),
+            CompactionOptions::Simple(_) | CompactionOptions::Tiered(_) => files.len() as u64,
+            _ => unreachable!(),
+        };
+        level_size.push(size);
+    }
+    let extra_iterators = if TS_ENABLED {
+        1 /* txn local iterator for OCC */
+    } else {
+        0
+    };
+    let num_iters = storage
+        .scan(Bound::Unbounded, Bound::Unbounded)
+        .unwrap()
+        .num_active_iterators();
+    let num_memtables = storage.inner.state.read().imm_memtables.len() + 1;
+    match compaction_options {
+        CompactionOptions::NoCompaction => unreachable!(),
+        CompactionOptions::Simple(SimpleLeveledCompactionOptions {
+            size_ratio_percent,
+            level0_file_num_compaction_trigger,
+            max_levels,
+        }) => {
+            assert!(l0_sst_num < level0_file_num_compaction_trigger);
+            assert!(level_size.len() <= max_levels);
+            for idx in 1..level_size.len() {
+                let prev_size = level_size[idx - 1];
+                let this_size = level_size[idx];
+                if prev_size == 0 && this_size == 0 {
+                    continue;
+                }
+                assert!(
+                    this_size as f64 / prev_size as f64 >= size_ratio_percent as f64 / 100.0,
+                    "L{}/L{}, {}/{}<{}%",
+                    state.levels[idx - 1].0,
+                    state.levels[idx].0,
+                    this_size,
+                    prev_size,
+                    size_ratio_percent
+                );
+            }
+            assert!(
+                num_iters <= l0_sst_num + num_memtables + max_levels + extra_iterators,
+                "we found {num_iters} iterators in your implementation, (l0_sst_num={l0_sst_num}, num_memtables={num_memtables}, max_levels={max_levels}) did you use concat iterators?"
+            );
+        }
+        CompactionOptions::Leveled(LeveledCompactionOptions {
+            level_size_multiplier,
+            level0_file_num_compaction_trigger,
+            max_levels,
+            ..
+        }) => {
+            assert!(l0_sst_num < level0_file_num_compaction_trigger);
+            assert!(level_size.len() <= max_levels);
+            let last_level_size = *level_size.last().unwrap();
+            let mut multiplier = 1.0;
+            for idx in (1..level_size.len()).rev() {
+                multiplier *= level_size_multiplier as f64;
+                let this_size = level_size[idx - 1];
+                assert!(
+                    // do not add hard requirement on level size multiplier considering bloom filters...
+                    this_size as f64 / last_level_size as f64 <= 1.0 / multiplier + 0.5,
+                    "L{}/L_max, {}/{}>>1.0/{}",
+                    state.levels[idx - 1].0,
+                    this_size,
+                    last_level_size,
+                    multiplier
+                );
+            }
+            assert!(
+                num_iters <= l0_sst_num + num_memtables + max_levels + extra_iterators,
+                "we found {num_iters} iterators in your implementation, (l0_sst_num={l0_sst_num}, num_memtables={num_memtables}, max_levels={max_levels}) did you use concat iterators?"
+            );
+        }
+        CompactionOptions::Tiered(TieredCompactionOptions {
+            num_tiers,
+            max_size_amplification_percent,
+            size_ratio,
+            min_merge_width,
+            ..
+        }) => {
+            let size_ratio_trigger = (100.0 + size_ratio as f64) / 100.0;
+            assert_eq!(l0_sst_num, 0);
+            assert!(level_size.len() <= num_tiers);
+            let mut sum_size = level_size[0];
+            for idx in 1..level_size.len() {
+                let this_size = level_size[idx];
+                if level_size.len() > min_merge_width {
+                    assert!(
+                        sum_size as f64 / this_size as f64 <= size_ratio_trigger,
+                        "violation of size ratio: sum(⬆️L{})/L{}, {}/{}>{}",
+                        state.levels[idx - 1].0,
+                        state.levels[idx].0,
+                        sum_size,
+                        this_size,
+                        size_ratio_trigger
+                    );
+                }
+                if idx + 1 == level_size.len() {
+                    assert!(
+                        sum_size as f64 / this_size as f64
+                            <= max_size_amplification_percent as f64 / 100.0,
+                        "violation of space amp: sum(⬆️L{})/L{}, {}/{}>{}%",
+                        state.levels[idx - 1].0,
+                        state.levels[idx].0,
+                        sum_size,
+                        this_size,
+                        max_size_amplification_percent
+                    );
+                }
+                sum_size += this_size;
+            }
+            assert!(
+                num_iters <= num_memtables + num_tiers + extra_iterators,
+                "we found {num_iters} iterators in your implementation, (num_memtables={num_memtables}, num_tiers={num_tiers}) did you use concat iterators?"
+            );
+        }
+    }
+}
+
+pub fn dump_files_in_dir(path: impl AsRef<Path>) {
+    println!("--- DIR DUMP ---");
+    for f in path.as_ref().read_dir().unwrap() {
+        let f = f.unwrap();
+        print!("{}", f.path().display());
+        println!(
+            ", size={:.3}KB",
+            f.metadata().unwrap().size() as f64 / 1024.0
+        );
+    }
+}
+
+pub fn construct_merge_iterator_over_storage(
+    state: &LsmStorageState,
+) -> MergeIterator<SsTableIterator> {
+    let mut iters = Vec::new();
+    for t in &state.l0_sstables {
+        iters.push(Box::new(
+            SsTableIterator::create_and_seek_to_first(state.sstables.get(t).cloned().unwrap())
+                .unwrap(),
+        ));
+    }
+    for (_, files) in &state.levels {
+        for f in files {
+            iters.push(Box::new(
+                SsTableIterator::create_and_seek_to_first(state.sstables.get(f).cloned().unwrap())
+                    .unwrap(),
+            ));
+        }
+    }
+    MergeIterator::create(iters)
+}

--- a/mini-lsm-starter/src/tests/week1_day1.rs
+++ b/mini-lsm-starter/src/tests/week1_day1.rs
@@ -1,0 +1,162 @@
+// Copyright (c) 2022-2025 Alex Chi Z
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use tempfile::tempdir;
+
+use crate::{
+    lsm_storage::{LsmStorageInner, LsmStorageOptions},
+    mem_table::MemTable,
+};
+
+#[test]
+fn test_task1_memtable_get() {
+    let memtable = MemTable::create(0);
+    memtable.for_testing_put_slice(b"key1", b"value1").unwrap();
+    memtable.for_testing_put_slice(b"key2", b"value2").unwrap();
+    memtable.for_testing_put_slice(b"key3", b"value3").unwrap();
+    assert_eq!(
+        &memtable.for_testing_get_slice(b"key1").unwrap()[..],
+        b"value1"
+    );
+    assert_eq!(
+        &memtable.for_testing_get_slice(b"key2").unwrap()[..],
+        b"value2"
+    );
+    assert_eq!(
+        &memtable.for_testing_get_slice(b"key3").unwrap()[..],
+        b"value3"
+    );
+}
+
+#[test]
+fn test_task1_memtable_overwrite() {
+    let memtable = MemTable::create(0);
+    memtable.for_testing_put_slice(b"key1", b"value1").unwrap();
+    memtable.for_testing_put_slice(b"key2", b"value2").unwrap();
+    memtable.for_testing_put_slice(b"key3", b"value3").unwrap();
+    memtable.for_testing_put_slice(b"key1", b"value11").unwrap();
+    memtable.for_testing_put_slice(b"key2", b"value22").unwrap();
+    memtable.for_testing_put_slice(b"key3", b"value33").unwrap();
+    assert_eq!(
+        &memtable.for_testing_get_slice(b"key1").unwrap()[..],
+        b"value11"
+    );
+    assert_eq!(
+        &memtable.for_testing_get_slice(b"key2").unwrap()[..],
+        b"value22"
+    );
+    assert_eq!(
+        &memtable.for_testing_get_slice(b"key3").unwrap()[..],
+        b"value33"
+    );
+}
+
+#[test]
+fn test_task2_storage_integration() {
+    let dir = tempdir().unwrap();
+    let storage = Arc::new(
+        LsmStorageInner::open(dir.path(), LsmStorageOptions::default_for_week1_test()).unwrap(),
+    );
+    assert_eq!(&storage.get(b"0").unwrap(), &None);
+    storage.put(b"1", b"233").unwrap();
+    storage.put(b"2", b"2333").unwrap();
+    storage.put(b"3", b"23333").unwrap();
+    assert_eq!(&storage.get(b"1").unwrap().unwrap()[..], b"233");
+    assert_eq!(&storage.get(b"2").unwrap().unwrap()[..], b"2333");
+    assert_eq!(&storage.get(b"3").unwrap().unwrap()[..], b"23333");
+    storage.delete(b"2").unwrap();
+    assert!(storage.get(b"2").unwrap().is_none());
+    storage.delete(b"0").unwrap(); // should NOT report any error
+}
+
+#[test]
+fn test_task3_storage_integration() {
+    let dir = tempdir().unwrap();
+    let storage = Arc::new(
+        LsmStorageInner::open(dir.path(), LsmStorageOptions::default_for_week1_test()).unwrap(),
+    );
+    storage.put(b"1", b"233").unwrap();
+    storage.put(b"2", b"2333").unwrap();
+    storage.put(b"3", b"23333").unwrap();
+    storage
+        .force_freeze_memtable(&storage.state_lock.lock())
+        .unwrap();
+    assert_eq!(storage.state.read().imm_memtables.len(), 1);
+    let previous_approximate_size = storage.state.read().imm_memtables[0].approximate_size();
+    assert!(previous_approximate_size >= 15);
+    storage.put(b"1", b"2333").unwrap();
+    storage.put(b"2", b"23333").unwrap();
+    storage.put(b"3", b"233333").unwrap();
+    storage
+        .force_freeze_memtable(&storage.state_lock.lock())
+        .unwrap();
+    assert_eq!(storage.state.read().imm_memtables.len(), 2);
+    assert!(
+        storage.state.read().imm_memtables[1].approximate_size() == previous_approximate_size,
+        "wrong order of memtables?"
+    );
+    assert!(storage.state.read().imm_memtables[0].approximate_size() > previous_approximate_size);
+}
+
+#[test]
+fn test_task3_freeze_on_capacity() {
+    let dir = tempdir().unwrap();
+    let mut options = LsmStorageOptions::default_for_week1_test();
+    options.target_sst_size = 1024;
+    options.num_memtable_limit = 1000;
+    let storage = Arc::new(LsmStorageInner::open(dir.path(), options).unwrap());
+    for _ in 0..1000 {
+        storage.put(b"1", b"2333").unwrap();
+    }
+    let num_imm_memtables = storage.state.read().imm_memtables.len();
+    assert!(num_imm_memtables >= 1, "no memtable frozen?");
+    for _ in 0..1000 {
+        storage.delete(b"1").unwrap();
+    }
+    assert!(
+        storage.state.read().imm_memtables.len() > num_imm_memtables,
+        "no more memtable frozen?"
+    );
+}
+
+#[test]
+fn test_task4_storage_integration() {
+    let dir = tempdir().unwrap();
+    let storage = Arc::new(
+        LsmStorageInner::open(dir.path(), LsmStorageOptions::default_for_week1_test()).unwrap(),
+    );
+    assert_eq!(&storage.get(b"0").unwrap(), &None);
+    storage.put(b"1", b"233").unwrap();
+    storage.put(b"2", b"2333").unwrap();
+    storage.put(b"3", b"23333").unwrap();
+    storage
+        .force_freeze_memtable(&storage.state_lock.lock())
+        .unwrap();
+    storage.delete(b"1").unwrap();
+    storage.delete(b"2").unwrap();
+    storage.put(b"3", b"2333").unwrap();
+    storage.put(b"4", b"23333").unwrap();
+    storage
+        .force_freeze_memtable(&storage.state_lock.lock())
+        .unwrap();
+    storage.put(b"1", b"233333").unwrap();
+    storage.put(b"3", b"233333").unwrap();
+    assert_eq!(storage.state.read().imm_memtables.len(), 2);
+    assert_eq!(&storage.get(b"1").unwrap().unwrap()[..], b"233333");
+    assert_eq!(&storage.get(b"2").unwrap(), &None);
+    assert_eq!(&storage.get(b"3").unwrap().unwrap()[..], b"233333");
+    assert_eq!(&storage.get(b"4").unwrap().unwrap()[..], b"23333");
+}

--- a/mini-lsm-starter/src/tests/week1_day2.rs
+++ b/mini-lsm-starter/src/tests/week1_day2.rs
@@ -1,0 +1,331 @@
+// Copyright (c) 2022-2025 Alex Chi Z
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::{ops::Bound, sync::Arc};
+
+use bytes::Bytes;
+use tempfile::tempdir;
+
+use crate::{
+    iterators::{StorageIterator, merge_iterator::MergeIterator},
+    lsm_iterator::FusedIterator,
+    lsm_storage::{LsmStorageInner, LsmStorageOptions},
+    mem_table::MemTable,
+    tests::harness::check_lsm_iter_result_by_key,
+};
+
+use super::harness::{MockIterator, check_iter_result_by_key, expect_iter_error};
+
+#[test]
+fn test_task1_memtable_iter() {
+    use std::ops::Bound;
+    let memtable = MemTable::create(0);
+    memtable.for_testing_put_slice(b"key1", b"value1").unwrap();
+    memtable.for_testing_put_slice(b"key2", b"value2").unwrap();
+    memtable.for_testing_put_slice(b"key3", b"value3").unwrap();
+
+    {
+        let mut iter = memtable.for_testing_scan_slice(Bound::Unbounded, Bound::Unbounded);
+        assert_eq!(iter.key().for_testing_key_ref(), b"key1");
+        assert_eq!(iter.value(), b"value1");
+        assert!(iter.is_valid());
+        iter.next().unwrap();
+        assert_eq!(iter.key().for_testing_key_ref(), b"key2");
+        assert_eq!(iter.value(), b"value2");
+        assert!(iter.is_valid());
+        iter.next().unwrap();
+        assert_eq!(iter.key().for_testing_key_ref(), b"key3");
+        assert_eq!(iter.value(), b"value3");
+        assert!(iter.is_valid());
+        iter.next().unwrap();
+        assert!(!iter.is_valid());
+    }
+
+    {
+        let mut iter =
+            memtable.for_testing_scan_slice(Bound::Included(b"key1"), Bound::Included(b"key2"));
+        assert_eq!(iter.key().for_testing_key_ref(), b"key1");
+        assert_eq!(iter.value(), b"value1");
+        assert!(iter.is_valid());
+        iter.next().unwrap();
+        assert_eq!(iter.key().for_testing_key_ref(), b"key2");
+        assert_eq!(iter.value(), b"value2");
+        assert!(iter.is_valid());
+        iter.next().unwrap();
+        assert!(!iter.is_valid());
+    }
+
+    {
+        let mut iter =
+            memtable.for_testing_scan_slice(Bound::Excluded(b"key1"), Bound::Excluded(b"key3"));
+        assert_eq!(iter.key().for_testing_key_ref(), b"key2");
+        assert_eq!(iter.value(), b"value2");
+        assert!(iter.is_valid());
+        iter.next().unwrap();
+        assert!(!iter.is_valid());
+    }
+}
+
+#[test]
+fn test_task1_empty_memtable_iter() {
+    use std::ops::Bound;
+    let memtable = MemTable::create(0);
+    {
+        let iter =
+            memtable.for_testing_scan_slice(Bound::Excluded(b"key1"), Bound::Excluded(b"key3"));
+        assert!(!iter.is_valid());
+    }
+    {
+        let iter =
+            memtable.for_testing_scan_slice(Bound::Included(b"key1"), Bound::Included(b"key2"));
+        assert!(!iter.is_valid());
+    }
+    {
+        let iter = memtable.for_testing_scan_slice(Bound::Unbounded, Bound::Unbounded);
+        assert!(!iter.is_valid());
+    }
+}
+
+#[test]
+fn test_task2_merge_1() {
+    let i1 = MockIterator::new(vec![
+        (Bytes::from("a"), Bytes::from("1.1")),
+        (Bytes::from("b"), Bytes::from("2.1")),
+        (Bytes::from("c"), Bytes::from("3.1")),
+        (Bytes::from("e"), Bytes::new()),
+    ]);
+    let i2 = MockIterator::new(vec![
+        (Bytes::from("a"), Bytes::from("1.2")),
+        (Bytes::from("b"), Bytes::from("2.2")),
+        (Bytes::from("c"), Bytes::from("3.2")),
+        (Bytes::from("d"), Bytes::from("4.2")),
+    ]);
+    let i3 = MockIterator::new(vec![
+        (Bytes::from("b"), Bytes::from("2.3")),
+        (Bytes::from("c"), Bytes::from("3.3")),
+        (Bytes::from("d"), Bytes::from("4.3")),
+    ]);
+
+    let mut iter = MergeIterator::create(vec![
+        Box::new(i1.clone()),
+        Box::new(i2.clone()),
+        Box::new(i3.clone()),
+    ]);
+
+    check_iter_result_by_key(
+        &mut iter,
+        vec![
+            (Bytes::from("a"), Bytes::from("1.1")),
+            (Bytes::from("b"), Bytes::from("2.1")),
+            (Bytes::from("c"), Bytes::from("3.1")),
+            (Bytes::from("d"), Bytes::from("4.2")),
+            (Bytes::from("e"), Bytes::new()),
+        ],
+    );
+
+    let mut iter = MergeIterator::create(vec![Box::new(i3), Box::new(i1), Box::new(i2)]);
+
+    check_iter_result_by_key(
+        &mut iter,
+        vec![
+            (Bytes::from("a"), Bytes::from("1.1")),
+            (Bytes::from("b"), Bytes::from("2.3")),
+            (Bytes::from("c"), Bytes::from("3.3")),
+            (Bytes::from("d"), Bytes::from("4.3")),
+            (Bytes::from("e"), Bytes::new()),
+        ],
+    );
+}
+
+#[test]
+fn test_task2_merge_2() {
+    let i1 = MockIterator::new(vec![
+        (Bytes::from("a"), Bytes::from("1.1")),
+        (Bytes::from("b"), Bytes::from("2.1")),
+        (Bytes::from("c"), Bytes::from("3.1")),
+    ]);
+    let i2 = MockIterator::new(vec![
+        (Bytes::from("d"), Bytes::from("1.2")),
+        (Bytes::from("e"), Bytes::from("2.2")),
+        (Bytes::from("f"), Bytes::from("3.2")),
+        (Bytes::from("g"), Bytes::from("4.2")),
+    ]);
+    let i3 = MockIterator::new(vec![
+        (Bytes::from("h"), Bytes::from("1.3")),
+        (Bytes::from("i"), Bytes::from("2.3")),
+        (Bytes::from("j"), Bytes::from("3.3")),
+        (Bytes::from("k"), Bytes::from("4.3")),
+    ]);
+    let i4 = MockIterator::new(vec![]);
+    let result = vec![
+        (Bytes::from("a"), Bytes::from("1.1")),
+        (Bytes::from("b"), Bytes::from("2.1")),
+        (Bytes::from("c"), Bytes::from("3.1")),
+        (Bytes::from("d"), Bytes::from("1.2")),
+        (Bytes::from("e"), Bytes::from("2.2")),
+        (Bytes::from("f"), Bytes::from("3.2")),
+        (Bytes::from("g"), Bytes::from("4.2")),
+        (Bytes::from("h"), Bytes::from("1.3")),
+        (Bytes::from("i"), Bytes::from("2.3")),
+        (Bytes::from("j"), Bytes::from("3.3")),
+        (Bytes::from("k"), Bytes::from("4.3")),
+    ];
+
+    let mut iter = MergeIterator::create(vec![
+        Box::new(i1.clone()),
+        Box::new(i2.clone()),
+        Box::new(i3.clone()),
+        Box::new(i4.clone()),
+    ]);
+    check_iter_result_by_key(&mut iter, result.clone());
+
+    let mut iter = MergeIterator::create(vec![
+        Box::new(i2.clone()),
+        Box::new(i4.clone()),
+        Box::new(i3.clone()),
+        Box::new(i1.clone()),
+    ]);
+    check_iter_result_by_key(&mut iter, result.clone());
+
+    let mut iter =
+        MergeIterator::create(vec![Box::new(i4), Box::new(i3), Box::new(i2), Box::new(i1)]);
+    check_iter_result_by_key(&mut iter, result);
+}
+
+#[test]
+fn test_task2_merge_empty() {
+    let mut iter = MergeIterator::<MockIterator>::create(vec![]);
+    check_iter_result_by_key(&mut iter, vec![]);
+
+    let i1 = MockIterator::new(vec![
+        (Bytes::from("a"), Bytes::from("1.1")),
+        (Bytes::from("b"), Bytes::from("2.1")),
+        (Bytes::from("c"), Bytes::from("3.1")),
+    ]);
+    let i2 = MockIterator::new(vec![]);
+    let mut iter = MergeIterator::<MockIterator>::create(vec![Box::new(i1), Box::new(i2)]);
+    check_iter_result_by_key(
+        &mut iter,
+        vec![
+            (Bytes::from("a"), Bytes::from("1.1")),
+            (Bytes::from("b"), Bytes::from("2.1")),
+            (Bytes::from("c"), Bytes::from("3.1")),
+        ],
+    );
+}
+
+#[test]
+fn test_task2_merge_error() {
+    let mut iter = MergeIterator::<MockIterator>::create(vec![]);
+    check_iter_result_by_key(&mut iter, vec![]);
+
+    let i1 = MockIterator::new(vec![
+        (Bytes::from("a"), Bytes::from("1.1")),
+        (Bytes::from("b"), Bytes::from("2.1")),
+        (Bytes::from("c"), Bytes::from("3.1")),
+    ]);
+    let i2 = MockIterator::new_with_error(
+        vec![
+            (Bytes::from("a"), Bytes::from("1.1")),
+            (Bytes::from("b"), Bytes::from("2.1")),
+            (Bytes::from("c"), Bytes::from("3.1")),
+        ],
+        1,
+    );
+    let iter = MergeIterator::<MockIterator>::create(vec![
+        Box::new(i1.clone()),
+        Box::new(i1),
+        Box::new(i2),
+    ]);
+    // your implementation should correctly throw an error instead of panic
+    expect_iter_error(iter);
+}
+
+#[test]
+fn test_task3_fused_iterator() {
+    let iter = MockIterator::new(vec![]);
+    let mut fused_iter = FusedIterator::new(iter);
+    assert!(!fused_iter.is_valid());
+    fused_iter.next().unwrap();
+    fused_iter.next().unwrap();
+    fused_iter.next().unwrap();
+    assert!(!fused_iter.is_valid());
+
+    let iter = MockIterator::new_with_error(
+        vec![
+            (Bytes::from("a"), Bytes::from("1.1")),
+            (Bytes::from("a"), Bytes::from("1.1")),
+        ],
+        1,
+    );
+    let mut fused_iter = FusedIterator::new(iter);
+    assert!(fused_iter.is_valid());
+    assert!(fused_iter.next().is_err());
+    assert!(!fused_iter.is_valid());
+    assert!(fused_iter.next().is_err());
+    assert!(fused_iter.next().is_err());
+}
+
+#[test]
+fn test_task4_integration() {
+    let dir = tempdir().unwrap();
+    let storage = Arc::new(
+        LsmStorageInner::open(dir.path(), LsmStorageOptions::default_for_week1_test()).unwrap(),
+    );
+    storage.put(b"1", b"233").unwrap();
+    storage.put(b"2", b"2333").unwrap();
+    storage.put(b"3", b"23333").unwrap();
+    storage
+        .force_freeze_memtable(&storage.state_lock.lock())
+        .unwrap();
+    storage.delete(b"1").unwrap();
+    storage.delete(b"2").unwrap();
+    storage.put(b"3", b"2333").unwrap();
+    storage.put(b"4", b"23333").unwrap();
+    storage
+        .force_freeze_memtable(&storage.state_lock.lock())
+        .unwrap();
+    storage.put(b"1", b"233333").unwrap();
+    storage.put(b"3", b"233333").unwrap();
+    {
+        let mut iter = storage.scan(Bound::Unbounded, Bound::Unbounded).unwrap();
+        check_lsm_iter_result_by_key(
+            &mut iter,
+            vec![
+                (Bytes::from_static(b"1"), Bytes::from_static(b"233333")),
+                (Bytes::from_static(b"3"), Bytes::from_static(b"233333")),
+                (Bytes::from_static(b"4"), Bytes::from_static(b"23333")),
+            ],
+        );
+        assert!(!iter.is_valid());
+        iter.next().unwrap();
+        iter.next().unwrap();
+        iter.next().unwrap();
+        assert!(!iter.is_valid());
+    }
+    {
+        let mut iter = storage
+            .scan(Bound::Included(b"2"), Bound::Included(b"3"))
+            .unwrap();
+        check_lsm_iter_result_by_key(
+            &mut iter,
+            vec![(Bytes::from_static(b"3"), Bytes::from_static(b"233333"))],
+        );
+        assert!(!iter.is_valid());
+        iter.next().unwrap();
+        iter.next().unwrap();
+        iter.next().unwrap();
+        assert!(!iter.is_valid());
+    }
+}

--- a/mini-lsm-starter/src/tests/week1_day3.rs
+++ b/mini-lsm-starter/src/tests/week1_day3.rs
@@ -1,0 +1,161 @@
+// Copyright (c) 2022-2025 Alex Chi Z
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use bytes::Bytes;
+
+use crate::{
+    block::{Block, BlockBuilder, BlockIterator},
+    key::{KeySlice, KeyVec},
+};
+
+#[test]
+fn test_block_build_single_key() {
+    let mut builder = BlockBuilder::new(16);
+    assert!(builder.add(KeySlice::for_testing_from_slice_no_ts(b"233"), b"233333"));
+    builder.build();
+}
+
+#[test]
+fn test_block_build_full() {
+    let mut builder = BlockBuilder::new(16);
+    assert!(builder.add(KeySlice::for_testing_from_slice_no_ts(b"11"), b"11"));
+    assert!(!builder.add(KeySlice::for_testing_from_slice_no_ts(b"22"), b"22"));
+    builder.build();
+}
+
+#[test]
+fn test_block_build_large_1() {
+    let mut builder = BlockBuilder::new(16);
+    assert!(builder.add(
+        KeySlice::for_testing_from_slice_no_ts(b"11"),
+        &b"1".repeat(100)
+    ));
+    builder.build();
+}
+
+#[test]
+fn test_block_build_large_2() {
+    let mut builder = BlockBuilder::new(16);
+    assert!(builder.add(KeySlice::for_testing_from_slice_no_ts(b"11"), b"1"));
+    assert!(!builder.add(
+        KeySlice::for_testing_from_slice_no_ts(b"11"),
+        &b"1".repeat(100)
+    ));
+}
+
+fn key_of(idx: usize) -> KeyVec {
+    KeyVec::for_testing_from_vec_no_ts(format!("key_{:03}", idx * 5).into_bytes())
+}
+
+fn value_of(idx: usize) -> Vec<u8> {
+    format!("value_{:010}", idx).into_bytes()
+}
+
+fn num_of_keys() -> usize {
+    100
+}
+
+fn generate_block() -> Block {
+    let mut builder = BlockBuilder::new(10000);
+    for idx in 0..num_of_keys() {
+        let key = key_of(idx);
+        let value = value_of(idx);
+        assert!(builder.add(key.as_key_slice(), &value[..]));
+    }
+    builder.build()
+}
+
+#[test]
+fn test_block_build_all() {
+    generate_block();
+}
+
+#[test]
+fn test_block_encode() {
+    let block = generate_block();
+    block.encode();
+}
+
+#[test]
+fn test_block_decode() {
+    let block = generate_block();
+    let encoded = block.encode();
+    let decoded_block = Block::decode(&encoded);
+    assert_eq!(block.offsets, decoded_block.offsets);
+    assert_eq!(block.data, decoded_block.data);
+}
+
+fn as_bytes(x: &[u8]) -> Bytes {
+    Bytes::copy_from_slice(x)
+}
+
+#[test]
+fn test_block_iterator() {
+    let block = Arc::new(generate_block());
+    let mut iter = BlockIterator::create_and_seek_to_first(block);
+    for _ in 0..5 {
+        for i in 0..num_of_keys() {
+            let key = iter.key();
+            let value = iter.value();
+            assert_eq!(
+                key.for_testing_key_ref(),
+                key_of(i).for_testing_key_ref(),
+                "expected key: {:?}, actual key: {:?}",
+                as_bytes(key_of(i).for_testing_key_ref()),
+                as_bytes(key.for_testing_key_ref())
+            );
+            assert_eq!(
+                value,
+                value_of(i),
+                "expected value: {:?}, actual value: {:?}",
+                as_bytes(&value_of(i)),
+                as_bytes(value)
+            );
+            iter.next();
+        }
+        iter.seek_to_first();
+    }
+}
+
+#[test]
+fn test_block_seek_key() {
+    let block = Arc::new(generate_block());
+    let mut iter = BlockIterator::create_and_seek_to_key(block, key_of(0).as_key_slice());
+    for offset in 1..=5 {
+        for i in 0..num_of_keys() {
+            let key = iter.key();
+            let value = iter.value();
+            assert_eq!(
+                key.for_testing_key_ref(),
+                key_of(i).for_testing_key_ref(),
+                "expected key: {:?}, actual key: {:?}",
+                as_bytes(key_of(i).for_testing_key_ref()),
+                as_bytes(key.for_testing_key_ref())
+            );
+            assert_eq!(
+                value,
+                value_of(i),
+                "expected value: {:?}, actual value: {:?}",
+                as_bytes(&value_of(i)),
+                as_bytes(value)
+            );
+            iter.seek_to_key(KeySlice::for_testing_from_slice_no_ts(
+                &format!("key_{:03}", i * 5 + offset).into_bytes(),
+            ));
+        }
+        iter.seek_to_key(KeySlice::for_testing_from_slice_no_ts(b"k"));
+    }
+}

--- a/mini-lsm-starter/src/tests/week1_day4.rs
+++ b/mini-lsm-starter/src/tests/week1_day4.rs
@@ -1,0 +1,180 @@
+// Copyright (c) 2022-2025 Alex Chi Z
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use bytes::Bytes;
+use tempfile::{TempDir, tempdir};
+
+use crate::block::BlockIterator;
+use crate::iterators::StorageIterator;
+use crate::key::{KeySlice, KeyVec};
+use crate::table::{SsTable, SsTableBuilder, SsTableIterator};
+
+#[test]
+fn test_sst_build_single_key() {
+    let mut builder = SsTableBuilder::new(16);
+    builder.add(KeySlice::for_testing_from_slice_no_ts(b"233"), b"233333");
+    let dir = tempdir().unwrap();
+    builder.build_for_test(dir.path().join("1.sst")).unwrap();
+}
+
+#[test]
+fn test_sst_build_two_blocks() {
+    let mut builder = SsTableBuilder::new(16);
+    builder.add(KeySlice::for_testing_from_slice_no_ts(b"11"), b"11");
+    builder.add(KeySlice::for_testing_from_slice_no_ts(b"22"), b"22");
+    builder.add(KeySlice::for_testing_from_slice_no_ts(b"33"), b"11");
+    builder.add(KeySlice::for_testing_from_slice_no_ts(b"44"), b"22");
+    builder.add(KeySlice::for_testing_from_slice_no_ts(b"55"), b"11");
+    builder.add(KeySlice::for_testing_from_slice_no_ts(b"66"), b"22");
+    assert!(builder.meta.len() >= 2);
+    let dir = tempdir().unwrap();
+    builder.build_for_test(dir.path().join("1.sst")).unwrap();
+}
+
+fn key_of(idx: usize) -> KeyVec {
+    KeyVec::for_testing_from_vec_no_ts(format!("key_{:03}", idx * 5).into_bytes())
+}
+
+fn value_of(idx: usize) -> Vec<u8> {
+    format!("value_{:010}", idx).into_bytes()
+}
+
+fn num_of_keys() -> usize {
+    100
+}
+
+fn generate_sst() -> (TempDir, SsTable) {
+    let mut builder = SsTableBuilder::new(128);
+    for idx in 0..num_of_keys() {
+        let key = key_of(idx);
+        let value = value_of(idx);
+        builder.add(key.as_key_slice(), &value[..]);
+    }
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("1.sst");
+    (dir, builder.build_for_test(path).unwrap())
+}
+
+#[test]
+fn test_sst_build_all() {
+    let (_, sst) = generate_sst();
+    assert_eq!(sst.first_key().as_key_slice(), key_of(0).as_key_slice());
+    assert_eq!(
+        sst.last_key().as_key_slice(),
+        key_of(num_of_keys() - 1).as_key_slice()
+    )
+}
+
+#[test]
+fn test_sst_block_metadata_matches_block_contents() {
+    let (_dir, sst) = generate_sst();
+    assert!(sst.num_of_blocks() > 1);
+
+    for (block_idx, meta) in sst.block_meta.iter().enumerate() {
+        let mut iter = BlockIterator::create_and_seek_to_first(sst.read_block(block_idx).unwrap());
+        let first_key = Bytes::copy_from_slice(iter.key().for_testing_key_ref());
+        let mut last_key = first_key.clone();
+        while iter.is_valid() {
+            last_key = Bytes::copy_from_slice(iter.key().for_testing_key_ref());
+            iter.next();
+        }
+
+        assert_eq!(meta.first_key.for_testing_key_ref(), first_key.as_ref());
+        assert_eq!(meta.last_key.for_testing_key_ref(), last_key.as_ref());
+    }
+}
+
+#[test]
+fn test_sst_decode() {
+    let (_dir, sst) = generate_sst();
+    let meta = sst.block_meta.clone();
+    let new_sst = SsTable::open_for_test(sst.file).unwrap();
+    assert_eq!(new_sst.block_meta, meta);
+    assert_eq!(
+        new_sst.first_key().for_testing_key_ref(),
+        key_of(0).for_testing_key_ref()
+    );
+    assert_eq!(
+        new_sst.last_key().for_testing_key_ref(),
+        key_of(num_of_keys() - 1).for_testing_key_ref()
+    );
+}
+
+fn as_bytes(x: &[u8]) -> Bytes {
+    Bytes::copy_from_slice(x)
+}
+
+#[test]
+fn test_sst_iterator() {
+    let (_dir, sst) = generate_sst();
+    let sst = Arc::new(sst);
+    let mut iter = SsTableIterator::create_and_seek_to_first(sst).unwrap();
+    for _ in 0..5 {
+        for i in 0..num_of_keys() {
+            let key = iter.key();
+            let value = iter.value();
+            assert_eq!(
+                key.for_testing_key_ref(),
+                key_of(i).for_testing_key_ref(),
+                "expected key: {:?}, actual key: {:?}",
+                as_bytes(key_of(i).for_testing_key_ref()),
+                as_bytes(key.for_testing_key_ref())
+            );
+            assert_eq!(
+                value,
+                value_of(i),
+                "expected value: {:?}, actual value: {:?}",
+                as_bytes(&value_of(i)),
+                as_bytes(value)
+            );
+            iter.next().unwrap();
+        }
+        iter.seek_to_first().unwrap();
+    }
+}
+
+#[test]
+fn test_sst_seek_key() {
+    let (_dir, sst) = generate_sst();
+    let sst = Arc::new(sst);
+    let mut iter = SsTableIterator::create_and_seek_to_key(sst, key_of(0).as_key_slice()).unwrap();
+    for offset in 1..=5 {
+        for i in 0..num_of_keys() {
+            let key = iter.key();
+            let value = iter.value();
+            assert_eq!(
+                key.for_testing_key_ref(),
+                key_of(i).for_testing_key_ref(),
+                "expected key: {:?}, actual key: {:?}",
+                as_bytes(key_of(i).for_testing_key_ref()),
+                as_bytes(key.for_testing_key_ref())
+            );
+            assert_eq!(
+                value,
+                value_of(i),
+                "expected value: {:?}, actual value: {:?}",
+                as_bytes(&value_of(i)),
+                as_bytes(value)
+            );
+            iter.seek_to_key(KeySlice::for_testing_from_slice_no_ts(
+                &format!("key_{:03}", i * 5 + offset).into_bytes(),
+            ))
+            .unwrap();
+        }
+        iter.seek_to_key(KeySlice::for_testing_from_slice_no_ts(b"k"))
+            .unwrap();
+    }
+}

--- a/mini-lsm-starter/src/tests/week1_day5.rs
+++ b/mini-lsm-starter/src/tests/week1_day5.rs
@@ -1,0 +1,324 @@
+// Copyright (c) 2022-2025 Alex Chi Z
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::ops::Bound;
+use std::sync::Arc;
+
+use self::harness::{MockIterator, check_iter_result_by_key};
+use self::harness::{check_lsm_iter_result_by_key, generate_sst};
+use bytes::Bytes;
+use tempfile::tempdir;
+
+use super::*;
+use crate::{
+    iterators::two_merge_iterator::TwoMergeIterator,
+    lsm_storage::{LsmStorageInner, LsmStorageOptions},
+};
+
+#[test]
+fn test_task1_merge_1() {
+    let i1 = MockIterator::new(vec![
+        (Bytes::from("a"), Bytes::from("1.1")),
+        (Bytes::from("b"), Bytes::from("2.1")),
+        (Bytes::from("c"), Bytes::from("3.1")),
+    ]);
+    let i2 = MockIterator::new(vec![
+        (Bytes::from("a"), Bytes::from("1.2")),
+        (Bytes::from("b"), Bytes::from("2.2")),
+        (Bytes::from("c"), Bytes::from("3.2")),
+        (Bytes::from("d"), Bytes::from("4.2")),
+    ]);
+    let mut iter = TwoMergeIterator::create(i1, i2).unwrap();
+    check_iter_result_by_key(
+        &mut iter,
+        vec![
+            (Bytes::from("a"), Bytes::from("1.1")),
+            (Bytes::from("b"), Bytes::from("2.1")),
+            (Bytes::from("c"), Bytes::from("3.1")),
+            (Bytes::from("d"), Bytes::from("4.2")),
+        ],
+    )
+}
+
+#[test]
+fn test_task1_merge_2() {
+    let i2 = MockIterator::new(vec![
+        (Bytes::from("a"), Bytes::from("1.1")),
+        (Bytes::from("b"), Bytes::from("2.1")),
+        (Bytes::from("c"), Bytes::from("3.1")),
+    ]);
+    let i1 = MockIterator::new(vec![
+        (Bytes::from("a"), Bytes::from("1.2")),
+        (Bytes::from("b"), Bytes::from("2.2")),
+        (Bytes::from("c"), Bytes::from("3.2")),
+        (Bytes::from("d"), Bytes::from("4.2")),
+    ]);
+    let mut iter = TwoMergeIterator::create(i1, i2).unwrap();
+    check_iter_result_by_key(
+        &mut iter,
+        vec![
+            (Bytes::from("a"), Bytes::from("1.2")),
+            (Bytes::from("b"), Bytes::from("2.2")),
+            (Bytes::from("c"), Bytes::from("3.2")),
+            (Bytes::from("d"), Bytes::from("4.2")),
+        ],
+    )
+}
+
+#[test]
+fn test_task1_merge_3() {
+    let i2 = MockIterator::new(vec![
+        (Bytes::from("a"), Bytes::from("1.1")),
+        (Bytes::from("b"), Bytes::from("2.1")),
+        (Bytes::from("c"), Bytes::from("3.1")),
+    ]);
+    let i1 = MockIterator::new(vec![
+        (Bytes::from("b"), Bytes::from("2.2")),
+        (Bytes::from("c"), Bytes::from("3.2")),
+        (Bytes::from("d"), Bytes::from("4.2")),
+    ]);
+    let mut iter = TwoMergeIterator::create(i1, i2).unwrap();
+    check_iter_result_by_key(
+        &mut iter,
+        vec![
+            (Bytes::from("a"), Bytes::from("1.1")),
+            (Bytes::from("b"), Bytes::from("2.2")),
+            (Bytes::from("c"), Bytes::from("3.2")),
+            (Bytes::from("d"), Bytes::from("4.2")),
+        ],
+    )
+}
+
+#[test]
+fn test_task1_merge_4() {
+    let i2 = MockIterator::new(vec![]);
+    let i1 = MockIterator::new(vec![
+        (Bytes::from("b"), Bytes::from("2.2")),
+        (Bytes::from("c"), Bytes::from("3.2")),
+        (Bytes::from("d"), Bytes::from("4.2")),
+    ]);
+    let mut iter = TwoMergeIterator::create(i1, i2).unwrap();
+    check_iter_result_by_key(
+        &mut iter,
+        vec![
+            (Bytes::from("b"), Bytes::from("2.2")),
+            (Bytes::from("c"), Bytes::from("3.2")),
+            (Bytes::from("d"), Bytes::from("4.2")),
+        ],
+    );
+    let i1 = MockIterator::new(vec![]);
+    let i2 = MockIterator::new(vec![
+        (Bytes::from("b"), Bytes::from("2.2")),
+        (Bytes::from("c"), Bytes::from("3.2")),
+        (Bytes::from("d"), Bytes::from("4.2")),
+    ]);
+    let mut iter = TwoMergeIterator::create(i1, i2).unwrap();
+    check_iter_result_by_key(
+        &mut iter,
+        vec![
+            (Bytes::from("b"), Bytes::from("2.2")),
+            (Bytes::from("c"), Bytes::from("3.2")),
+            (Bytes::from("d"), Bytes::from("4.2")),
+        ],
+    );
+}
+
+#[test]
+fn test_task1_merge_5() {
+    let i2 = MockIterator::new(vec![]);
+    let i1 = MockIterator::new(vec![]);
+    let mut iter = TwoMergeIterator::create(i1, i2).unwrap();
+    check_iter_result_by_key(&mut iter, vec![])
+}
+
+#[test]
+fn test_task2_storage_scan() {
+    let dir = tempdir().unwrap();
+    let storage =
+        Arc::new(LsmStorageInner::open(&dir, LsmStorageOptions::default_for_week1_test()).unwrap());
+    storage.put(b"1", b"233").unwrap();
+    storage.put(b"2", b"2333").unwrap();
+    storage.put(b"00", b"2333").unwrap();
+    storage
+        .force_freeze_memtable(&storage.state_lock.lock())
+        .unwrap();
+    storage.put(b"3", b"23333").unwrap();
+    storage.delete(b"1").unwrap();
+    let sst1 = generate_sst(
+        10,
+        dir.path().join("10.sst"),
+        vec![
+            (Bytes::from_static(b"0"), Bytes::from_static(b"2333333")),
+            (Bytes::from_static(b"00"), Bytes::from_static(b"2333333")),
+            (Bytes::from_static(b"4"), Bytes::from_static(b"23")),
+        ],
+        Some(storage.block_cache.clone()),
+    );
+    let sst2 = generate_sst(
+        11,
+        dir.path().join("11.sst"),
+        vec![(Bytes::from_static(b"4"), Bytes::from_static(b""))],
+        Some(storage.block_cache.clone()),
+    );
+    {
+        let mut state = storage.state.write();
+        let mut snapshot = state.as_ref().clone();
+        snapshot.l0_sstables.push(sst2.sst_id()); // this is the latest SST
+        snapshot.l0_sstables.push(sst1.sst_id());
+        snapshot.sstables.insert(sst2.sst_id(), sst2.into());
+        snapshot.sstables.insert(sst1.sst_id(), sst1.into());
+        *state = snapshot.into();
+    }
+    check_lsm_iter_result_by_key(
+        &mut storage.scan(Bound::Unbounded, Bound::Unbounded).unwrap(),
+        vec![
+            (Bytes::from("0"), Bytes::from("2333333")),
+            (Bytes::from("00"), Bytes::from("2333")),
+            (Bytes::from("2"), Bytes::from("2333")),
+            (Bytes::from("3"), Bytes::from("23333")),
+        ],
+    );
+    check_lsm_iter_result_by_key(
+        &mut storage
+            .scan(Bound::Included(b"1"), Bound::Included(b"2"))
+            .unwrap(),
+        vec![(Bytes::from("2"), Bytes::from("2333"))],
+    );
+    check_lsm_iter_result_by_key(
+        &mut storage
+            .scan(Bound::Excluded(b"1"), Bound::Excluded(b"3"))
+            .unwrap(),
+        vec![(Bytes::from("2"), Bytes::from("2333"))],
+    );
+    check_lsm_iter_result_by_key(
+        &mut storage
+            .scan(Bound::Included(b"0"), Bound::Included(b"1"))
+            .unwrap(),
+        vec![
+            (Bytes::from_static(b"0"), Bytes::from_static(b"2333333")),
+            (Bytes::from("00"), Bytes::from("2333")),
+        ],
+    );
+    check_lsm_iter_result_by_key(
+        &mut storage
+            .scan(Bound::Excluded(b"0"), Bound::Included(b"1"))
+            .unwrap(),
+        vec![(Bytes::from("00"), Bytes::from("2333"))],
+    );
+}
+
+#[test]
+fn test_task2_storage_scan_end_bound_at_seek_position() {
+    let dir = tempdir().unwrap();
+    let storage =
+        Arc::new(LsmStorageInner::open(&dir, LsmStorageOptions::default_for_week1_test()).unwrap());
+    let sst1 = generate_sst(
+        10,
+        dir.path().join("10.sst"),
+        vec![
+            (Bytes::from_static(b"key00"), Bytes::from_static(b"233")),
+            (Bytes::from_static(b"key11"), Bytes::from_static(b"2333")),
+        ],
+        Some(storage.block_cache.clone()),
+    );
+    {
+        let mut state = storage.state.write();
+        let mut snapshot = state.as_ref().clone();
+        snapshot.l0_sstables.push(sst1.sst_id());
+        snapshot.sstables.insert(sst1.sst_id(), sst1.into());
+        *state = snapshot.into();
+    }
+    check_lsm_iter_result_by_key(
+        &mut storage
+            .scan(Bound::Included(b"key01"), Bound::Included(b"key01"))
+            .unwrap(),
+        vec![],
+    );
+    check_lsm_iter_result_by_key(
+        &mut storage
+            .scan(Bound::Included(b"key01"), Bound::Excluded(b"key11"))
+            .unwrap(),
+        vec![],
+    );
+    check_lsm_iter_result_by_key(
+        &mut storage
+            .scan(Bound::Included(b"key01"), Bound::Included(b"key11"))
+            .unwrap(),
+        vec![(Bytes::from("key11"), Bytes::from("2333"))],
+    );
+}
+
+#[test]
+fn test_task3_storage_get() {
+    let dir = tempdir().unwrap();
+    let storage =
+        Arc::new(LsmStorageInner::open(&dir, LsmStorageOptions::default_for_week1_test()).unwrap());
+    storage.put(b"1", b"233").unwrap();
+    storage.put(b"2", b"2333").unwrap();
+    storage.put(b"00", b"2333").unwrap();
+    storage
+        .force_freeze_memtable(&storage.state_lock.lock())
+        .unwrap();
+    storage.put(b"3", b"23333").unwrap();
+    storage.delete(b"1").unwrap();
+    let sst1 = generate_sst(
+        10,
+        dir.path().join("10.sst"),
+        vec![
+            (Bytes::from_static(b"0"), Bytes::from_static(b"2333333")),
+            (Bytes::from_static(b"00"), Bytes::from_static(b"2333333")),
+            (Bytes::from_static(b"10"), Bytes::from_static(b"test")),
+            (Bytes::from_static(b"4"), Bytes::from_static(b"23")),
+        ],
+        Some(storage.block_cache.clone()),
+    );
+    let sst2 = generate_sst(
+        11,
+        dir.path().join("11.sst"),
+        vec![(Bytes::from_static(b"4"), Bytes::from_static(b""))],
+        Some(storage.block_cache.clone()),
+    );
+    {
+        let mut state = storage.state.write();
+        let mut snapshot = state.as_ref().clone();
+        snapshot.l0_sstables.push(sst2.sst_id()); // this is the latest SST
+        snapshot.l0_sstables.push(sst1.sst_id());
+        snapshot.sstables.insert(sst2.sst_id(), sst2.into());
+        snapshot.sstables.insert(sst1.sst_id(), sst1.into());
+        *state = snapshot.into();
+    }
+    assert_eq!(
+        storage.get(b"0").unwrap(),
+        Some(Bytes::from_static(b"2333333"))
+    );
+    assert_eq!(
+        storage.get(b"00").unwrap(),
+        Some(Bytes::from_static(b"2333"))
+    );
+    assert_eq!(
+        storage.get(b"2").unwrap(),
+        Some(Bytes::from_static(b"2333"))
+    );
+    assert_eq!(
+        storage.get(b"3").unwrap(),
+        Some(Bytes::from_static(b"23333"))
+    );
+    assert_eq!(
+        storage.get(b"10").unwrap(),
+        Some(Bytes::from_static(b"test"))
+    );
+    assert_eq!(storage.get(b"4").unwrap(), None);
+    assert_eq!(storage.get(b"--").unwrap(), None);
+    assert_eq!(storage.get(b"555").unwrap(), None);
+}

--- a/mini-lsm-starter/src/tests/week1_day6.rs
+++ b/mini-lsm-starter/src/tests/week1_day6.rs
@@ -1,0 +1,224 @@
+// Copyright (c) 2022-2025 Alex Chi Z
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::{ops::Bound, sync::Arc, time::Duration};
+
+use bytes::Bytes;
+use tempfile::tempdir;
+
+use self::harness::{check_lsm_iter_result_by_key, sync};
+
+use super::*;
+use crate::{
+    iterators::StorageIterator,
+    lsm_storage::{LsmStorageInner, LsmStorageOptions, MiniLsm},
+};
+
+#[test]
+fn test_force_flush_empty_imm_memtable() {
+    let dir = tempdir().unwrap();
+    let storage =
+        Arc::new(LsmStorageInner::open(&dir, LsmStorageOptions::default_for_week1_test()).unwrap());
+
+    storage.force_flush_next_imm_memtable().unwrap();
+
+    let state = storage.state.read();
+    assert!(state.imm_memtables.is_empty());
+    assert!(state.l0_sstables.is_empty());
+}
+
+#[test]
+fn test_task1_storage_scan() {
+    let dir = tempdir().unwrap();
+    let storage =
+        Arc::new(LsmStorageInner::open(&dir, LsmStorageOptions::default_for_week1_test()).unwrap());
+    storage.put(b"0", b"2333333").unwrap();
+    storage.put(b"00", b"2333333").unwrap();
+    storage.put(b"4", b"23").unwrap();
+    sync(&storage);
+
+    storage.delete(b"4").unwrap();
+    sync(&storage);
+
+    storage.put(b"1", b"233").unwrap();
+    storage.put(b"2", b"2333").unwrap();
+    storage
+        .force_freeze_memtable(&storage.state_lock.lock())
+        .unwrap();
+    storage.put(b"00", b"2333").unwrap();
+    storage
+        .force_freeze_memtable(&storage.state_lock.lock())
+        .unwrap();
+    storage.put(b"3", b"23333").unwrap();
+    storage.delete(b"1").unwrap();
+
+    {
+        let state = storage.state.read();
+        assert_eq!(state.l0_sstables.len(), 2);
+        assert_eq!(state.imm_memtables.len(), 2);
+    }
+
+    check_lsm_iter_result_by_key(
+        &mut storage.scan(Bound::Unbounded, Bound::Unbounded).unwrap(),
+        vec![
+            (Bytes::from("0"), Bytes::from("2333333")),
+            (Bytes::from("00"), Bytes::from("2333")),
+            (Bytes::from("2"), Bytes::from("2333")),
+            (Bytes::from("3"), Bytes::from("23333")),
+        ],
+    );
+    check_lsm_iter_result_by_key(
+        &mut storage
+            .scan(Bound::Included(b"1"), Bound::Included(b"2"))
+            .unwrap(),
+        vec![(Bytes::from("2"), Bytes::from("2333"))],
+    );
+    check_lsm_iter_result_by_key(
+        &mut storage
+            .scan(Bound::Excluded(b"1"), Bound::Excluded(b"3"))
+            .unwrap(),
+        vec![(Bytes::from("2"), Bytes::from("2333"))],
+    );
+}
+
+#[test]
+fn test_task1_storage_get() {
+    let dir = tempdir().unwrap();
+    let storage =
+        Arc::new(LsmStorageInner::open(&dir, LsmStorageOptions::default_for_week1_test()).unwrap());
+    storage.put(b"0", b"2333333").unwrap();
+    storage.put(b"00", b"2333333").unwrap();
+    storage.put(b"4", b"23").unwrap();
+    sync(&storage);
+
+    storage.delete(b"4").unwrap();
+    sync(&storage);
+
+    storage.put(b"1", b"233").unwrap();
+    storage.put(b"2", b"2333").unwrap();
+    storage
+        .force_freeze_memtable(&storage.state_lock.lock())
+        .unwrap();
+    storage.put(b"00", b"2333").unwrap();
+    storage
+        .force_freeze_memtable(&storage.state_lock.lock())
+        .unwrap();
+    storage.put(b"3", b"23333").unwrap();
+    storage.delete(b"1").unwrap();
+
+    {
+        let state = storage.state.read();
+        assert_eq!(state.l0_sstables.len(), 2);
+        assert_eq!(state.imm_memtables.len(), 2);
+    }
+
+    assert_eq!(
+        storage.get(b"0").unwrap(),
+        Some(Bytes::from_static(b"2333333"))
+    );
+    assert_eq!(
+        storage.get(b"00").unwrap(),
+        Some(Bytes::from_static(b"2333"))
+    );
+    assert_eq!(
+        storage.get(b"2").unwrap(),
+        Some(Bytes::from_static(b"2333"))
+    );
+    assert_eq!(
+        storage.get(b"3").unwrap(),
+        Some(Bytes::from_static(b"23333"))
+    );
+    assert_eq!(storage.get(b"4").unwrap(), None);
+    assert_eq!(storage.get(b"--").unwrap(), None);
+    assert_eq!(storage.get(b"555").unwrap(), None);
+}
+
+#[test]
+fn test_task2_auto_flush() {
+    let dir = tempdir().unwrap();
+    let storage = MiniLsm::open(&dir, LsmStorageOptions::default_for_week1_day6_test()).unwrap();
+
+    let value = "1".repeat(1024); // 1KB
+
+    // approximately 6MB
+    for i in 0..6000 {
+        storage
+            .put(format!("{i}").as_bytes(), value.as_bytes())
+            .unwrap();
+    }
+
+    std::thread::sleep(Duration::from_millis(500));
+
+    assert!(!storage.inner.state.read().l0_sstables.is_empty());
+}
+
+#[test]
+fn test_task3_sst_filter() {
+    let dir = tempdir().unwrap();
+    let storage =
+        Arc::new(LsmStorageInner::open(&dir, LsmStorageOptions::default_for_week1_test()).unwrap());
+
+    for i in 1..=10000 {
+        if i % 1000 == 0 {
+            sync(&storage);
+        }
+        storage
+            .put(format!("{:05}", i).as_bytes(), b"2333333")
+            .unwrap();
+    }
+
+    let iter = storage.scan(Bound::Unbounded, Bound::Unbounded).unwrap();
+    assert!(
+        iter.num_active_iterators() >= 10,
+        "did you implement num_active_iterators? current active iterators = {}",
+        iter.num_active_iterators()
+    );
+    let max_num = iter.num_active_iterators();
+    let iter = storage
+        .scan(
+            Bound::Excluded(format!("{:05}", 10000).as_bytes()),
+            Bound::Unbounded,
+        )
+        .unwrap();
+    assert!(iter.num_active_iterators() < max_num);
+    let min_num = iter.num_active_iterators();
+    let iter = storage
+        .scan(
+            Bound::Unbounded,
+            Bound::Excluded(format!("{:05}", 1).as_bytes()),
+        )
+        .unwrap();
+    assert_eq!(iter.num_active_iterators(), min_num);
+    let iter = storage
+        .scan(
+            Bound::Unbounded,
+            Bound::Included(format!("{:05}", 0).as_bytes()),
+        )
+        .unwrap();
+    assert_eq!(iter.num_active_iterators(), min_num);
+    let iter = storage
+        .scan(
+            Bound::Included(format!("{:05}", 10001).as_bytes()),
+            Bound::Unbounded,
+        )
+        .unwrap();
+    assert_eq!(iter.num_active_iterators(), min_num);
+    let iter = storage
+        .scan(
+            Bound::Included(format!("{:05}", 5000).as_bytes()),
+            Bound::Excluded(format!("{:05}", 6000).as_bytes()),
+        )
+        .unwrap();
+    assert!(min_num <= iter.num_active_iterators() && iter.num_active_iterators() < max_num);
+}

--- a/mini-lsm-starter/src/tests/week1_day7.rs
+++ b/mini-lsm-starter/src/tests/week1_day7.rs
@@ -1,0 +1,105 @@
+// Copyright (c) 2022-2025 Alex Chi Z
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use tempfile::tempdir;
+
+use crate::{
+    key::{KeySlice, TS_ENABLED},
+    table::{FileObject, SsTable, SsTableBuilder, bloom::Bloom},
+};
+
+fn key_of(idx: usize) -> Vec<u8> {
+    format!("key_{:010}", idx * 5).into_bytes()
+}
+
+fn value_of(idx: usize) -> Vec<u8> {
+    format!("value_{:010}", idx).into_bytes()
+}
+
+fn num_of_keys() -> usize {
+    100
+}
+
+#[test]
+fn test_task1_bloom_filter() {
+    let mut key_hashes = Vec::new();
+    for idx in 0..num_of_keys() {
+        let key = key_of(idx);
+        key_hashes.push(farmhash::fingerprint32(&key));
+    }
+    let bits_per_key = Bloom::bloom_bits_per_key(key_hashes.len(), 0.01);
+    println!("bits per key: {}", bits_per_key);
+    let bloom = Bloom::build_from_key_hashes(&key_hashes, bits_per_key);
+    println!("bloom size: {}, k={}", bloom.filter.len(), bloom.k);
+    assert!(bloom.k < 30);
+    for idx in 0..num_of_keys() {
+        let key = key_of(idx);
+        assert!(bloom.may_contain(farmhash::fingerprint32(&key)));
+    }
+    let mut x = 0;
+    let mut cnt = 0;
+    for idx in num_of_keys()..(num_of_keys() * 10) {
+        let key = key_of(idx);
+        if bloom.may_contain(farmhash::fingerprint32(&key)) {
+            x += 1;
+        }
+        cnt += 1;
+    }
+    assert_ne!(x, cnt, "bloom filter not taking effect?");
+    assert_ne!(x, 0, "bloom filter not taking effect?");
+}
+
+#[test]
+fn test_task2_sst_decode() {
+    let mut builder = SsTableBuilder::new(128);
+    for idx in 0..num_of_keys() {
+        let key = key_of(idx);
+        let value = value_of(idx);
+        builder.add(KeySlice::for_testing_from_slice_no_ts(&key[..]), &value[..]);
+    }
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("1.sst");
+    let sst = builder.build_for_test(&path).unwrap();
+    let sst2 = SsTable::open(0, None, FileObject::open(&path).unwrap()).unwrap();
+    let bloom_1 = sst.bloom.as_ref().unwrap();
+    let bloom_2 = sst2.bloom.as_ref().unwrap();
+    assert_eq!(bloom_1.k, bloom_2.k);
+    assert_eq!(bloom_1.filter, bloom_2.filter);
+}
+
+#[test]
+fn test_task3_block_key_compression() {
+    let mut builder = SsTableBuilder::new(128);
+    for idx in 0..num_of_keys() {
+        let key = key_of(idx);
+        let value = value_of(idx);
+        builder.add(KeySlice::for_testing_from_slice_no_ts(&key[..]), &value[..]);
+    }
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("1.sst");
+    let sst = builder.build_for_test(path).unwrap();
+    if TS_ENABLED {
+        assert!(
+            sst.block_meta.len() <= 34,
+            "you have {} blocks, expect 34",
+            sst.block_meta.len()
+        );
+    } else {
+        assert!(
+            sst.block_meta.len() <= 25,
+            "you have {} blocks, expect 25",
+            sst.block_meta.len()
+        );
+    }
+}


### PR DESCRIPTION
## Purpose

This is an experimental stacked PR on #207 and is not intended to merge. It records a full Week 1 coding-agent walkthrough using the revised rule that each checkpoint receives an independent compiling implementation before its supplied tests are copied or inspected.

## Result

- The subagent implemented ordered memtables and merging, the final compressed block/SST representation, Bloom filters, the complete memory/L0 read path, freezing, flushing, and Day 1 lifecycle behavior.
- Every newly revealed checkpoint suite passed on its first run; the final check passed all 46 Week 1 tests and Clippy.
- A temporary excluded-upper-bound fault failed the predicted focused test and was immediately reverted.
- `WEEK1_AGENT_WALKTHROUGH.md` contains the full primary-agent/subagent transcript, exact instructions and answers, implementation reports, validation evidence, and path feedback.
- The copied supplied tests are included only to preserve the exact experimental worktree state.

## Observations

The implementation-before-test boundary worked: the book, starter interfaces, and student-owned decisions were sufficient to reach passing implementations without test-shaped development. The main cost was interaction volume: the transcript contains 50 explicit decision questions plus slice authorizations. Because each first pass happened to pass, the new student-led product-failure diagnosis rule was not exercised naturally and needs a separate intentional-bug trial.

_AI-assisted: Codex._
