### PR TITLE
Align coding-agent track status

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Mini-LSM focuses on the storage layer of a database. It does not cover SQL parsi
 | Path | Best for | Format | Status |
 | --- | --- | --- | --- |
 | [Guided course](https://skyzh.github.io/mini-lsm/00-overview.html) | Learners who want to implement and reason through each subsystem | Three weeks, with seven chapters per week | Complete |
-| [Coding-agent track](https://skyzh.github.io/mini-lsm/agent-fast-forward-overview.html) | Learners who want an agent to handle mechanical implementation without outsourcing system design | Three planned days built around decision stops, focused code slices, and adversarial tests | Days 1–2 available |
+| [Coding-agent track](https://skyzh.github.io/mini-lsm/agent-fast-forward-overview.html) | Learners who want an agent to handle mechanical implementation without outsourcing system design | Three planned days built around decision stops, focused code slices, and adversarial tests | Days 1–3 available (WIP) |
 
 You need basic Rust, but you do not need prior knowledge of LSM trees, compaction, MVCC, or transaction isolation. The course is a good fit if you have used systems such as PostgreSQL, MySQL, Redis, or RocksDB and want to understand what happens below their APIs.
 


### PR DESCRIPTION
## Why

The README still says only Days 1–2 are available even though the book now publishes all three coding-agent days.

## Change

Mark Days 1–3 available while retaining the track’s WIP qualification.

_AI-assisted: Codex._