### PR TITLE
Repair Week 3 starter tests and WAL recovery

### DIFF
--- a/mini-lsm-mvcc/src/key.rs
+++ b/mini-lsm-mvcc/src/key.rs
@@ -147,8 +147,13 @@ impl<'a> Key<&'a [u8]> {
         Key(self.0.to_vec(), self.1)
     }
 
-    /// Create a key slice from a slice. Will be removed in week 3.
-    pub fn from_slice(slice: &'a [u8], ts: u64) -> Self {
+    /// Create a key slice from a slice with the default timestamp.
+    pub fn from_slice(slice: &'a [u8]) -> Self {
+        Self(slice, TS_DEFAULT)
+    }
+
+    /// Create a key slice from a slice and an explicit timestamp.
+    pub fn from_slice_with_ts(slice: &'a [u8], ts: u64) -> Self {
         Self(slice, ts)
     }
 

--- a/mini-lsm-mvcc/src/lsm_storage.rs
+++ b/mini-lsm-mvcc/src/lsm_storage.rs
@@ -500,13 +500,13 @@ impl LsmStorageInner {
 
         let mut memtable_iters = Vec::with_capacity(snapshot.imm_memtables.len() + 1);
         memtable_iters.push(Box::new(snapshot.memtable.scan(
-            Bound::Included(KeySlice::from_slice(key, key::TS_RANGE_BEGIN)),
-            Bound::Included(KeySlice::from_slice(key, key::TS_RANGE_END)),
+            Bound::Included(KeySlice::from_slice_with_ts(key, key::TS_RANGE_BEGIN)),
+            Bound::Included(KeySlice::from_slice_with_ts(key, key::TS_RANGE_END)),
         )));
         for memtable in snapshot.imm_memtables.iter() {
             memtable_iters.push(Box::new(memtable.scan(
-                Bound::Included(KeySlice::from_slice(key, key::TS_RANGE_BEGIN)),
-                Bound::Included(KeySlice::from_slice(key, key::TS_RANGE_END)),
+                Bound::Included(KeySlice::from_slice_with_ts(key, key::TS_RANGE_BEGIN)),
+                Bound::Included(KeySlice::from_slice_with_ts(key, key::TS_RANGE_END)),
             )));
         }
         let memtable_iter = MergeIterator::create(memtable_iters);
@@ -535,7 +535,7 @@ impl LsmStorageInner {
             if keep_table(key, &table) {
                 l0_iters.push(Box::new(SsTableIterator::create_and_seek_to_key(
                     table,
-                    KeySlice::from_slice(key, key::TS_RANGE_BEGIN),
+                    KeySlice::from_slice_with_ts(key, key::TS_RANGE_BEGIN),
                 )?));
             }
         }
@@ -551,7 +551,7 @@ impl LsmStorageInner {
             }
             let level_iter = SstConcatIterator::create_and_seek_to_key(
                 level_ssts,
-                KeySlice::from_slice(key, key::TS_RANGE_BEGIN),
+                KeySlice::from_slice_with_ts(key, key::TS_RANGE_BEGIN),
             )?;
             level_iters.push(Box::new(level_iter));
         }
@@ -584,14 +584,14 @@ impl LsmStorageInner {
                 WriteBatchRecord::Del(key) => {
                     let key = key.as_ref();
                     assert!(!key.is_empty(), "key cannot be empty");
-                    batch_datas.push((KeySlice::from_slice(key, ts), b""));
+                    batch_datas.push((KeySlice::from_slice_with_ts(key, ts), b""));
                 }
                 WriteBatchRecord::Put(key, value) => {
                     let key = key.as_ref();
                     let value = value.as_ref();
                     assert!(!key.is_empty(), "key cannot be empty");
                     assert!(!value.is_empty(), "value cannot be empty");
-                    batch_datas.push((KeySlice::from_slice(key, ts), value));
+                    batch_datas.push((KeySlice::from_slice_with_ts(key, ts), value));
                 }
             }
         }
