### PR TITLE
Make leveled simulator traces reproducible

### DIFF
--- a/mini-lsm-book/src/week2-04-leveled.md
+++ b/mini-lsm-book/src/week2-04-leveled.md
@@ -53,11 +53,17 @@ In this chapter, you will implement a more realistic leveled compaction strategy
 src/compact/leveled.rs
 ```
 
-To run the compaction simulator,
+To run the compaction simulator with a recorded workload seed,
 
+```shell
+cargo run --locked --bin compaction-simulator -- leveled --seed 42
 ```
-cargo run --bin compaction-simulator leveled
-```
+
+The seed controls the mock SST key ranges. When you compare learner and
+reference output, run both binaries from the same checkout and `Cargo.lock`
+with the same explicit seed. Changing the seed changes the workload. The
+default is `42`, but include `--seed` in saved evidence so another person can
+replay it.
 
 ### Task 1.1: Compute Target Sizes
 
@@ -148,7 +154,9 @@ After choosing the upper SST, find every lower-level SST whose key range overlap
 
 When compaction completes, remove the selected files and insert the outputs in the correct lower-level position. In every level except L0, keep SST IDs ordered by first key.
 
-Running the compaction simulator, you should see:
+Running the compaction simulator, you should see the same structural behavior.
+The IDs and key ranges in this excerpt are illustrative; compare exact values
+only when the source revision, lockfile, options, and seed are the same:
 
 ```
 --- After Compaction ---

--- a/mini-lsm-book/src/week2-fast-forward.md
+++ b/mini-lsm-book/src/week2-fast-forward.md
@@ -158,8 +158,13 @@ Use these simulator commands without consulting the reference implementation:
 ```shell
 cargo run --bin compaction-simulator simple
 cargo run --bin compaction-simulator tiered
-cargo run --bin compaction-simulator leveled
+cargo run --locked --bin compaction-simulator -- leveled --seed 42
 ```
+
+The leveled simulator's seed controls its mock SST key ranges. Record the seed
+with the trace, and use the same source checkout, `Cargo.lock`, options, and
+seed for any authorized learner/reference comparison. A different seed is a
+different workload.
 
 For at least one trace per policy, annotate the selected inputs, the reason the task fired, whether it reaches the bottom, the source that wins equal keys, and the files that remain afterward. Change one threshold and predict the next task before rerunning the simulator.
 

--- a/mini-lsm-mvcc/agent-walkthroughs/week2.md
+++ b/mini-lsm-mvcc/agent-walkthroughs/week2.md
@@ -1,5 +1,13 @@
 # Week 2 Student–Apprentice Walkthrough
 
+> **Archive reproducibility note:** The dynamic-leveled simulator commands and
+> exact amplification/space figures captured below predate the simulator's
+> `--seed` option. Treat those numbers as historical observations, not
+> reproducible evidence. To reproduce a current trace, run learner and
+> reference binaries from the same source revision and `Cargo.lock` with the
+> same explicit `--seed` and options. The simple and tiered traces do not
+> generate random key ranges and are unaffected.
+
 ## Setup
 
 ### Student
@@ -1861,6 +1869,10 @@ Trace annotation (`max_levels=4`, `base_level_size_mb=128`, multiplier 2, 32 MiB
 - The L0 tasks select every L4 SST overlapping the combined L0 key envelope. The observed broad envelopes select zero, two, and then four lower SSTs, respectively; outputs are restored in first-key order.
 - Final level counts are `L0=0, L1=0, L2=0, L3=0, L4=6`; the trace reports 3.000x write amplification, 2.000x maximum space usage, and 1x read amplification.
 
+> **Archive note:** This run did not record a workload seed. Its exact
+> amplification and space figures are illustrative and must not be used as
+> reproducible comparison evidence.
+
 Important expression (`src/compact/leveled.rs:68`):
 
 ```rust
@@ -3590,6 +3602,10 @@ Observed outcome: exit status 0 for the combined command.
 - Simple leveled performed cascade compactions at iterations 1 and 3 and two compactions at iteration 5; its final level counts were `0 0 2 4`, with 4.000x write amplification, 1.333x maximum space amplification, and 2x read amplification.
 - Tiered accumulated eight single-SST tiers through iteration 7, then compacted all eight into eight output SSTs; its final level counts were `0 8`, with 2.000x write amplification, 2.000x maximum space amplification, and 1x read amplification.
 - Leveled triggered L0-to-L4 compactions at iterations 1, 3, and 5; its final level counts were `0 0 0 0 6`, with 2.667x write amplification, 1.667x maximum space amplification, and 1x read amplification.
+
+> **Archive note:** The leveled command above did not record a workload seed.
+> Its exact amplification and space figures are illustrative; reproduce the
+> workload with the current explicit-seed command before making a comparison.
 
 ### 78. Re-run the six focused Checkpoint 4 tests after restoring the fault
 