@@ -823,12 +823,12 @@ impl LsmStorageInner {
                 let iter = match lower {
                     Bound::Included(key) => SsTableIterator::create_and_seek_to_key(
                         table,
-                        KeySlice::from_slice(key, key::TS_RANGE_BEGIN),
+                        KeySlice::from_slice_with_ts(key, key::TS_RANGE_BEGIN),
                     )?,
                     Bound::Excluded(key) => {
                         let mut iter = SsTableIterator::create_and_seek_to_key(
                             table,
-                            KeySlice::from_slice(key, key::TS_RANGE_BEGIN),
+                            KeySlice::from_slice_with_ts(key, key::TS_RANGE_BEGIN),
                         )?;
                         // TODO: we can implement `key.next()` so that we can directly seek to the
                         // right place in the previous line.
@@ -863,12 +863,12 @@ impl LsmStorageInner {
             let level_iter = match lower {
                 Bound::Included(key) => SstConcatIterator::create_and_seek_to_key(
                     level_ssts,
-                    KeySlice::from_slice(key, key::TS_RANGE_BEGIN),
+                    KeySlice::from_slice_with_ts(key, key::TS_RANGE_BEGIN),
                 )?,
                 Bound::Excluded(key) => {
                     let mut iter = SstConcatIterator::create_and_seek_to_key(
                         level_ssts,
-                        KeySlice::from_slice(key, key::TS_RANGE_BEGIN),
+                        KeySlice::from_slice_with_ts(key, key::TS_RANGE_BEGIN),
                     )?;
                     while iter.is_valid() && iter.key().key_ref() == key {
                         iter.next()?;

--- a/mini-lsm-mvcc/src/mem_table.rs
+++ b/mini-lsm-mvcc/src/mem_table.rs
@@ -71,8 +71,8 @@ pub(crate) fn map_key_bound_plus_ts<'a>(
 ) -> (Bound<KeySlice<'a>>, Bound<KeySlice<'a>>) {
     (
         match lower {
-            Bound::Included(x) => Bound::Included(KeySlice::from_slice(x, ts)),
-            Bound::Excluded(x) => Bound::Excluded(KeySlice::from_slice(x, TS_RANGE_END)),
+            Bound::Included(x) => Bound::Included(KeySlice::from_slice_with_ts(x, ts)),
+            Bound::Excluded(x) => Bound::Excluded(KeySlice::from_slice_with_ts(x, TS_RANGE_END)),
             Bound::Unbounded => Bound::Unbounded,
         },
         match upper {
@@ -80,9 +80,9 @@ pub(crate) fn map_key_bound_plus_ts<'a>(
                 // Note that we order the ts descending, but for a MVCC scan, we need all the history
                 // so that we can access the latest key in case it is not updated in the current ts.
                 // Therefore, we need to scan all the way to ts 0.
-                Bound::Included(KeySlice::from_slice(x, TS_RANGE_END))
+                Bound::Included(KeySlice::from_slice_with_ts(x, TS_RANGE_END))
             }
-            Bound::Excluded(x) => Bound::Excluded(KeySlice::from_slice(x, TS_RANGE_BEGIN)),
+            Bound::Excluded(x) => Bound::Excluded(KeySlice::from_slice_with_ts(x, TS_RANGE_BEGIN)),
             Bound::Unbounded => Bound::Unbounded,
         },
     )
@@ -130,11 +130,11 @@ impl MemTable {
     }
 
     pub fn for_testing_put_slice(&self, key: &[u8], value: &[u8]) -> Result<()> {
-        self.put(KeySlice::from_slice(key, TS_DEFAULT), value)
+        self.put(KeySlice::from_slice_with_ts(key, TS_DEFAULT), value)
     }
 
     pub fn for_testing_get_slice(&self, key: &[u8]) -> Option<Bytes> {
-        self.get(KeySlice::from_slice(key, TS_DEFAULT))
+        self.get(KeySlice::from_slice_with_ts(key, TS_DEFAULT))
     }
 
     pub fn for_testing_scan_slice(
@@ -143,8 +143,8 @@ impl MemTable {
         upper: Bound<&[u8]>,
     ) -> MemTableIterator {
         self.scan(
-            lower.map(|x| KeySlice::from_slice(x, TS_DEFAULT)),
-            upper.map(|x| KeySlice::from_slice(x, TS_DEFAULT)),
+            lower.map(|x| KeySlice::from_slice_with_ts(x, TS_DEFAULT)),
+            upper.map(|x| KeySlice::from_slice_with_ts(x, TS_DEFAULT)),
         )
     }
 

--- a/mini-lsm-mvcc/src/tests/week3_day1.rs
+++ b/mini-lsm-mvcc/src/tests/week3_day1.rs
@@ -25,14 +25,8 @@ use super::harness::{check_iter_result_by_key_and_ts, generate_sst_with_ts};
 #[test]
 fn test_sst_build_multi_version_simple() {
     let mut builder = SsTableBuilder::new(16);
-    builder.add(
-        KeySlice::for_testing_from_slice_with_ts(b"233", 233),
-        b"233333",
-    );
-    builder.add(
-        KeySlice::for_testing_from_slice_with_ts(b"233", 0),
-        b"2333333",
-    );
+    builder.add(KeySlice::from_slice_with_ts(b"233", 233), b"233333");
+    builder.add(KeySlice::from_slice_with_ts(b"233", 0), b"2333333");
     let dir = tempdir().unwrap();
     builder.build_for_test(dir.path().join("1.sst")).unwrap();
 }

--- a/mini-lsm-mvcc/src/tests/week3_day3.rs
+++ b/mini-lsm-mvcc/src/tests/week3_day3.rs
@@ -25,6 +25,43 @@ use crate::{
     tests::harness::check_lsm_iter_result_by_key,
 };
 
+fn check_all_range_bound_combinations(storage: &MiniLsm) {
+    check_lsm_iter_result_by_key(
+        &mut storage
+            .scan(Bound::Included(b"a"), Bound::Included(b"c"))
+            .unwrap(),
+        vec![
+            (Bytes::from("a"), Bytes::from("1")),
+            (Bytes::from("b"), Bytes::from("2")),
+            (Bytes::from("c"), Bytes::from("3")),
+        ],
+    );
+    check_lsm_iter_result_by_key(
+        &mut storage
+            .scan(Bound::Included(b"a"), Bound::Excluded(b"c"))
+            .unwrap(),
+        vec![
+            (Bytes::from("a"), Bytes::from("1")),
+            (Bytes::from("b"), Bytes::from("2")),
+        ],
+    );
+    check_lsm_iter_result_by_key(
+        &mut storage
+            .scan(Bound::Excluded(b"a"), Bound::Included(b"c"))
+            .unwrap(),
+        vec![
+            (Bytes::from("b"), Bytes::from("2")),
+            (Bytes::from("c"), Bytes::from("3")),
+        ],
+    );
+    check_lsm_iter_result_by_key(
+        &mut storage
+            .scan(Bound::Excluded(b"a"), Bound::Excluded(b"c"))
+            .unwrap(),
+        vec![(Bytes::from("b"), Bytes::from("2"))],
+    );
+}
+
 #[test]
 fn test_task2_memtable_mvcc() {
     let dir = tempdir().unwrap();
@@ -327,6 +364,32 @@ fn test_task2_lsm_iterator_mvcc() {
             .unwrap(),
         vec![],
     );
+}
+
+#[test]
+fn test_task2_all_range_bounds_across_l0_and_level_ssts() {
+    let dir = tempdir().unwrap();
+    let options = LsmStorageOptions::default_for_week2_test(CompactionOptions::NoCompaction);
+    let storage = MiniLsm::open(&dir, options).unwrap();
+    storage.put(b"a", b"1").unwrap();
+    storage.put(b"b", b"2").unwrap();
+    storage.put(b"c", b"3").unwrap();
+
+    storage.force_flush().unwrap();
+    {
+        let state = storage.inner.state.read();
+        assert!(!state.l0_sstables.is_empty());
+        assert!(state.levels[0].1.is_empty());
+    }
+    check_all_range_bound_combinations(&storage);
+
+    storage.force_full_compaction().unwrap();
+    {
+        let state = storage.inner.state.read();
+        assert!(state.l0_sstables.is_empty());
+        assert!(!state.levels[0].1.is_empty());
+    }
+    check_all_range_bound_combinations(&storage);
 }
 
 #[test]

--- a/mini-lsm-mvcc/src/tests/week3_day3.rs
+++ b/mini-lsm-mvcc/src/tests/week3_day3.rs
@@ -395,12 +395,12 @@ fn test_task2_all_range_bounds_across_l0_and_level_ssts() {
 #[test]
 fn test_task3_sst_ts() {
     let mut builder = SsTableBuilder::new(16);
-    builder.add(KeySlice::for_testing_from_slice_with_ts(b"11", 1), b"11");
-    builder.add(KeySlice::for_testing_from_slice_with_ts(b"22", 2), b"22");
-    builder.add(KeySlice::for_testing_from_slice_with_ts(b"33", 3), b"11");
-    builder.add(KeySlice::for_testing_from_slice_with_ts(b"44", 4), b"22");
-    builder.add(KeySlice::for_testing_from_slice_with_ts(b"55", 5), b"11");
-    builder.add(KeySlice::for_testing_from_slice_with_ts(b"66", 6), b"22");
+    builder.add(KeySlice::from_slice_with_ts(b"11", 1), b"11");
+    builder.add(KeySlice::from_slice_with_ts(b"22", 2), b"22");
+    builder.add(KeySlice::from_slice_with_ts(b"33", 3), b"11");
+    builder.add(KeySlice::from_slice_with_ts(b"44", 4), b"22");
+    builder.add(KeySlice::from_slice_with_ts(b"55", 5), b"11");
+    builder.add(KeySlice::from_slice_with_ts(b"66", 6), b"22");
     let dir = tempdir().unwrap();
     let sst = builder.build_for_test(dir.path().join("1.sst")).unwrap();
     assert_eq!(sst.max_ts(), 6);

--- a/mini-lsm-mvcc/src/tests/week3_day5.rs
+++ b/mini-lsm-mvcc/src/tests/week3_day5.rs
@@ -149,15 +149,14 @@ fn test_task4_wal_batch_round_trip() {
 }
 
 #[test]
-fn test_task4_wal_rejects_truncated_or_corrupt_batch_without_applying_it() {
+fn test_task4_wal_ignores_and_truncates_incomplete_final_batch() {
     let dir = tempdir().unwrap();
     let path = dir.path().join("test.wal");
     let wal = Wal::create(&path).unwrap();
-    wal.put_batch(&[
-        (KeySlice::from_slice(b"a", 2), b"1"),
-        (KeySlice::from_slice(b"b", 2), b"2"),
-    ])
-    .unwrap();
+    let a = KeyBytes::from_bytes_with_ts(Bytes::from_static(b"a"), 2);
+    let b = KeyBytes::from_bytes_with_ts(Bytes::from_static(b"b"), 2);
+    wal.put_batch(&[(a.as_key_slice(), b"1"), (b.as_key_slice(), b"2")])
+        .unwrap();
     wal.sync().unwrap();
     drop(wal);
 
@@ -169,18 +168,115 @@ fn test_task4_wal_rejects_truncated_or_corrupt_batch_without_applying_it() {
         let truncated_path = dir.path().join(format!("truncated-{idx}.wal"));
         std::fs::write(&truncated_path, &encoded[..cutoff]).unwrap();
         let map = SkipMap::<KeyBytes, Bytes>::new();
-        assert!(Wal::recover(&truncated_path, &map).is_err());
+        drop(Wal::recover(&truncated_path, &map).unwrap());
         assert!(map.is_empty());
+        assert_eq!(std::fs::metadata(&truncated_path).unwrap().len(), 0);
     }
+}
+
+#[test]
+fn test_task4_wal_rejects_corrupt_batch_without_applying_it() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("test.wal");
+    let wal = Wal::create(&path).unwrap();
+    wal.put_batch(&[
+        (KeySlice::from_slice(b"a", 2), b"1"),
+        (KeySlice::from_slice(b"b", 2), b"2"),
+    ])
+    .unwrap();
+    wal.sync().unwrap();
+    drop(wal);
 
     let corrupt_path = dir.path().join("corrupt.wal");
-    let mut corrupt = encoded;
+    let mut corrupt = std::fs::read(&path).unwrap();
     let checksum_byte = corrupt.last_mut().unwrap();
     *checksum_byte ^= 0xff;
     std::fs::write(&corrupt_path, corrupt).unwrap();
     let map = SkipMap::<KeyBytes, Bytes>::new();
     assert!(Wal::recover(&corrupt_path, &map).is_err());
     assert!(map.is_empty());
+}
+
+#[test]
+fn test_task4_wal_recovery_is_atomic_across_frames() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("test.wal");
+    let wal = Wal::create(&path).unwrap();
+    let first_key = KeyBytes::from_bytes_with_ts(Bytes::from_static(b"first"), 1);
+    wal.put_batch(&[(first_key.as_key_slice(), b"committed")])
+        .unwrap();
+    wal.sync().unwrap();
+    let first_frame_len = std::fs::read(&path).unwrap().len();
+
+    let second_key = KeyBytes::from_bytes_with_ts(Bytes::from_static(b"second"), 2);
+    wal.put_batch(&[(second_key.as_key_slice(), b"torn")])
+        .unwrap();
+    wal.sync().unwrap();
+    drop(wal);
+
+    let encoded = std::fs::read(&path).unwrap();
+    assert!(encoded.len() > first_frame_len + std::mem::size_of::<u32>());
+
+    for (idx, cutoff) in [
+        first_frame_len + 1,
+        first_frame_len + std::mem::size_of::<u32>() + 1,
+        encoded.len() - 1,
+    ]
+    .into_iter()
+    .enumerate()
+    {
+        let truncated_path = dir.path().join(format!("two-frame-truncated-{idx}.wal"));
+        std::fs::write(&truncated_path, &encoded[..cutoff]).unwrap();
+        let map = SkipMap::<KeyBytes, Bytes>::new();
+        drop(Wal::recover(&truncated_path, &map).unwrap());
+        assert_eq!(map.len(), 1);
+        assert_eq!(
+            map.get(&first_key).unwrap().value(),
+            &Bytes::from_static(b"committed")
+        );
+        assert!(map.get(&second_key).is_none());
+        assert_eq!(
+            std::fs::metadata(&truncated_path).unwrap().len(),
+            first_frame_len as u64
+        );
+    }
+
+    let corrupt_path = dir.path().join("two-frame-corrupt.wal");
+    let mut corrupt = encoded;
+    *corrupt.last_mut().unwrap() ^= 0xff;
+    std::fs::write(&corrupt_path, corrupt).unwrap();
+    let map = SkipMap::<KeyBytes, Bytes>::new();
+    assert!(Wal::recover(&corrupt_path, &map).is_err());
+    assert_eq!(map.len(), 1);
+    assert_eq!(
+        map.get(&first_key).unwrap().value(),
+        &Bytes::from_static(b"committed")
+    );
+    assert!(map.get(&second_key).is_none());
+
+    let invalid_length_path = dir.path().join("two-frame-invalid-length.wal");
+    let mut invalid_length = std::fs::read(&path).unwrap();
+    let second_batch_size = u32::from_be_bytes(
+        invalid_length[first_frame_len..first_frame_len + std::mem::size_of::<u32>()]
+            .try_into()
+            .unwrap(),
+    ) as usize;
+    let second_batch_start = first_frame_len + std::mem::size_of::<u32>();
+    invalid_length[second_batch_start..second_batch_start + std::mem::size_of::<u16>()]
+        .copy_from_slice(&u16::MAX.to_be_bytes());
+    let second_checksum_start = second_batch_start + second_batch_size;
+    let checksum = crc32fast::hash(&invalid_length[second_batch_start..second_checksum_start]);
+    invalid_length[second_checksum_start..second_checksum_start + std::mem::size_of::<u32>()]
+        .copy_from_slice(&checksum.to_be_bytes());
+    std::fs::write(&invalid_length_path, invalid_length).unwrap();
+    let map = SkipMap::<KeyBytes, Bytes>::new();
+    assert!(Wal::recover(&invalid_length_path, &map).is_err());
+    assert_eq!(map.len(), 1);
+    assert_eq!(
+        map.get(&first_key).unwrap().value(),
+        &Bytes::from_static(b"committed")
+    );
+    assert!(map.get(&second_key).is_none());
 }
 
 #[test]

--- a/mini-lsm-mvcc/src/tests/week3_day5.rs
+++ b/mini-lsm-mvcc/src/tests/week3_day5.rs
@@ -108,11 +108,11 @@ fn test_task4_batch_uses_one_memtable_and_timestamp() {
     let state = storage.state.read();
     assert_eq!(state.imm_memtables.len(), 1);
     assert_eq!(
-        state.imm_memtables[0].get(KeySlice::from_slice(b"a", commit_ts)),
+        state.imm_memtables[0].get(KeySlice::from_slice_with_ts(b"a", commit_ts)),
         Some(Bytes::from_static(b"1"))
     );
     assert_eq!(
-        state.imm_memtables[0].get(KeySlice::from_slice(b"b", commit_ts)),
+        state.imm_memtables[0].get(KeySlice::from_slice_with_ts(b"b", commit_ts)),
         Some(Bytes::from_static(b"2"))
     );
 }
@@ -123,8 +123,8 @@ fn test_task4_wal_batch_round_trip() {
     let path = dir.path().join("test.wal");
     let wal = Wal::create(&path).unwrap();
     wal.put_batch(&[
-        (KeySlice::from_slice(b"a", 2), b"1"),
-        (KeySlice::from_slice(b"b", 2), b""),
+        (KeySlice::from_slice_with_ts(b"a", 2), b"1"),
+        (KeySlice::from_slice_with_ts(b"b", 2), b""),
     ])
     .unwrap();
     wal.sync().unwrap();
@@ -180,8 +180,8 @@ fn test_task4_wal_rejects_corrupt_batch_without_applying_it() {
     let path = dir.path().join("test.wal");
     let wal = Wal::create(&path).unwrap();
     wal.put_batch(&[
-        (KeySlice::from_slice(b"a", 2), b"1"),
-        (KeySlice::from_slice(b"b", 2), b"2"),
+        (KeySlice::from_slice_with_ts(b"a", 2), b"1"),
+        (KeySlice::from_slice_with_ts(b"b", 2), b"2"),
     ])
     .unwrap();
     wal.sync().unwrap();
@@ -286,7 +286,10 @@ fn test_task4_wal_rejects_oversized_fields() {
     let wal = Wal::create(&path).unwrap();
     let oversized_value = vec![0; usize::from(u16::MAX) + 1];
     assert!(
-        wal.put_batch(&[(KeySlice::from_slice(b"key", 1), oversized_value.as_slice(),)])
-            .is_err()
+        wal.put_batch(&[(
+            KeySlice::from_slice_with_ts(b"key", 1),
+            oversized_value.as_slice(),
+        )])
+        .is_err()
     );
 }

--- a/mini-lsm-mvcc/src/wal.rs
+++ b/mini-lsm-mvcc/src/wal.rs
@@ -53,16 +53,18 @@ impl Wal {
         let mut buf = Vec::new();
         file.read_to_end(&mut buf)?;
         let mut rbuf: &[u8] = buf.as_slice();
+        let mut valid_len = 0;
+        let mut has_truncated_tail = false;
         while rbuf.has_remaining() {
-            ensure!(
-                rbuf.remaining() >= std::mem::size_of::<u32>(),
-                "incomplete WAL batch header"
-            );
+            if rbuf.remaining() < std::mem::size_of::<u32>() {
+                has_truncated_tail = true;
+                break;
+            }
             let batch_size = rbuf.get_u32() as usize;
-            ensure!(
-                batch_size <= rbuf.remaining().saturating_sub(std::mem::size_of::<u32>()),
-                "incomplete WAL batch"
-            );
+            if batch_size > rbuf.remaining().saturating_sub(std::mem::size_of::<u32>()) {
+                has_truncated_tail = true;
+                break;
+            }
             let mut batch_buf = &rbuf[..batch_size];
             let mut kv_pairs = Vec::new();
             let mut hasher = crc32fast::Hasher::new();
@@ -104,6 +106,14 @@ impl Wal {
             for (key, ts, value) in kv_pairs {
                 skiplist.insert(KeyBytes::from_bytes_with_ts(key, ts), value);
             }
+            valid_len = buf.len() - rbuf.len();
+        }
+        if has_truncated_tail {
+            eprintln!("warning: ignoring incomplete WAL frame at byte offset {valid_len}");
+            file.set_len(valid_len as u64)
+                .context("failed to truncate incomplete WAL tail")?;
+            file.sync_all()
+                .context("failed to sync truncated WAL tail")?;
         }
         Ok(Self {
             file: Arc::new(Mutex::new(BufWriter::new(file))),


### PR DESCRIPTION
## What

- Standardize Week 3 timestamped keys on `KeySlice::from_slice_with_ts` so tests copy without rewrites.
- Test all four user-bound combinations through both L0 and leveled SSTs.
- Treat an incomplete final WAL frame as a crash tail: warn, truncate it, and replay the valid prefix. Fully present checksum or length corruption still fails.

## Why

Week 3 tests used inconsistent key constructors, range-bound coverage missed persisted storage paths, and WAL recovery treated crash-torn tails as corruption.

## Test

- `cargo x ci`
- `mini-lsm-book/sitemap.sh --check`