--- a/mini-lsm-starter/src/bin/compaction-simulator.rs
+++ b/mini-lsm-starter/src/bin/compaction-simulator.rs
@@ -28,6 +28,8 @@ use mini_lsm_wrapper::key::KeyBytes;
 use mini_lsm_wrapper::lsm_storage::LsmStorageState;
 use mini_lsm_wrapper::mem_table::MemTable;
 use mini_lsm_wrapper::table::SsTable;
+use rand::rngs::StdRng;
+use rand::{Rng, RngExt, SeedableRng};
 
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
@@ -102,6 +104,10 @@ enum Args {
         iterations: usize,
         #[clap(long, default_value = "32")]
         sst_size_mb: usize,
+        /// Seed for the mock SST key ranges. Use the same seed when comparing
+        /// learner and reference output.
+        #[clap(long, default_value = "42")]
+        seed: u64,
     },
 }
 
@@ -236,15 +242,13 @@ impl MockStorage {
     }
 }
 
-fn generate_random_key_range() -> (KeyBytes, KeyBytes) {
-    use rand::RngExt;
-    let mut rng = rand::rng();
-    let begin: usize = rng.random_range(0..(1 << 31));
-    let end: usize = begin + rng.random_range((1 << 10)..(1 << 31));
+fn generate_random_key_range<R: Rng + ?Sized>(rng: &mut R) -> (KeyBytes, KeyBytes) {
+    let begin: u64 = rng.random_range(0..(1 << 31));
+    let end: u64 = begin + rng.random_range((1 << 10)..(1 << 31));
     let mut begin_bytes = BytesMut::new();
     let mut end_bytes = BytesMut::new();
-    begin_bytes.put_u64(begin as u64);
-    end_bytes.put_u64(end as u64);
+    begin_bytes.put_u64(begin);
+    end_bytes.put_u64(end);
     (
         KeyBytes::for_testing_from_bytes_no_ts(begin_bytes.freeze()),
         KeyBytes::for_testing_from_bytes_no_ts(end_bytes.freeze()),
@@ -499,6 +503,7 @@ fn main() {
             base_level_size_mb,
             iterations,
             sst_size_mb,
+            seed,
         } => {
             let controller = LeveledCompactionController::new(LeveledCompactionOptions {
                 level0_file_num_compaction_trigger,
@@ -508,6 +513,8 @@ fn main() {
             });
 
             let mut storage = MockStorage::new();
+            let mut rng = StdRng::seed_from_u64(seed);
+            println!("Seed: {seed}");
             for i in 0..max_levels {
                 storage.snapshot.levels.push((i + 1, Vec::new()));
             }
@@ -515,7 +522,7 @@ fn main() {
             for i in 0..iterations {
                 println!("=== Iteration {i} ===");
                 let id = storage.flush_sst_to_l0();
-                let (first_key, last_key) = generate_random_key_range();
+                let (first_key, last_key) = generate_random_key_range(&mut rng);
                 storage.snapshot.sstables.insert(
                     id,
                     Arc::new(SsTable::create_meta_only(


### PR DESCRIPTION
## Why

The dynamic-leveled compaction simulator generated mock SST key ranges from an unseeded RNG. Identical learner/reference commands could therefore select different overlap sets and report different write/space amplification, while an archived walkthrough presented one unseeded run as exact evidence.

## What changed

- add an explicit `--seed <u64>` to the leveled simulator (default `42`), seed one shared RNG per run, and print the seed in the trace;
- document that learner/reference comparisons must use the same source revision, `Cargo.lock`, options, and explicit seed;
- mark the archived unseeded dynamic-leveled metrics as historical illustrations rather than reproducible evidence;
- keep simple and tiered simulator behavior unchanged.

Validation:

- `cargo x ci`: format/check/clippy, 159/159 standard+MVCC+xtask tests, and mdBook build passed;
- `mini-lsm-book/sitemap.sh --check`: passed;
- two 50-iteration standard reference runs at seed 42 were byte-identical (`f862b233…`), and the MVCC reference produced the same trace;
- seed 43 produced a different trace (`f5fcd3ad…`), proving the workload is seed-controlled;
- standard and MVCC simple/tiered 50-iteration traces remained byte-identical across each pair.

## Review note

The pristine starter has no copied tests, so `cargo x scheck` compiles successfully and then exits at Nextest's existing “no tests to run” condition. The repository's authoritative full-workspace CI gate is green. `mdbook test` is not a configured project gate and still fails on longstanding untagged shell/pseudocode fences in untouched chapters; mdBook build and sitemap checks pass.

AI-Assisted: GPT-5.6 Sol + Tuner
Reviewed-by: DeepSeek V4 Flash + Oracle (consistency)
Reviewed-by: GPT-5.6 Sol + Sage (correctness)
