### PR TITLE
Harden persisted-record recovery

### DIFF
--- a/mini-lsm-mvcc/src/block.rs
+++ b/mini-lsm-mvcc/src/block.rs
@@ -15,8 +15,9 @@
 mod builder;
 mod iterator;
 
+use anyhow::{Context, Result, ensure};
 pub use builder::BlockBuilder;
-use bytes::{Buf, BufMut, Bytes};
+use bytes::{BufMut, Bytes};
 pub use iterator::BlockIterator;
 
 pub(crate) const SIZEOF_U16: usize = std::mem::size_of::<u16>();
@@ -41,17 +42,83 @@ impl Block {
     }
 
     pub fn decode(data: &[u8]) -> Self {
+        Self::decode_checked(data).expect("invalid block encoding")
+    }
+
+    pub(crate) fn decode_checked(data: &[u8]) -> Result<Self> {
         // get number of elements in the block
-        let entry_offsets_len = (&data[data.len() - SIZEOF_U16..]).get_u16() as usize;
-        let data_end = data.len() - SIZEOF_U16 - entry_offsets_len * SIZEOF_U16;
+        ensure!(data.len() >= SIZEOF_U16, "block footer is truncated");
+        let entry_offsets_len =
+            u16::from_be_bytes([data[data.len() - 2], data[data.len() - 1]]) as usize;
+        ensure!(entry_offsets_len > 0, "block has no entries");
+        let offsets_size = entry_offsets_len
+            .checked_mul(SIZEOF_U16)
+            .context("block offset table is too large")?;
+        let footer_size = offsets_size
+            .checked_add(SIZEOF_U16)
+            .context("block footer is too large")?;
+        ensure!(footer_size <= data.len(), "block offset table is truncated");
+        let data_end = data.len() - footer_size;
         let offsets_raw = &data[data_end..data.len() - SIZEOF_U16];
         // get offset array
-        let offsets = offsets_raw
+        let offsets: Vec<u16> = offsets_raw
             .chunks(SIZEOF_U16)
-            .map(|mut x| x.get_u16())
+            .map(|x| u16::from_be_bytes([x[0], x[1]]))
             .collect();
+        ensure!(
+            offsets[0] == 0,
+            "first block entry must start at offset zero"
+        );
+        ensure!(
+            offsets.windows(2).all(|pair| pair[0] < pair[1]),
+            "block entry offsets are not strictly increasing"
+        );
+        ensure!(
+            offsets.iter().all(|offset| usize::from(*offset) < data_end),
+            "block entry offset is outside the data section"
+        );
+
+        let mut first_key_len = None;
+        for (idx, offset) in offsets.iter().enumerate() {
+            let entry_start = usize::from(*offset);
+            let entry_end = offsets
+                .get(idx + 1)
+                .map_or(data_end, |offset| usize::from(*offset));
+            let entry = &data[entry_start..entry_end];
+            ensure!(entry.len() >= 14, "block entry header is truncated");
+            let overlap = u16::from_be_bytes([entry[0], entry[1]]) as usize;
+            let key_len = u16::from_be_bytes([entry[2], entry[3]]) as usize;
+            if idx == 0 {
+                ensure!(overlap == 0, "first block key has a nonzero overlap");
+                first_key_len = Some(key_len);
+            } else {
+                ensure!(
+                    overlap <= first_key_len.context("block is missing its first key")?,
+                    "block key overlap exceeds the first key"
+                );
+            }
+            let key_end = 4usize
+                .checked_add(key_len)
+                .context("block key length overflow")?;
+            let value_len_offset = key_end
+                .checked_add(std::mem::size_of::<u64>())
+                .context("block timestamp offset overflow")?;
+            let value_len_end = value_len_offset
+                .checked_add(SIZEOF_U16)
+                .context("block value header overflow")?;
+            ensure!(
+                value_len_end <= entry.len(),
+                "block key, timestamp, or value length is truncated"
+            );
+            let value_len =
+                u16::from_be_bytes([entry[value_len_offset], entry[value_len_offset + 1]]) as usize;
+            let entry_len = value_len_end
+                .checked_add(value_len)
+                .context("block value length overflow")?;
+            ensure!(entry_len == entry.len(), "block value length is invalid");
+        }
         // retrieve data
         let data = data[0..data_end].to_vec();
-        Self { data, offsets }
+        Ok(Self { data, offsets })
     }
 }

--- a/mini-lsm-mvcc/src/block/builder.rs
+++ b/mini-lsm-mvcc/src/block/builder.rs
@@ -64,24 +64,41 @@ impl BlockBuilder {
     #[must_use]
     pub fn add(&mut self, key: KeySlice, value: &[u8]) -> bool {
         assert!(!key.is_empty(), "key must not be empty");
-        if self.estimated_size() + key.raw_len() + value.len() + SIZEOF_U16 * 3 /* key_len, value_len and offset */ > self.block_size
-            && !self.is_empty()
-        {
+        let Ok(key_len) = u16::try_from(key.key_len()) else {
+            return false;
+        };
+        let Ok(value_len) = u16::try_from(value.len()) else {
+            return false;
+        };
+        let entry_size = key
+            .raw_len()
+            .saturating_add(value.len())
+            .saturating_add(SIZEOF_U16 * 3);
+        let block_is_full = self.estimated_size().saturating_add(entry_size) > self.block_size;
+        let offset_is_full = self.data.len() > usize::from(u16::MAX);
+        let count_is_full = self.offsets.len() >= usize::from(u16::MAX);
+        if !self.is_empty() && (block_is_full || offset_is_full || count_is_full) {
             return false;
         }
         // Add the offset of the data into the offset array.
-        self.offsets.push(self.data.len() as u16);
+        let Ok(offset) = u16::try_from(self.data.len()) else {
+            return false;
+        };
+        self.offsets.push(offset);
         let overlap = compute_overlap(self.first_key.as_key_slice(), key);
+        let Ok(overlap) = u16::try_from(overlap) else {
+            return false;
+        };
         // Encode key overlap.
-        self.data.put_u16(overlap as u16);
+        self.data.put_u16(overlap);
         // Encode key length.
-        self.data.put_u16((key.key_len() - overlap) as u16);
+        self.data.put_u16(key_len - overlap);
         // Encode key content.
-        self.data.put(&key.key_ref()[overlap..]);
+        self.data.put(&key.key_ref()[usize::from(overlap)..]);
         // Encode key ts
         self.data.put_u64(key.ts());
         // Encode value length.
-        self.data.put_u16(value.len() as u16);
+        self.data.put_u16(value_len);
         // Encode value content.
         self.data.put(value);
 

--- a/mini-lsm-mvcc/src/lsm_storage.rs
+++ b/mini-lsm-mvcc/src/lsm_storage.rs
@@ -19,7 +19,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::atomic::AtomicUsize;
 
-use anyhow::{Context, Result};
+use anyhow::{Context, Result, ensure};
 use bytes::Bytes;
 use parking_lot::{Mutex, MutexGuard, RwLock};
 
@@ -61,6 +61,36 @@ pub struct LsmStorageState {
 pub enum WriteBatchRecord<T: AsRef<[u8]>> {
     Put(T, T),
     Del(T),
+}
+
+fn validate_write_batch<T: AsRef<[u8]>>(batch: &[WriteBatchRecord<T>]) -> Result<()> {
+    let mut encoded_batch_len = 0usize;
+    for record in batch {
+        let (key, value) = match record {
+            WriteBatchRecord::Put(key, value) => (key.as_ref(), value.as_ref()),
+            WriteBatchRecord::Del(key) => (key.as_ref(), &[][..]),
+        };
+        ensure!(
+            u16::try_from(key.len()).is_ok(),
+            "key is too large for the on-disk format"
+        );
+        ensure!(
+            u16::try_from(value.len()).is_ok(),
+            "value is too large for the on-disk format"
+        );
+        encoded_batch_len = encoded_batch_len
+            .checked_add(std::mem::size_of::<u16>())
+            .and_then(|len| len.checked_add(key.len()))
+            .and_then(|len| len.checked_add(std::mem::size_of::<u64>()))
+            .and_then(|len| len.checked_add(std::mem::size_of::<u16>()))
+            .and_then(|len| len.checked_add(value.len()))
+            .context("write batch size overflow")?;
+    }
+    ensure!(
+        u32::try_from(encoded_batch_len).is_ok(),
+        "write batch is too large for the on-disk format"
+    );
+    Ok(())
 }
 
 impl LsmStorageState {
@@ -575,6 +605,7 @@ impl LsmStorageInner {
         if batch.is_empty() {
             return Ok(self.mvcc().latest_commit_ts());
         }
+        validate_write_batch(batch)?;
         let _lck = self.mvcc().write_lock.lock();
         let ts = self.mvcc().latest_commit_ts() + 1;
         let mut batch_datas: Vec<(key::Key<&[u8]>, &[u8])> = vec![];

--- a/mini-lsm-mvcc/src/manifest.rs
+++ b/mini-lsm-mvcc/src/manifest.rs
@@ -18,7 +18,7 @@ use std::path::Path;
 use std::sync::Arc;
 
 use anyhow::{Context, Result, bail};
-use bytes::{Buf, BufMut};
+use bytes::BufMut;
 use parking_lot::{Mutex, MutexGuard};
 use serde::{Deserialize, Serialize};
 
@@ -57,18 +57,63 @@ impl Manifest {
             .context("failed to recover manifest")?;
         let mut buf = Vec::new();
         file.read_to_end(&mut buf)?;
-        let mut buf_ptr = buf.as_slice();
         let mut records = Vec::new();
-        while buf_ptr.has_remaining() {
-            let len = buf_ptr.get_u64();
-            let slice = &buf_ptr[..len as usize];
-            let json = serde_json::from_slice::<ManifestRecord>(slice)?;
-            buf_ptr.advance(len as usize);
-            let checksum = buf_ptr.get_u32();
-            if checksum != crc32fast::hash(slice) {
-                bail!("checksum mismatched!");
+        let mut valid_len = 0usize;
+        while valid_len < buf.len() {
+            let remaining = &buf[valid_len..];
+            if remaining.len() < std::mem::size_of::<u64>() {
+                break;
             }
-            records.push(json);
+
+            let len = u64::from_be_bytes([
+                remaining[0],
+                remaining[1],
+                remaining[2],
+                remaining[3],
+                remaining[4],
+                remaining[5],
+                remaining[6],
+                remaining[7],
+            ]);
+            let Ok(len) = usize::try_from(len) else {
+                break;
+            };
+            let Some(frame_len) = std::mem::size_of::<u64>()
+                .checked_add(len)
+                .and_then(|len| len.checked_add(std::mem::size_of::<u32>()))
+            else {
+                break;
+            };
+            if remaining.len() < frame_len {
+                break;
+            }
+
+            let body_start = std::mem::size_of::<u64>();
+            let body_end = body_start + len;
+            let body = &remaining[body_start..body_end];
+            let checksum = u32::from_be_bytes([
+                remaining[body_end],
+                remaining[body_end + 1],
+                remaining[body_end + 2],
+                remaining[body_end + 3],
+            ]);
+            if checksum != crc32fast::hash(body) {
+                bail!("manifest checksum mismatched at byte offset {valid_len}");
+            }
+            records.push(
+                serde_json::from_slice::<ManifestRecord>(body).with_context(|| {
+                    format!("invalid manifest record at byte offset {valid_len}")
+                })?,
+            );
+            valid_len += frame_len;
+        }
+
+        if valid_len < buf.len() {
+            eprintln!("warning: ignoring incomplete manifest frame at byte offset {valid_len}");
+            file.set_len(valid_len as u64)
+                .context("failed to truncate incomplete manifest tail")?;
+            file.sync_all()
+                .context("failed to sync truncated manifest tail")?;
         }
         Ok((
             Self {
@@ -90,7 +135,8 @@ impl Manifest {
         let mut file = self.file.lock();
         let mut buf = serde_json::to_vec(&record)?;
         let hash = crc32fast::hash(&buf);
-        file.write_all(&(buf.len() as u64).to_be_bytes())?;
+        let len = u64::try_from(buf.len()).context("manifest record is too large")?;
+        file.write_all(&len.to_be_bytes())?;
         buf.put_u32(hash);
         file.write_all(&buf)?;
         file.sync_all()?;

--- a/mini-lsm-mvcc/src/table.rs
+++ b/mini-lsm-mvcc/src/table.rs
@@ -20,9 +20,9 @@ use std::fs::File;
 use std::path::Path;
 use std::sync::Arc;
 
-use anyhow::{Result, anyhow, bail};
+use anyhow::{Context, Result, anyhow, bail, ensure};
 pub use builder::SsTableBuilder;
-use bytes::{Buf, BufMut};
+use bytes::BufMut;
 pub use iterator::SsTableIterator;
 
 use crate::block::Block;
@@ -30,6 +30,30 @@ use crate::key::{KeyBytes, KeySlice};
 use crate::lsm_storage::BlockCache;
 
 use self::bloom::Bloom;
+
+fn take_bytes<'a>(buf: &mut &'a [u8], len: usize, what: &str) -> Result<&'a [u8]> {
+    ensure!(buf.len() >= len, "{what} is truncated");
+    let (value, rest) = buf.split_at(len);
+    *buf = rest;
+    Ok(value)
+}
+
+fn take_u16(buf: &mut &[u8], what: &str) -> Result<u16> {
+    let value = take_bytes(buf, std::mem::size_of::<u16>(), what)?;
+    Ok(u16::from_be_bytes([value[0], value[1]]))
+}
+
+fn take_u32(buf: &mut &[u8], what: &str) -> Result<u32> {
+    let value = take_bytes(buf, std::mem::size_of::<u32>(), what)?;
+    Ok(u32::from_be_bytes([value[0], value[1], value[2], value[3]]))
+}
+
+fn take_u64(buf: &mut &[u8], what: &str) -> Result<u64> {
+    let value = take_bytes(buf, std::mem::size_of::<u64>(), what)?;
+    Ok(u64::from_be_bytes([
+        value[0], value[1], value[2], value[3], value[4], value[5], value[6], value[7],
+    ]))
+}
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct BlockMeta {
@@ -43,7 +67,11 @@ pub struct BlockMeta {
 
 impl BlockMeta {
     /// Encode block meta to a buffer.
-    pub fn encode_block_meta(block_meta: &[BlockMeta], max_ts: u64, buf: &mut Vec<u8>) {
+    pub fn encode_block_meta(
+        block_meta: &[BlockMeta],
+        max_ts: u64,
+        buf: &mut Vec<u8>,
+    ) -> Result<()> {
         let mut estimated_size = std::mem::size_of::<u32>(); // number of blocks
         for meta in block_meta {
             // The size of offset
@@ -64,44 +92,80 @@ impl BlockMeta {
         // large
         buf.reserve(estimated_size);
         let original_len = buf.len();
-        buf.put_u32(block_meta.len() as u32);
+        buf.put_u32(u32::try_from(block_meta.len()).context("too many SST blocks")?);
         for meta in block_meta {
-            buf.put_u32(meta.offset as u32);
-            buf.put_u16(meta.first_key.key_len() as u16);
+            buf.put_u32(u32::try_from(meta.offset).context("SST block offset is too large")?);
+            buf.put_u16(
+                u16::try_from(meta.first_key.key_len()).context("SST first key is too large")?,
+            );
             buf.put_slice(meta.first_key.key_ref());
             buf.put_u64(meta.first_key.ts());
-            buf.put_u16(meta.last_key.key_len() as u16);
+            buf.put_u16(
+                u16::try_from(meta.last_key.key_len()).context("SST last key is too large")?,
+            );
             buf.put_slice(meta.last_key.key_ref());
             buf.put_u64(meta.last_key.ts());
         }
         buf.put_u64(max_ts);
         buf.put_u32(crc32fast::hash(&buf[original_len + 4..]));
         assert_eq!(estimated_size, buf.len() - original_len);
+        Ok(())
     }
 
     /// Decode block meta from a buffer.
-    pub fn decode_block_meta(mut buf: &[u8]) -> Result<(Vec<BlockMeta>, u64)> {
+    pub fn decode_block_meta(buf: &[u8]) -> Result<(Vec<BlockMeta>, u64)> {
+        let trailer_size = std::mem::size_of::<u64>() + std::mem::size_of::<u32>();
+        ensure!(
+            buf.len() >= std::mem::size_of::<u32>() + trailer_size,
+            "SST block metadata is truncated"
+        );
+        let checksum_offset = buf.len() - std::mem::size_of::<u32>();
+        let expected_checksum = u32::from_be_bytes([
+            buf[checksum_offset],
+            buf[checksum_offset + 1],
+            buf[checksum_offset + 2],
+            buf[checksum_offset + 3],
+        ]);
+        let checksum = crc32fast::hash(&buf[std::mem::size_of::<u32>()..checksum_offset]);
+        ensure!(expected_checksum == checksum, "meta checksum mismatched");
+
+        let mut cursor = buf;
         let mut block_meta = Vec::new();
-        let num = buf.get_u32() as usize;
-        let checksum = crc32fast::hash(&buf[..buf.remaining() - 4]);
+        let num = take_u32(&mut cursor, "SST block count")? as usize;
+        let minimum_entry_size = std::mem::size_of::<u32>()
+            + std::mem::size_of::<u16>() * 2
+            + std::mem::size_of::<u64>() * 2;
+        ensure!(
+            num <= checksum_offset
+                .saturating_sub(std::mem::size_of::<u32>() + std::mem::size_of::<u64>())
+                / minimum_entry_size,
+            "SST block count exceeds the metadata length"
+        );
         for _ in 0..num {
-            let offset = buf.get_u32() as usize;
-            let first_key_len = buf.get_u16() as usize;
-            let first_key =
-                KeyBytes::from_bytes_with_ts(buf.copy_to_bytes(first_key_len), buf.get_u64());
-            let last_key_len: usize = buf.get_u16() as usize;
-            let last_key =
-                KeyBytes::from_bytes_with_ts(buf.copy_to_bytes(last_key_len), buf.get_u64());
+            let offset = take_u32(&mut cursor, "SST block offset")? as usize;
+            let first_key_len = take_u16(&mut cursor, "SST first-key length")? as usize;
+            ensure!(first_key_len > 0, "SST first key is empty");
+            let first_key = take_bytes(&mut cursor, first_key_len, "SST first key")?;
+            let first_key_ts = take_u64(&mut cursor, "SST first-key timestamp")?;
+            let first_key = KeyBytes::from_bytes_with_ts(first_key.to_vec().into(), first_key_ts);
+            let last_key_len = take_u16(&mut cursor, "SST last-key length")? as usize;
+            ensure!(last_key_len > 0, "SST last key is empty");
+            let last_key = take_bytes(&mut cursor, last_key_len, "SST last key")?;
+            let last_key_ts = take_u64(&mut cursor, "SST last-key timestamp")?;
+            let last_key = KeyBytes::from_bytes_with_ts(last_key.to_vec().into(), last_key_ts);
             block_meta.push(BlockMeta {
                 offset,
                 first_key,
                 last_key,
             });
         }
-        let max_ts = buf.get_u64();
-        if buf.get_u32() != checksum {
-            bail!("meta checksum mismatched");
-        }
+        ensure!(
+            cursor.len() == trailer_size,
+            "SST block metadata has trailing or missing bytes"
+        );
+        let max_ts = take_u64(&mut cursor, "SST maximum timestamp")?;
+        let stored_checksum = take_u32(&mut cursor, "SST metadata checksum")?;
+        ensure!(stored_checksum == checksum, "meta checksum mismatched");
 
         Ok((block_meta, max_ts))
     }
@@ -113,10 +177,15 @@ pub struct FileObject(Option<File>, u64);
 impl FileObject {
     pub fn read(&self, offset: u64, len: u64) -> Result<Vec<u8>> {
         use std::os::unix::fs::FileExt;
-        let mut data = vec![0; len as usize];
+        let end = offset
+            .checked_add(len)
+            .context("file read range overflow")?;
+        ensure!(end <= self.1, "file read range is out of bounds");
+        let len = usize::try_from(len).context("file read is too large")?;
+        let mut data = vec![0; len];
         self.0
             .as_ref()
-            .unwrap()
+            .context("cannot read a metadata-only file object")?
             .read_exact_at(&mut data[..], offset)?;
         Ok(data)
     }
@@ -131,7 +200,7 @@ impl FileObject {
         File::open(path)?.sync_all()?;
         Ok(FileObject(
             Some(File::options().read(true).write(false).open(path)?),
-            data.len() as u64,
+            u64::try_from(data.len()).context("SST file is too large")?,
         ))
     }
 
@@ -166,20 +235,65 @@ impl SsTable {
     /// Open SSTable from a file.
     pub fn open(id: usize, block_cache: Option<Arc<BlockCache>>, file: FileObject) -> Result<Self> {
         let len = file.size();
-        let raw_bloom_offset = file.read(len - 4, 4)?;
-        let bloom_offset = (&raw_bloom_offset[..]).get_u32() as u64;
-        let raw_bloom = file.read(bloom_offset, len - 4 - bloom_offset)?;
+        let bloom_trailer_offset = len
+            .checked_sub(std::mem::size_of::<u32>() as u64)
+            .context("SST bloom-offset trailer is truncated")?;
+        let raw_bloom_offset = file.read(bloom_trailer_offset, 4)?;
+        let bloom_offset = u32::from_be_bytes([
+            raw_bloom_offset[0],
+            raw_bloom_offset[1],
+            raw_bloom_offset[2],
+            raw_bloom_offset[3],
+        ]) as u64;
+        ensure!(
+            bloom_offset <= bloom_trailer_offset,
+            "SST bloom offset is out of bounds"
+        );
+        let meta_trailer_offset = bloom_offset
+            .checked_sub(std::mem::size_of::<u32>() as u64)
+            .context("SST metadata-offset trailer is truncated")?;
+        let raw_bloom = file.read(bloom_offset, bloom_trailer_offset - bloom_offset)?;
         let bloom_filter = Bloom::decode(&raw_bloom)?;
-        let raw_meta_offset = file.read(bloom_offset - 4, 4)?;
-        let block_meta_offset = (&raw_meta_offset[..]).get_u32() as u64;
-        let raw_meta = file.read(block_meta_offset, bloom_offset - 4 - block_meta_offset)?;
+        let raw_meta_offset = file.read(meta_trailer_offset, 4)?;
+        let block_meta_offset = u32::from_be_bytes([
+            raw_meta_offset[0],
+            raw_meta_offset[1],
+            raw_meta_offset[2],
+            raw_meta_offset[3],
+        ]) as u64;
+        ensure!(
+            block_meta_offset <= meta_trailer_offset,
+            "SST block-metadata offset is out of bounds"
+        );
+        let raw_meta = file.read(block_meta_offset, meta_trailer_offset - block_meta_offset)?;
         let (block_meta, max_ts) = BlockMeta::decode_block_meta(&raw_meta[..])?;
+        ensure!(!block_meta.is_empty(), "SST has no data blocks");
+        ensure!(
+            block_meta[0].offset == 0,
+            "first SST block must start at zero"
+        );
+        ensure!(
+            block_meta
+                .windows(2)
+                .all(|pair| pair[0].offset < pair[1].offset),
+            "SST block offsets are not strictly increasing"
+        );
+        let block_meta_offset_usize =
+            usize::try_from(block_meta_offset).context("SST metadata offset is too large")?;
+        ensure!(
+            block_meta.iter().all(|meta| {
+                meta.offset
+                    .checked_add(std::mem::size_of::<u32>())
+                    .is_some_and(|end| end < block_meta_offset_usize)
+            }),
+            "SST block offset or checksum is out of bounds"
+        );
         Ok(Self {
             file,
-            first_key: block_meta.first().unwrap().first_key.clone(),
-            last_key: block_meta.last().unwrap().last_key.clone(),
+            first_key: block_meta[0].first_key.clone(),
+            last_key: block_meta[block_meta.len() - 1].last_key.clone(),
             block_meta,
-            block_meta_offset: block_meta_offset as usize,
+            block_meta_offset: block_meta_offset_usize,
             id,
             block_cache,
             bloom: Some(bloom_filter),
@@ -209,21 +323,33 @@ impl SsTable {
 
     /// Read a block from the disk.
     pub fn read_block(&self, block_idx: usize) -> Result<Arc<Block>> {
-        let offset = self.block_meta[block_idx].offset;
+        let offset = self
+            .block_meta
+            .get(block_idx)
+            .context("SST block index is out of bounds")?
+            .offset;
         let offset_end = self
             .block_meta
             .get(block_idx + 1)
             .map_or(self.block_meta_offset, |x| x.offset);
-        let block_len = offset_end - offset - 4;
-        let block_data_with_chksum: Vec<u8> = self
-            .file
-            .read(offset as u64, (offset_end - offset) as u64)?;
+        let range_len = offset_end
+            .checked_sub(offset)
+            .context("SST block offsets are reversed")?;
+        let block_len = range_len
+            .checked_sub(std::mem::size_of::<u32>())
+            .context("SST block checksum is truncated")?;
+        let block_data_with_chksum: Vec<u8> = self.file.read(offset as u64, range_len as u64)?;
         let block_data = &block_data_with_chksum[..block_len];
-        let checksum = (&block_data_with_chksum[block_len..]).get_u32();
+        let checksum = u32::from_be_bytes([
+            block_data_with_chksum[block_len],
+            block_data_with_chksum[block_len + 1],
+            block_data_with_chksum[block_len + 2],
+            block_data_with_chksum[block_len + 3],
+        ]);
         if checksum != crc32fast::hash(block_data) {
             bail!("block checksum mismatched");
         }
-        Ok(Arc::new(Block::decode(block_data)))
+        Ok(Arc::new(Block::decode_checked(block_data)?))
     }
 
     /// Read a block from disk, with block cache.

--- a/mini-lsm-mvcc/src/table/bloom.rs
+++ b/mini-lsm-mvcc/src/table/bloom.rs
@@ -14,8 +14,8 @@
 
 // Copyright 2021 TiKV Project Authors. Licensed under Apache-2.0.
 
-use anyhow::{Result, bail};
-use bytes::{Buf, BufMut, Bytes, BytesMut};
+use anyhow::{Result, bail, ensure};
+use bytes::{BufMut, Bytes, BytesMut};
 
 /// Implements a bloom filter
 pub struct Bloom {
@@ -61,11 +61,18 @@ impl<T: AsMut<[u8]>> BitSliceMut for T {
 impl Bloom {
     /// Decode a bloom filter
     pub fn decode(buf: &[u8]) -> Result<Self> {
-        let checksum = (&buf[buf.len() - 4..buf.len()]).get_u32();
+        ensure!(buf.len() >= 5, "bloom filter is truncated");
+        let checksum = u32::from_be_bytes([
+            buf[buf.len() - 4],
+            buf[buf.len() - 3],
+            buf[buf.len() - 2],
+            buf[buf.len() - 1],
+        ]);
         if checksum != crc32fast::hash(&buf[..buf.len() - 4]) {
             bail!("checksum mismatched for bloom filters");
         }
         let filter = &buf[..buf.len() - 5];
+        ensure!(!filter.is_empty(), "bloom filter has no bits");
         let k = buf[buf.len() - 5];
         Ok(Self {
             filter: filter.to_vec().into(),

--- a/mini-lsm-mvcc/src/table/builder.rs
+++ b/mini-lsm-mvcc/src/table/builder.rs
@@ -15,7 +15,7 @@
 use std::path::Path;
 use std::sync::Arc;
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use bytes::BufMut;
 
 use super::bloom::Bloom;
@@ -104,15 +104,15 @@ impl SsTableBuilder {
         self.finish_block();
         let mut buf = self.data;
         let meta_offset = buf.len();
-        BlockMeta::encode_block_meta(&self.meta, self.max_ts, &mut buf);
-        buf.put_u32(meta_offset as u32);
+        BlockMeta::encode_block_meta(&self.meta, self.max_ts, &mut buf)?;
+        buf.put_u32(u32::try_from(meta_offset).context("SST metadata offset is too large")?);
         let bloom = Bloom::build_from_key_hashes(
             &self.key_hashes,
             Bloom::bloom_bits_per_key(self.key_hashes.len(), 0.01),
         );
         let bloom_offset = buf.len();
         bloom.encode(&mut buf);
-        buf.put_u32(bloom_offset as u32);
+        buf.put_u32(u32::try_from(bloom_offset).context("SST bloom offset is too large")?);
         let file = FileObject::create(path.as_ref(), buf)?;
         Ok(SsTable {
             id,

--- a/mini-lsm-mvcc/src/tests.rs
+++ b/mini-lsm-mvcc/src/tests.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 mod harness;
+mod release_regressions;
 mod week1_day1;
 mod week1_day2;
 mod week1_day3;

--- a/mini-lsm-mvcc/src/tests/release_regressions.rs
+++ b/mini-lsm-mvcc/src/tests/release_regressions.rs
@@ -1,0 +1,235 @@
+// Copyright (c) 2022-2026 Alex Chi Z
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::panic::{AssertUnwindSafe, catch_unwind};
+
+use anyhow::Result;
+use bytes::Bytes;
+use tempfile::tempdir;
+
+use crate::{
+    compact::CompactionOptions,
+    key::KeySlice,
+    lsm_storage::{LsmStorageOptions, MiniLsm, WriteBatchRecord},
+    manifest::{Manifest, ManifestRecord},
+    table::{FileObject, SsTable, SsTableBuilder},
+};
+
+fn options(enable_wal: bool, serializable: bool) -> LsmStorageOptions {
+    let mut options = LsmStorageOptions::default_for_week2_test(CompactionOptions::NoCompaction);
+    options.enable_wal = enable_wal;
+    options.serializable = serializable;
+    options
+}
+
+fn assert_round_trip(enable_wal: bool, serializable: bool, key: &[u8], value: &[u8]) {
+    let dir = tempdir().unwrap();
+    let storage = MiniLsm::open(&dir, options(enable_wal, serializable)).unwrap();
+    storage.put(key, value).unwrap();
+    assert_eq!(
+        storage.get(key).unwrap(),
+        Some(Bytes::copy_from_slice(value))
+    );
+    storage.force_flush().unwrap();
+    assert_eq!(
+        storage.get(key).unwrap(),
+        Some(Bytes::copy_from_slice(value))
+    );
+    storage.close().unwrap();
+    drop(storage);
+
+    let storage = MiniLsm::open(&dir, options(enable_wal, serializable)).unwrap();
+    assert_eq!(
+        storage.get(key).unwrap(),
+        Some(Bytes::copy_from_slice(value))
+    );
+    storage.close().unwrap();
+}
+
+fn open_and_read_all_blocks(path: &std::path::Path) -> Result<()> {
+    let table = SsTable::open_for_test(FileObject::open(path)?)?;
+    for idx in 0..table.num_of_blocks() {
+        table.read_block(idx)?;
+    }
+    Ok(())
+}
+
+#[test]
+fn test_release_manifest_torn_tail_preserves_durable_prefix() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("MANIFEST");
+    let manifest = Manifest::create(&path).unwrap();
+    manifest
+        .add_record_when_init(ManifestRecord::NewMemtable(1))
+        .unwrap();
+    manifest
+        .add_record_when_init(ManifestRecord::NewMemtable(2))
+        .unwrap();
+    drop(manifest);
+
+    let encoded = std::fs::read(&path).unwrap();
+    let first_body_len = u64::from_be_bytes(encoded[..8].try_into().unwrap()) as usize;
+    let first_frame_len = 8 + first_body_len + 4;
+
+    for cutoff in 0..first_frame_len {
+        let truncated = dir.path().join(format!("first-{cutoff}.manifest"));
+        std::fs::write(&truncated, &encoded[..cutoff]).unwrap();
+        let (_, records) = Manifest::recover(&truncated).unwrap();
+        assert!(records.is_empty());
+        assert_eq!(std::fs::metadata(truncated).unwrap().len(), 0);
+    }
+
+    for cutoff in first_frame_len + 1..encoded.len() {
+        let truncated = dir.path().join(format!("second-{cutoff}.manifest"));
+        std::fs::write(&truncated, &encoded[..cutoff]).unwrap();
+        let (_, records) = Manifest::recover(&truncated).unwrap();
+        assert_eq!(records.len(), 1);
+        assert!(matches!(records[0], ManifestRecord::NewMemtable(1)));
+        assert_eq!(
+            std::fs::metadata(truncated).unwrap().len(),
+            first_frame_len as u64
+        );
+    }
+}
+
+#[test]
+fn test_release_manifest_corruption_never_panics() {
+    let dir = tempdir().unwrap();
+    let source = dir.path().join("MANIFEST");
+    let manifest = Manifest::create(&source).unwrap();
+    manifest
+        .add_record_when_init(ManifestRecord::NewMemtable(1))
+        .unwrap();
+    drop(manifest);
+    let encoded = std::fs::read(source).unwrap();
+
+    let mut checksum_corrupt = encoded.clone();
+    *checksum_corrupt.last_mut().unwrap() ^= 0x80;
+    let checksum_path = dir.path().join("checksum.manifest");
+    std::fs::write(&checksum_path, checksum_corrupt).unwrap();
+    assert!(Manifest::recover(checksum_path).is_err());
+
+    for idx in 0..8 {
+        let mut corrupt = encoded.clone();
+        corrupt[idx] ^= 0x80;
+        let path = dir.path().join(format!("length-{idx}.manifest"));
+        std::fs::write(&path, corrupt).unwrap();
+        let outcome = catch_unwind(AssertUnwindSafe(|| Manifest::recover(&path)));
+        assert!(outcome.is_ok(), "length byte {idx} panicked");
+    }
+}
+
+#[test]
+fn test_release_sst_corruption_and_truncation_never_panic() {
+    let dir = tempdir().unwrap();
+    let source = dir.path().join("source.sst");
+    let mut builder = SsTableBuilder::new(32);
+    builder.add(KeySlice::from_slice_with_ts(b"a", 2), b"1");
+    builder.add(KeySlice::from_slice_with_ts(b"b", 1), b"2");
+    drop(builder.build_for_test(&source).unwrap());
+    let encoded = std::fs::read(&source).unwrap();
+
+    for cutoff in 0..encoded.len() {
+        let path = dir.path().join(format!("truncated-{cutoff}.sst"));
+        std::fs::write(&path, &encoded[..cutoff]).unwrap();
+        let outcome = catch_unwind(AssertUnwindSafe(|| open_and_read_all_blocks(&path)));
+        assert!(outcome.is_ok(), "SST cutoff {cutoff} panicked");
+        assert!(
+            outcome.unwrap().is_err(),
+            "SST cutoff {cutoff} was accepted"
+        );
+    }
+
+    for idx in 0..encoded.len() {
+        let mut corrupt = encoded.clone();
+        corrupt[idx] ^= 0x80;
+        let path = dir.path().join(format!("corrupt-{idx}.sst"));
+        std::fs::write(&path, corrupt).unwrap();
+        let outcome = catch_unwind(AssertUnwindSafe(|| open_and_read_all_blocks(&path)));
+        assert!(outcome.is_ok(), "SST byte {idx} panicked");
+        assert!(outcome.unwrap().is_err(), "SST byte {idx} was accepted");
+    }
+}
+
+#[test]
+fn test_release_public_write_size_boundaries() {
+    let max_key = vec![b'k'; usize::from(u16::MAX)];
+    let max_value = vec![b'v'; usize::from(u16::MAX)];
+    for enable_wal in [false, true] {
+        for serializable in [false, true] {
+            assert_round_trip(enable_wal, serializable, b"value-boundary", &max_value);
+            assert_round_trip(enable_wal, serializable, &max_key, b"key-boundary");
+
+            let dir = tempdir().unwrap();
+            let storage = MiniLsm::open(&dir, options(enable_wal, serializable)).unwrap();
+            let oversized = vec![0; usize::from(u16::MAX) + 1];
+            assert!(storage.put(b"oversized-value", &oversized).is_err());
+            assert!(storage.put(&oversized, b"oversized-key").is_err());
+            let batch = [
+                WriteBatchRecord::Put(b"would-be-partial".as_slice(), b"value".as_slice()),
+                WriteBatchRecord::Put(b"oversized".as_slice(), oversized.as_slice()),
+            ];
+            assert!(storage.write_batch(&batch).is_err());
+            assert_eq!(storage.get(b"would-be-partial").unwrap(), None);
+            assert_eq!(storage.get(b"oversized-value").unwrap(), None);
+            storage.close().unwrap();
+            drop(storage);
+
+            let storage = MiniLsm::open(&dir, options(enable_wal, serializable)).unwrap();
+            assert_eq!(storage.get(b"would-be-partial").unwrap(), None);
+            assert_eq!(storage.get(b"oversized-value").unwrap(), None);
+            storage.close().unwrap();
+        }
+    }
+}
+
+#[test]
+fn test_release_first_key_max_sst_restart_advances_timestamp() {
+    let dir = tempdir().unwrap();
+    let storage = MiniLsm::open(&dir, options(false, false)).unwrap();
+    storage.put(b"b", b"ts1").unwrap();
+    storage.put(b"a", b"ts2").unwrap();
+    assert_eq!(storage.inner.mvcc().latest_commit_ts(), 2);
+    storage.force_flush().unwrap();
+    storage.close().unwrap();
+    drop(storage);
+
+    let storage = MiniLsm::open(&dir, options(false, false)).unwrap();
+    assert_eq!(storage.inner.mvcc().latest_commit_ts(), 2);
+    assert_eq!(storage.get(b"a").unwrap(), Some(Bytes::from_static(b"ts2")));
+    storage.put(b"c", b"ts3").unwrap();
+    assert_eq!(storage.inner.mvcc().latest_commit_ts(), 3);
+    assert_eq!(storage.get(b"a").unwrap(), Some(Bytes::from_static(b"ts2")));
+    storage.close().unwrap();
+}
+
+#[test]
+fn test_release_live_wal_restart_advances_timestamp() {
+    let dir = tempdir().unwrap();
+    let storage = MiniLsm::open(&dir, options(true, false)).unwrap();
+    storage.put(b"a", b"ts1").unwrap();
+    storage.put(b"c", b"ts2").unwrap();
+    storage.put(b"b", b"ts3").unwrap();
+    assert_eq!(storage.inner.mvcc().latest_commit_ts(), 3);
+    storage.close().unwrap();
+    drop(storage);
+
+    let storage = MiniLsm::open(&dir, options(true, false)).unwrap();
+    assert_eq!(storage.inner.mvcc().latest_commit_ts(), 3);
+    assert_eq!(storage.get(b"b").unwrap(), Some(Bytes::from_static(b"ts3")));
+    storage.put(b"d", b"ts4").unwrap();
+    assert_eq!(storage.inner.mvcc().latest_commit_ts(), 4);
+    assert_eq!(storage.get(b"b").unwrap(), Some(Bytes::from_static(b"ts3")));
+    storage.close().unwrap();
+}

--- a/mini-lsm-mvcc/src/tests/week3_day3.rs
+++ b/mini-lsm-mvcc/src/tests/week3_day3.rs
@@ -395,12 +395,12 @@ fn test_task2_all_range_bounds_across_l0_and_level_ssts() {
 #[test]
 fn test_task3_sst_ts() {
     let mut builder = SsTableBuilder::new(16);
-    builder.add(KeySlice::from_slice_with_ts(b"11", 1), b"11");
-    builder.add(KeySlice::from_slice_with_ts(b"22", 2), b"22");
+    builder.add(KeySlice::from_slice_with_ts(b"11", 6), b"11");
+    builder.add(KeySlice::from_slice_with_ts(b"22", 1), b"22");
     builder.add(KeySlice::from_slice_with_ts(b"33", 3), b"11");
     builder.add(KeySlice::from_slice_with_ts(b"44", 4), b"22");
     builder.add(KeySlice::from_slice_with_ts(b"55", 5), b"11");
-    builder.add(KeySlice::from_slice_with_ts(b"66", 6), b"22");
+    builder.add(KeySlice::from_slice_with_ts(b"66", 2), b"22");
     let dir = tempdir().unwrap();
     let sst = builder.build_for_test(dir.path().join("1.sst")).unwrap();
     assert_eq!(sst.max_ts(), 6);

--- a/mini-lsm-mvcc/src/wal.rs
+++ b/mini-lsm-mvcc/src/wal.rs
@@ -99,7 +99,10 @@ impl Wal {
             rbuf.advance(batch_size);
             let expected_checksum = rbuf.get_u32();
             let component_checksum = hasher.finalize();
-            assert_eq!(component_checksum, single_checksum);
+            ensure!(
+                component_checksum == single_checksum,
+                "WAL component checksum disagrees with frame checksum"
+            );
             if single_checksum != expected_checksum {
                 bail!("checksum mismatch");
             }

--- a/mini-lsm/src/block.rs
+++ b/mini-lsm/src/block.rs
@@ -15,8 +15,9 @@
 mod builder;
 mod iterator;
 
+use anyhow::{Context, Result, ensure};
 pub use builder::BlockBuilder;
-use bytes::{Buf, BufMut, Bytes};
+use bytes::{BufMut, Bytes};
 pub use iterator::BlockIterator;
 
 pub(crate) const SIZEOF_U16: usize = std::mem::size_of::<u16>();
@@ -41,17 +42,79 @@ impl Block {
     }
 
     pub fn decode(data: &[u8]) -> Self {
+        Self::decode_checked(data).expect("invalid block encoding")
+    }
+
+    pub(crate) fn decode_checked(data: &[u8]) -> Result<Self> {
         // get number of elements in the block
-        let entry_offsets_len = (&data[data.len() - SIZEOF_U16..]).get_u16() as usize;
-        let data_end = data.len() - SIZEOF_U16 - entry_offsets_len * SIZEOF_U16;
+        ensure!(data.len() >= SIZEOF_U16, "block footer is truncated");
+        let entry_offsets_len =
+            u16::from_be_bytes([data[data.len() - 2], data[data.len() - 1]]) as usize;
+        ensure!(entry_offsets_len > 0, "block has no entries");
+        let offsets_size = entry_offsets_len
+            .checked_mul(SIZEOF_U16)
+            .context("block offset table is too large")?;
+        let footer_size = offsets_size
+            .checked_add(SIZEOF_U16)
+            .context("block footer is too large")?;
+        ensure!(footer_size <= data.len(), "block offset table is truncated");
+        let data_end = data.len() - footer_size;
         let offsets_raw = &data[data_end..data.len() - SIZEOF_U16];
         // get offset array
-        let offsets = offsets_raw
+        let offsets: Vec<u16> = offsets_raw
             .chunks(SIZEOF_U16)
-            .map(|mut x| x.get_u16())
+            .map(|x| u16::from_be_bytes([x[0], x[1]]))
             .collect();
+        ensure!(
+            offsets[0] == 0,
+            "first block entry must start at offset zero"
+        );
+        ensure!(
+            offsets.windows(2).all(|pair| pair[0] < pair[1]),
+            "block entry offsets are not strictly increasing"
+        );
+        ensure!(
+            offsets.iter().all(|offset| usize::from(*offset) < data_end),
+            "block entry offset is outside the data section"
+        );
+
+        let mut first_key_len = None;
+        for (idx, offset) in offsets.iter().enumerate() {
+            let entry_start = usize::from(*offset);
+            let entry_end = offsets
+                .get(idx + 1)
+                .map_or(data_end, |offset| usize::from(*offset));
+            let entry = &data[entry_start..entry_end];
+            ensure!(entry.len() >= 6, "block entry header is truncated");
+            let overlap = u16::from_be_bytes([entry[0], entry[1]]) as usize;
+            let key_len = u16::from_be_bytes([entry[2], entry[3]]) as usize;
+            if idx == 0 {
+                ensure!(overlap == 0, "first block key has a nonzero overlap");
+                first_key_len = Some(key_len);
+            } else {
+                ensure!(
+                    overlap <= first_key_len.context("block is missing its first key")?,
+                    "block key overlap exceeds the first key"
+                );
+            }
+            let key_end = 4usize
+                .checked_add(key_len)
+                .context("block key length overflow")?;
+            let value_len_end = key_end
+                .checked_add(SIZEOF_U16)
+                .context("block value header overflow")?;
+            ensure!(
+                value_len_end <= entry.len(),
+                "block key or value length is truncated"
+            );
+            let value_len = u16::from_be_bytes([entry[key_end], entry[key_end + 1]]) as usize;
+            let entry_len = value_len_end
+                .checked_add(value_len)
+                .context("block value length overflow")?;
+            ensure!(entry_len == entry.len(), "block value length is invalid");
+        }
         // retrieve data
         let data = data[0..data_end].to_vec();
-        Self { data, offsets }
+        Ok(Self { data, offsets })
     }
 }

--- a/mini-lsm/src/block/builder.rs
+++ b/mini-lsm/src/block/builder.rs
@@ -64,22 +64,39 @@ impl BlockBuilder {
     #[must_use]
     pub fn add(&mut self, key: KeySlice, value: &[u8]) -> bool {
         assert!(!key.is_empty(), "key must not be empty");
-        if self.estimated_size() + key.len() + value.len() + SIZEOF_U16 * 3 /* key_len, value_len and offset */ > self.block_size
-            && !self.is_empty()
-        {
+        let Ok(key_len) = u16::try_from(key.len()) else {
+            return false;
+        };
+        let Ok(value_len) = u16::try_from(value.len()) else {
+            return false;
+        };
+        let entry_size = key
+            .len()
+            .saturating_add(value.len())
+            .saturating_add(SIZEOF_U16 * 3);
+        let block_is_full = self.estimated_size().saturating_add(entry_size) > self.block_size;
+        let offset_is_full = self.data.len() > usize::from(u16::MAX);
+        let count_is_full = self.offsets.len() >= usize::from(u16::MAX);
+        if !self.is_empty() && (block_is_full || offset_is_full || count_is_full) {
             return false;
         }
         // Add the offset of the data into the offset array.
-        self.offsets.push(self.data.len() as u16);
+        let Ok(offset) = u16::try_from(self.data.len()) else {
+            return false;
+        };
+        self.offsets.push(offset);
         let overlap = compute_overlap(self.first_key.as_key_slice(), key);
+        let Ok(overlap) = u16::try_from(overlap) else {
+            return false;
+        };
         // Encode key overlap.
-        self.data.put_u16(overlap as u16);
+        self.data.put_u16(overlap);
         // Encode key length.
-        self.data.put_u16((key.len() - overlap) as u16);
+        self.data.put_u16(key_len - overlap);
         // Encode key content.
-        self.data.put(&key.raw_ref()[overlap..]);
+        self.data.put(&key.raw_ref()[usize::from(overlap)..]);
         // Encode value length.
-        self.data.put_u16(value.len() as u16);
+        self.data.put_u16(value_len);
         // Encode value content.
         self.data.put(value);
 

--- a/mini-lsm/src/lsm_storage.rs
+++ b/mini-lsm/src/lsm_storage.rs
@@ -19,7 +19,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::atomic::AtomicUsize;
 
-use anyhow::{Context, Result};
+use anyhow::{Context, Result, ensure};
 use bytes::Bytes;
 use parking_lot::{Mutex, MutexGuard, RwLock};
 
@@ -60,6 +60,24 @@ pub struct LsmStorageState {
 pub enum WriteBatchRecord<T: AsRef<[u8]>> {
     Put(T, T),
     Del(T),
+}
+
+fn validate_write_batch<T: AsRef<[u8]>>(batch: &[WriteBatchRecord<T>]) -> Result<()> {
+    for record in batch {
+        let (key, value) = match record {
+            WriteBatchRecord::Put(key, value) => (key.as_ref(), value.as_ref()),
+            WriteBatchRecord::Del(key) => (key.as_ref(), &[][..]),
+        };
+        ensure!(
+            u16::try_from(key.len()).is_ok(),
+            "key is too large for the on-disk format"
+        );
+        ensure!(
+            u16::try_from(value.len()).is_ok(),
+            "value is too large for the on-disk format"
+        );
+    }
+    Ok(())
 }
 
 impl LsmStorageState {
@@ -553,6 +571,7 @@ impl LsmStorageInner {
     }
 
     pub fn write_batch<T: AsRef<[u8]>>(&self, batch: &[WriteBatchRecord<T>]) -> Result<()> {
+        validate_write_batch(batch)?;
         for record in batch {
             match record {
                 WriteBatchRecord::Del(key) => {

--- a/mini-lsm/src/manifest.rs
+++ b/mini-lsm/src/manifest.rs
@@ -18,7 +18,7 @@ use std::path::Path;
 use std::sync::Arc;
 
 use anyhow::{Context, Result, bail};
-use bytes::{Buf, BufMut};
+use bytes::BufMut;
 use parking_lot::{Mutex, MutexGuard};
 use serde::{Deserialize, Serialize};
 
@@ -57,18 +57,63 @@ impl Manifest {
             .context("failed to recover manifest")?;
         let mut buf = Vec::new();
         file.read_to_end(&mut buf)?;
-        let mut buf_ptr = buf.as_slice();
         let mut records = Vec::new();
-        while buf_ptr.has_remaining() {
-            let len = buf_ptr.get_u64();
-            let slice = &buf_ptr[..len as usize];
-            let json = serde_json::from_slice::<ManifestRecord>(slice)?;
-            buf_ptr.advance(len as usize);
-            let checksum = buf_ptr.get_u32();
-            if checksum != crc32fast::hash(slice) {
-                bail!("checksum mismatched!");
+        let mut valid_len = 0usize;
+        while valid_len < buf.len() {
+            let remaining = &buf[valid_len..];
+            if remaining.len() < std::mem::size_of::<u64>() {
+                break;
             }
-            records.push(json);
+
+            let len = u64::from_be_bytes([
+                remaining[0],
+                remaining[1],
+                remaining[2],
+                remaining[3],
+                remaining[4],
+                remaining[5],
+                remaining[6],
+                remaining[7],
+            ]);
+            let Ok(len) = usize::try_from(len) else {
+                break;
+            };
+            let Some(frame_len) = std::mem::size_of::<u64>()
+                .checked_add(len)
+                .and_then(|len| len.checked_add(std::mem::size_of::<u32>()))
+            else {
+                break;
+            };
+            if remaining.len() < frame_len {
+                break;
+            }
+
+            let body_start = std::mem::size_of::<u64>();
+            let body_end = body_start + len;
+            let body = &remaining[body_start..body_end];
+            let checksum = u32::from_be_bytes([
+                remaining[body_end],
+                remaining[body_end + 1],
+                remaining[body_end + 2],
+                remaining[body_end + 3],
+            ]);
+            if checksum != crc32fast::hash(body) {
+                bail!("manifest checksum mismatched at byte offset {valid_len}");
+            }
+            records.push(
+                serde_json::from_slice::<ManifestRecord>(body).with_context(|| {
+                    format!("invalid manifest record at byte offset {valid_len}")
+                })?,
+            );
+            valid_len += frame_len;
+        }
+
+        if valid_len < buf.len() {
+            eprintln!("warning: ignoring incomplete manifest frame at byte offset {valid_len}");
+            file.set_len(valid_len as u64)
+                .context("failed to truncate incomplete manifest tail")?;
+            file.sync_all()
+                .context("failed to sync truncated manifest tail")?;
         }
         Ok((
             Self {
@@ -90,7 +135,8 @@ impl Manifest {
         let mut file = self.file.lock();
         let mut buf = serde_json::to_vec(&record)?;
         let hash = crc32fast::hash(&buf);
-        file.write_all(&(buf.len() as u64).to_be_bytes())?;
+        let len = u64::try_from(buf.len()).context("manifest record is too large")?;
+        file.write_all(&len.to_be_bytes())?;
         buf.put_u32(hash);
         file.write_all(&buf)?;
         file.sync_all()?;

--- a/mini-lsm/src/table.rs
+++ b/mini-lsm/src/table.rs
@@ -20,9 +20,9 @@ use std::fs::File;
 use std::path::Path;
 use std::sync::Arc;
 
-use anyhow::{Result, anyhow, bail};
+use anyhow::{Context, Result, anyhow, bail, ensure};
 pub use builder::SsTableBuilder;
-use bytes::{Buf, BufMut};
+use bytes::BufMut;
 pub use iterator::SsTableIterator;
 
 use crate::block::Block;
@@ -30,6 +30,23 @@ use crate::key::{KeyBytes, KeySlice};
 use crate::lsm_storage::BlockCache;
 
 use self::bloom::Bloom;
+
+fn take_bytes<'a>(buf: &mut &'a [u8], len: usize, what: &str) -> Result<&'a [u8]> {
+    ensure!(buf.len() >= len, "{what} is truncated");
+    let (value, rest) = buf.split_at(len);
+    *buf = rest;
+    Ok(value)
+}
+
+fn take_u16(buf: &mut &[u8], what: &str) -> Result<u16> {
+    let value = take_bytes(buf, std::mem::size_of::<u16>(), what)?;
+    Ok(u16::from_be_bytes([value[0], value[1]]))
+}
+
+fn take_u32(buf: &mut &[u8], what: &str) -> Result<u32> {
+    let value = take_bytes(buf, std::mem::size_of::<u32>(), what)?;
+    Ok(u32::from_be_bytes([value[0], value[1], value[2], value[3]]))
+}
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct BlockMeta {
@@ -43,7 +60,7 @@ pub struct BlockMeta {
 
 impl BlockMeta {
     /// Encode block meta to a buffer.
-    pub fn encode_block_meta(block_meta: &[BlockMeta], buf: &mut Vec<u8>) {
+    pub fn encode_block_meta(block_meta: &[BlockMeta], buf: &mut Vec<u8>) -> Result<()> {
         let mut estimated_size = std::mem::size_of::<u32>();
         for meta in block_meta {
             // The size of offset
@@ -62,38 +79,71 @@ impl BlockMeta {
         // large
         buf.reserve(estimated_size);
         let original_len = buf.len();
-        buf.put_u32(block_meta.len() as u32);
+        buf.put_u32(u32::try_from(block_meta.len()).context("too many SST blocks")?);
         for meta in block_meta {
-            buf.put_u32(meta.offset as u32);
-            buf.put_u16(meta.first_key.len() as u16);
+            buf.put_u32(u32::try_from(meta.offset).context("SST block offset is too large")?);
+            buf.put_u16(u16::try_from(meta.first_key.len()).context("SST first key is too large")?);
             buf.put_slice(meta.first_key.raw_ref());
-            buf.put_u16(meta.last_key.len() as u16);
+            buf.put_u16(u16::try_from(meta.last_key.len()).context("SST last key is too large")?);
             buf.put_slice(meta.last_key.raw_ref());
         }
         buf.put_u32(crc32fast::hash(&buf[original_len + 4..]));
         assert_eq!(estimated_size, buf.len() - original_len);
+        Ok(())
     }
 
     /// Decode block meta from a buffer.
-    pub fn decode_block_meta(mut buf: &[u8]) -> Result<Vec<BlockMeta>> {
+    pub fn decode_block_meta(buf: &[u8]) -> Result<Vec<BlockMeta>> {
+        ensure!(
+            buf.len() >= std::mem::size_of::<u32>() * 2,
+            "SST block metadata is truncated"
+        );
+        let checksum_offset = buf.len() - std::mem::size_of::<u32>();
+        let expected_checksum = u32::from_be_bytes([
+            buf[checksum_offset],
+            buf[checksum_offset + 1],
+            buf[checksum_offset + 2],
+            buf[checksum_offset + 3],
+        ]);
+        let checksum = crc32fast::hash(&buf[std::mem::size_of::<u32>()..checksum_offset]);
+        ensure!(expected_checksum == checksum, "meta checksum mismatched");
+
+        let mut cursor = buf;
         let mut block_meta = Vec::new();
-        let num = buf.get_u32() as usize;
-        let checksum = crc32fast::hash(&buf[..buf.remaining() - 4]);
+        let num = take_u32(&mut cursor, "SST block count")? as usize;
+        let minimum_entry_size = std::mem::size_of::<u32>() + std::mem::size_of::<u16>() * 2;
+        ensure!(
+            num <= checksum_offset.saturating_sub(std::mem::size_of::<u32>()) / minimum_entry_size,
+            "SST block count exceeds the metadata length"
+        );
         for _ in 0..num {
-            let offset = buf.get_u32() as usize;
-            let first_key_len = buf.get_u16() as usize;
-            let first_key = KeyBytes::from_bytes(buf.copy_to_bytes(first_key_len));
-            let last_key_len: usize = buf.get_u16() as usize;
-            let last_key = KeyBytes::from_bytes(buf.copy_to_bytes(last_key_len));
+            let offset = take_u32(&mut cursor, "SST block offset")? as usize;
+            let first_key_len = take_u16(&mut cursor, "SST first-key length")? as usize;
+            ensure!(first_key_len > 0, "SST first key is empty");
+            let first_key = KeyBytes::from_bytes(
+                take_bytes(&mut cursor, first_key_len, "SST first key")?
+                    .to_vec()
+                    .into(),
+            );
+            let last_key_len = take_u16(&mut cursor, "SST last-key length")? as usize;
+            ensure!(last_key_len > 0, "SST last key is empty");
+            let last_key = KeyBytes::from_bytes(
+                take_bytes(&mut cursor, last_key_len, "SST last key")?
+                    .to_vec()
+                    .into(),
+            );
             block_meta.push(BlockMeta {
                 offset,
                 first_key,
                 last_key,
             });
         }
-        if buf.get_u32() != checksum {
-            bail!("meta checksum mismatched");
-        }
+        ensure!(
+            cursor.len() == std::mem::size_of::<u32>(),
+            "SST block metadata has trailing or missing bytes"
+        );
+        let stored_checksum = take_u32(&mut cursor, "SST metadata checksum")?;
+        ensure!(stored_checksum == checksum, "meta checksum mismatched");
 
         Ok(block_meta)
     }
@@ -105,10 +155,15 @@ pub struct FileObject(Option<File>, u64);
 impl FileObject {
     pub fn read(&self, offset: u64, len: u64) -> Result<Vec<u8>> {
         use std::os::unix::fs::FileExt;
-        let mut data = vec![0; len as usize];
+        let end = offset
+            .checked_add(len)
+            .context("file read range overflow")?;
+        ensure!(end <= self.1, "file read range is out of bounds");
+        let len = usize::try_from(len).context("file read is too large")?;
+        let mut data = vec![0; len];
         self.0
             .as_ref()
-            .unwrap()
+            .context("cannot read a metadata-only file object")?
             .read_exact_at(&mut data[..], offset)?;
         Ok(data)
     }
@@ -123,7 +178,7 @@ impl FileObject {
         File::open(path)?.sync_all()?;
         Ok(FileObject(
             Some(File::options().read(true).write(false).open(path)?),
-            data.len() as u64,
+            u64::try_from(data.len()).context("SST file is too large")?,
         ))
     }
 
@@ -158,20 +213,65 @@ impl SsTable {
     /// Open SSTable from a file.
     pub fn open(id: usize, block_cache: Option<Arc<BlockCache>>, file: FileObject) -> Result<Self> {
         let len = file.size();
-        let raw_bloom_offset = file.read(len - 4, 4)?;
-        let bloom_offset = (&raw_bloom_offset[..]).get_u32() as u64;
-        let raw_bloom = file.read(bloom_offset, len - 4 - bloom_offset)?;
+        let bloom_trailer_offset = len
+            .checked_sub(std::mem::size_of::<u32>() as u64)
+            .context("SST bloom-offset trailer is truncated")?;
+        let raw_bloom_offset = file.read(bloom_trailer_offset, 4)?;
+        let bloom_offset = u32::from_be_bytes([
+            raw_bloom_offset[0],
+            raw_bloom_offset[1],
+            raw_bloom_offset[2],
+            raw_bloom_offset[3],
+        ]) as u64;
+        ensure!(
+            bloom_offset <= bloom_trailer_offset,
+            "SST bloom offset is out of bounds"
+        );
+        let meta_trailer_offset = bloom_offset
+            .checked_sub(std::mem::size_of::<u32>() as u64)
+            .context("SST metadata-offset trailer is truncated")?;
+        let raw_bloom = file.read(bloom_offset, bloom_trailer_offset - bloom_offset)?;
         let bloom_filter = Bloom::decode(&raw_bloom)?;
-        let raw_meta_offset = file.read(bloom_offset - 4, 4)?;
-        let block_meta_offset = (&raw_meta_offset[..]).get_u32() as u64;
-        let raw_meta = file.read(block_meta_offset, bloom_offset - 4 - block_meta_offset)?;
+        let raw_meta_offset = file.read(meta_trailer_offset, 4)?;
+        let block_meta_offset = u32::from_be_bytes([
+            raw_meta_offset[0],
+            raw_meta_offset[1],
+            raw_meta_offset[2],
+            raw_meta_offset[3],
+        ]) as u64;
+        ensure!(
+            block_meta_offset <= meta_trailer_offset,
+            "SST block-metadata offset is out of bounds"
+        );
+        let raw_meta = file.read(block_meta_offset, meta_trailer_offset - block_meta_offset)?;
         let block_meta = BlockMeta::decode_block_meta(&raw_meta[..])?;
+        ensure!(!block_meta.is_empty(), "SST has no data blocks");
+        ensure!(
+            block_meta[0].offset == 0,
+            "first SST block must start at zero"
+        );
+        ensure!(
+            block_meta
+                .windows(2)
+                .all(|pair| pair[0].offset < pair[1].offset),
+            "SST block offsets are not strictly increasing"
+        );
+        let block_meta_offset_usize =
+            usize::try_from(block_meta_offset).context("SST metadata offset is too large")?;
+        ensure!(
+            block_meta.iter().all(|meta| {
+                meta.offset
+                    .checked_add(std::mem::size_of::<u32>())
+                    .is_some_and(|end| end < block_meta_offset_usize)
+            }),
+            "SST block offset or checksum is out of bounds"
+        );
         Ok(Self {
             file,
-            first_key: block_meta.first().unwrap().first_key.clone(),
-            last_key: block_meta.last().unwrap().last_key.clone(),
+            first_key: block_meta[0].first_key.clone(),
+            last_key: block_meta[block_meta.len() - 1].last_key.clone(),
             block_meta,
-            block_meta_offset: block_meta_offset as usize,
+            block_meta_offset: block_meta_offset_usize,
             id,
             block_cache,
             bloom: Some(bloom_filter),
@@ -201,21 +301,33 @@ impl SsTable {
 
     /// Read a block from the disk.
     pub fn read_block(&self, block_idx: usize) -> Result<Arc<Block>> {
-        let offset = self.block_meta[block_idx].offset;
+        let offset = self
+            .block_meta
+            .get(block_idx)
+            .context("SST block index is out of bounds")?
+            .offset;
         let offset_end = self
             .block_meta
             .get(block_idx + 1)
             .map_or(self.block_meta_offset, |x| x.offset);
-        let block_len = offset_end - offset - 4;
-        let block_data_with_chksum: Vec<u8> = self
-            .file
-            .read(offset as u64, (offset_end - offset) as u64)?;
+        let range_len = offset_end
+            .checked_sub(offset)
+            .context("SST block offsets are reversed")?;
+        let block_len = range_len
+            .checked_sub(std::mem::size_of::<u32>())
+            .context("SST block checksum is truncated")?;
+        let block_data_with_chksum: Vec<u8> = self.file.read(offset as u64, range_len as u64)?;
         let block_data = &block_data_with_chksum[..block_len];
-        let checksum = (&block_data_with_chksum[block_len..]).get_u32();
+        let checksum = u32::from_be_bytes([
+            block_data_with_chksum[block_len],
+            block_data_with_chksum[block_len + 1],
+            block_data_with_chksum[block_len + 2],
+            block_data_with_chksum[block_len + 3],
+        ]);
         if checksum != crc32fast::hash(block_data) {
             bail!("block checksum mismatched");
         }
-        Ok(Arc::new(Block::decode(block_data)))
+        Ok(Arc::new(Block::decode_checked(block_data)?))
     }
 
     /// Read a block from disk, with block cache.

--- a/mini-lsm/src/table/bloom.rs
+++ b/mini-lsm/src/table/bloom.rs
@@ -14,8 +14,8 @@
 
 // Copyright 2021 TiKV Project Authors. Licensed under Apache-2.0.
 
-use anyhow::{Result, bail};
-use bytes::{Buf, BufMut, Bytes, BytesMut};
+use anyhow::{Result, bail, ensure};
+use bytes::{BufMut, Bytes, BytesMut};
 
 /// Implements a bloom filter
 pub struct Bloom {
@@ -61,11 +61,18 @@ impl<T: AsMut<[u8]>> BitSliceMut for T {
 impl Bloom {
     /// Decode a bloom filter
     pub fn decode(buf: &[u8]) -> Result<Self> {
-        let checksum = (&buf[buf.len() - 4..buf.len()]).get_u32();
+        ensure!(buf.len() >= 5, "bloom filter is truncated");
+        let checksum = u32::from_be_bytes([
+            buf[buf.len() - 4],
+            buf[buf.len() - 3],
+            buf[buf.len() - 2],
+            buf[buf.len() - 1],
+        ]);
         if checksum != crc32fast::hash(&buf[..buf.len() - 4]) {
             bail!("checksum mismatched for bloom filters");
         }
         let filter = &buf[..buf.len() - 5];
+        ensure!(!filter.is_empty(), "bloom filter has no bits");
         let k = buf[buf.len() - 5];
         Ok(Self {
             filter: filter.to_vec().into(),

--- a/mini-lsm/src/table/builder.rs
+++ b/mini-lsm/src/table/builder.rs
@@ -15,7 +15,7 @@
 use std::path::Path;
 use std::sync::Arc;
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use bytes::BufMut;
 
 use super::bloom::Bloom;
@@ -99,15 +99,15 @@ impl SsTableBuilder {
         self.finish_block();
         let mut buf = self.data;
         let meta_offset = buf.len();
-        BlockMeta::encode_block_meta(&self.meta, &mut buf);
-        buf.put_u32(meta_offset as u32);
+        BlockMeta::encode_block_meta(&self.meta, &mut buf)?;
+        buf.put_u32(u32::try_from(meta_offset).context("SST metadata offset is too large")?);
         let bloom = Bloom::build_from_key_hashes(
             &self.key_hashes,
             Bloom::bloom_bits_per_key(self.key_hashes.len(), 0.01),
         );
         let bloom_offset = buf.len();
         bloom.encode(&mut buf);
-        buf.put_u32(bloom_offset as u32);
+        buf.put_u32(u32::try_from(bloom_offset).context("SST bloom offset is too large")?);
         let file = FileObject::create(path.as_ref(), buf)?;
         Ok(SsTable {
             id,

--- a/mini-lsm/src/tests.rs
+++ b/mini-lsm/src/tests.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 mod harness;
+mod release_regressions;
 mod week1_day1;
 mod week1_day2;
 mod week1_day3;

--- a/mini-lsm/src/tests/release_regressions.rs
+++ b/mini-lsm/src/tests/release_regressions.rs
@@ -1,0 +1,259 @@
+// Copyright (c) 2022-2025 Alex Chi Z
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::panic::{AssertUnwindSafe, catch_unwind};
+
+use anyhow::Result;
+use bytes::Bytes;
+use crossbeam_skiplist::SkipMap;
+use tempfile::tempdir;
+
+use crate::{
+    compact::CompactionOptions,
+    key::KeySlice,
+    lsm_storage::{LsmStorageOptions, MiniLsm, WriteBatchRecord},
+    manifest::{Manifest, ManifestRecord},
+    table::{FileObject, SsTable, SsTableBuilder},
+    wal::Wal,
+};
+
+fn options(enable_wal: bool) -> LsmStorageOptions {
+    let mut options = LsmStorageOptions::default_for_week2_test(CompactionOptions::NoCompaction);
+    options.enable_wal = enable_wal;
+    options
+}
+
+fn assert_round_trip(enable_wal: bool, key: &[u8], value: &[u8]) {
+    let dir = tempdir().unwrap();
+    let storage = MiniLsm::open(&dir, options(enable_wal)).unwrap();
+    storage.put(key, value).unwrap();
+    assert_eq!(
+        storage.get(key).unwrap(),
+        Some(Bytes::copy_from_slice(value))
+    );
+    storage.force_flush().unwrap();
+    assert_eq!(
+        storage.get(key).unwrap(),
+        Some(Bytes::copy_from_slice(value))
+    );
+    storage.close().unwrap();
+    drop(storage);
+
+    let storage = MiniLsm::open(&dir, options(enable_wal)).unwrap();
+    assert_eq!(
+        storage.get(key).unwrap(),
+        Some(Bytes::copy_from_slice(value))
+    );
+    storage.close().unwrap();
+}
+
+fn open_and_read_all_blocks(path: &std::path::Path) -> Result<()> {
+    let table = SsTable::open_for_test(FileObject::open(path)?)?;
+    for idx in 0..table.num_of_blocks() {
+        table.read_block(idx)?;
+    }
+    Ok(())
+}
+
+#[test]
+fn test_release_manifest_torn_tail_preserves_durable_prefix() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("MANIFEST");
+    let manifest = Manifest::create(&path).unwrap();
+    manifest
+        .add_record_when_init(ManifestRecord::NewMemtable(1))
+        .unwrap();
+    manifest
+        .add_record_when_init(ManifestRecord::NewMemtable(2))
+        .unwrap();
+    drop(manifest);
+
+    let encoded = std::fs::read(&path).unwrap();
+    let first_body_len = u64::from_be_bytes(encoded[..8].try_into().unwrap()) as usize;
+    let first_frame_len = 8 + first_body_len + 4;
+
+    for cutoff in 0..first_frame_len {
+        let truncated = dir.path().join(format!("first-{cutoff}.manifest"));
+        std::fs::write(&truncated, &encoded[..cutoff]).unwrap();
+        let (_, records) = Manifest::recover(&truncated).unwrap();
+        assert!(records.is_empty());
+        assert_eq!(std::fs::metadata(truncated).unwrap().len(), 0);
+    }
+
+    for cutoff in first_frame_len + 1..encoded.len() {
+        let truncated = dir.path().join(format!("second-{cutoff}.manifest"));
+        std::fs::write(&truncated, &encoded[..cutoff]).unwrap();
+        let (_, records) = Manifest::recover(&truncated).unwrap();
+        assert_eq!(records.len(), 1);
+        assert!(matches!(records[0], ManifestRecord::NewMemtable(1)));
+        assert_eq!(
+            std::fs::metadata(truncated).unwrap().len(),
+            first_frame_len as u64
+        );
+    }
+}
+
+#[test]
+fn test_release_manifest_corruption_never_panics() {
+    let dir = tempdir().unwrap();
+    let source = dir.path().join("MANIFEST");
+    let manifest = Manifest::create(&source).unwrap();
+    manifest
+        .add_record_when_init(ManifestRecord::NewMemtable(1))
+        .unwrap();
+    drop(manifest);
+    let encoded = std::fs::read(source).unwrap();
+
+    let mut checksum_corrupt = encoded.clone();
+    *checksum_corrupt.last_mut().unwrap() ^= 0x80;
+    let checksum_path = dir.path().join("checksum.manifest");
+    std::fs::write(&checksum_path, checksum_corrupt).unwrap();
+    assert!(Manifest::recover(checksum_path).is_err());
+
+    for idx in 0..8 {
+        let mut corrupt = encoded.clone();
+        corrupt[idx] ^= 0x80;
+        let path = dir.path().join(format!("length-{idx}.manifest"));
+        std::fs::write(&path, corrupt).unwrap();
+        let outcome = catch_unwind(AssertUnwindSafe(|| Manifest::recover(&path)));
+        assert!(outcome.is_ok(), "length byte {idx} panicked");
+    }
+}
+
+#[test]
+fn test_release_sst_corruption_and_truncation_never_panic() {
+    let dir = tempdir().unwrap();
+    let source = dir.path().join("source.sst");
+    let mut builder = SsTableBuilder::new(32);
+    builder.add(KeySlice::from_slice(b"a"), b"1");
+    builder.add(KeySlice::from_slice(b"b"), b"2");
+    drop(builder.build_for_test(&source).unwrap());
+    let encoded = std::fs::read(&source).unwrap();
+
+    for cutoff in 0..encoded.len() {
+        let path = dir.path().join(format!("truncated-{cutoff}.sst"));
+        std::fs::write(&path, &encoded[..cutoff]).unwrap();
+        let outcome = catch_unwind(AssertUnwindSafe(|| open_and_read_all_blocks(&path)));
+        assert!(outcome.is_ok(), "SST cutoff {cutoff} panicked");
+        assert!(
+            outcome.unwrap().is_err(),
+            "SST cutoff {cutoff} was accepted"
+        );
+    }
+
+    for idx in 0..encoded.len() {
+        let mut corrupt = encoded.clone();
+        corrupt[idx] ^= 0x80;
+        let path = dir.path().join(format!("corrupt-{idx}.sst"));
+        std::fs::write(&path, corrupt).unwrap();
+        let outcome = catch_unwind(AssertUnwindSafe(|| open_and_read_all_blocks(&path)));
+        assert!(outcome.is_ok(), "SST byte {idx} panicked");
+        assert!(outcome.unwrap().is_err(), "SST byte {idx} was accepted");
+    }
+}
+
+#[test]
+fn test_release_wal_torn_tail_preserves_durable_prefix() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("source.wal");
+    let wal = Wal::create(&path).unwrap();
+    wal.put(b"a", b"1").unwrap();
+    wal.put(b"b", b"2").unwrap();
+    wal.sync().unwrap();
+    drop(wal);
+    let encoded = std::fs::read(&path).unwrap();
+    let first_frame_len = 2 + 1 + 2 + 1 + 4;
+
+    for cutoff in 0..first_frame_len {
+        let truncated = dir.path().join(format!("first-{cutoff}.wal"));
+        std::fs::write(&truncated, &encoded[..cutoff]).unwrap();
+        let map = SkipMap::new();
+        drop(Wal::recover(&truncated, &map).unwrap());
+        assert!(map.is_empty());
+        assert_eq!(std::fs::metadata(truncated).unwrap().len(), 0);
+    }
+
+    for cutoff in first_frame_len + 1..encoded.len() {
+        let truncated = dir.path().join(format!("second-{cutoff}.wal"));
+        std::fs::write(&truncated, &encoded[..cutoff]).unwrap();
+        let map = SkipMap::new();
+        drop(Wal::recover(&truncated, &map).unwrap());
+        assert_eq!(map.get(b"a".as_slice()).unwrap().value(), b"1".as_slice());
+        assert!(map.get(b"b".as_slice()).is_none());
+        assert_eq!(
+            std::fs::metadata(truncated).unwrap().len(),
+            first_frame_len as u64
+        );
+    }
+}
+
+#[test]
+fn test_release_wal_corruption_and_oversized_fields_fail_closed() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("source.wal");
+    let wal = Wal::create(&path).unwrap();
+    wal.put(b"key", b"value").unwrap();
+    wal.sync().unwrap();
+    drop(wal);
+    let encoded = std::fs::read(&path).unwrap();
+
+    for idx in 0..encoded.len() {
+        let mut corrupt = encoded.clone();
+        corrupt[idx] ^= 0x80;
+        let corrupt_path = dir.path().join(format!("corrupt-{idx}.wal"));
+        std::fs::write(&corrupt_path, corrupt).unwrap();
+        let map = SkipMap::new();
+        let outcome = catch_unwind(AssertUnwindSafe(|| Wal::recover(&corrupt_path, &map)));
+        assert!(outcome.is_ok(), "WAL byte {idx} panicked");
+    }
+
+    let empty_path = dir.path().join("empty.wal");
+    let wal = Wal::create(&empty_path).unwrap();
+    let oversized = vec![0; usize::from(u16::MAX) + 1];
+    assert!(wal.put(b"key", &oversized).is_err());
+    assert!(wal.put(&oversized, b"value").is_err());
+    wal.sync().unwrap();
+    drop(wal);
+    assert_eq!(std::fs::metadata(empty_path).unwrap().len(), 0);
+}
+
+#[test]
+fn test_release_public_write_size_boundaries() {
+    let max_key = vec![b'k'; usize::from(u16::MAX)];
+    let max_value = vec![b'v'; usize::from(u16::MAX)];
+    for enable_wal in [false, true] {
+        assert_round_trip(enable_wal, b"value-boundary", &max_value);
+        assert_round_trip(enable_wal, &max_key, b"key-boundary");
+
+        let dir = tempdir().unwrap();
+        let storage = MiniLsm::open(&dir, options(enable_wal)).unwrap();
+        let oversized = vec![0; usize::from(u16::MAX) + 1];
+        assert!(storage.put(b"oversized-value", &oversized).is_err());
+        assert!(storage.put(&oversized, b"oversized-key").is_err());
+        let batch = [
+            WriteBatchRecord::Put(b"would-be-partial".as_slice(), b"value".as_slice()),
+            WriteBatchRecord::Put(b"oversized".as_slice(), oversized.as_slice()),
+        ];
+        assert!(storage.write_batch(&batch).is_err());
+        assert_eq!(storage.get(b"would-be-partial").unwrap(), None);
+        assert_eq!(storage.get(b"oversized-value").unwrap(), None);
+        storage.close().unwrap();
+        drop(storage);
+
+        let storage = MiniLsm::open(&dir, options(enable_wal)).unwrap();
+        assert_eq!(storage.get(b"would-be-partial").unwrap(), None);
+        assert_eq!(storage.get(b"oversized-value").unwrap(), None);
+        storage.close().unwrap();
+    }
+}

--- a/mini-lsm/src/wal.rs
+++ b/mini-lsm/src/wal.rs
@@ -19,7 +19,7 @@ use std::path::Path;
 use std::sync::Arc;
 
 use anyhow::{Context, Result, bail};
-use bytes::{Buf, BufMut, Bytes};
+use bytes::{BufMut, Bytes};
 use crossbeam_skiplist::SkipMap;
 use parking_lot::Mutex;
 
@@ -52,24 +52,57 @@ impl Wal {
             .context("failed to recover from WAL")?;
         let mut buf = Vec::new();
         file.read_to_end(&mut buf)?;
-        let mut rbuf: &[u8] = buf.as_slice();
-        while rbuf.has_remaining() {
-            let mut hasher = crc32fast::Hasher::new();
-            let key_len = rbuf.get_u16() as usize;
-            hasher.write(&(key_len as u16).to_be_bytes());
-            let key = Bytes::copy_from_slice(&rbuf[..key_len]);
-            hasher.write(&key);
-            rbuf.advance(key_len);
-            let value_len = rbuf.get_u16() as usize;
-            hasher.write(&(value_len as u16).to_be_bytes());
-            let value = Bytes::copy_from_slice(&rbuf[..value_len]);
-            hasher.write(&value);
-            rbuf.advance(value_len);
-            let checksum = rbuf.get_u32();
-            if hasher.finalize() != checksum {
-                bail!("checksum mismatch");
+        let mut valid_len = 0usize;
+        while valid_len < buf.len() {
+            let remaining = &buf[valid_len..];
+            if remaining.len() < std::mem::size_of::<u16>() {
+                break;
             }
+            let key_len = u16::from_be_bytes([remaining[0], remaining[1]]) as usize;
+            let Some(value_len_offset) = std::mem::size_of::<u16>().checked_add(key_len) else {
+                break;
+            };
+            let Some(value_offset) = value_len_offset.checked_add(std::mem::size_of::<u16>())
+            else {
+                break;
+            };
+            if remaining.len() < value_offset {
+                break;
+            }
+            let value_len =
+                u16::from_be_bytes([remaining[value_len_offset], remaining[value_len_offset + 1]])
+                    as usize;
+            let Some(checksum_offset) = value_offset.checked_add(value_len) else {
+                break;
+            };
+            let Some(record_len) = checksum_offset.checked_add(std::mem::size_of::<u32>()) else {
+                break;
+            };
+            if remaining.len() < record_len {
+                break;
+            }
+
+            let expected_checksum = u32::from_be_bytes([
+                remaining[checksum_offset],
+                remaining[checksum_offset + 1],
+                remaining[checksum_offset + 2],
+                remaining[checksum_offset + 3],
+            ]);
+            if crc32fast::hash(&remaining[..checksum_offset]) != expected_checksum {
+                bail!("WAL checksum mismatch at byte offset {valid_len}");
+            }
+            let key = Bytes::copy_from_slice(&remaining[2..value_len_offset]);
+            let value = Bytes::copy_from_slice(&remaining[value_offset..checksum_offset]);
             skiplist.insert(key, value);
+            valid_len += record_len;
+        }
+
+        if valid_len < buf.len() {
+            eprintln!("warning: ignoring incomplete WAL record at byte offset {valid_len}");
+            file.set_len(valid_len as u64)
+                .context("failed to truncate incomplete WAL tail")?;
+            file.sync_all()
+                .context("failed to sync truncated WAL tail")?;
         }
         Ok(Self {
             file: Arc::new(Mutex::new(BufWriter::new(file))),
@@ -77,17 +110,19 @@ impl Wal {
     }
 
     pub fn put(&self, key: &[u8], value: &[u8]) -> Result<()> {
+        let key_len = u16::try_from(key.len()).context("WAL key is too large")?;
+        let value_len = u16::try_from(value.len()).context("WAL value is too large")?;
         let mut file = self.file.lock();
         let mut buf: Vec<u8> = Vec::with_capacity(
             key.len() + value.len() + std::mem::size_of::<u16>() * 2 + std::mem::size_of::<u32>(),
         );
         let mut hasher = crc32fast::Hasher::new();
-        hasher.write(&(key.len() as u16).to_be_bytes());
-        buf.put_u16(key.len() as u16);
+        hasher.write(&key_len.to_be_bytes());
+        buf.put_u16(key_len);
         hasher.write(key);
         buf.put_slice(key);
-        hasher.write(&(value.len() as u16).to_be_bytes());
-        buf.put_u16(value.len() as u16);
+        hasher.write(&value_len.to_be_bytes());
+        buf.put_u16(value_len);
         buf.put_slice(value);
         hasher.write(value);
         // add checksum: week 2 day 7


### PR DESCRIPTION
## Why

Malformed or torn persistence records could panic during recovery, and 65,536-byte keys or values could wrap their on-disk lengths after mutating engine state.

## What changed

- validate manifest, SST/block/Bloom, and WAL framing before indexing or decoding; retain only a complete durable prefix for torn final records
- reject unrepresentable fields and batches before engine or WAL mutation in both standard and MVCC tracks
- add exhaustive truncation/corruption, 65,535/65,536 boundary, and SST/WAL restart timestamp regressions

## Review note

cargo x ci passes 171/171. The SST and live-WAL timestamp regressions each fail under independent max-to-last/first mutations and pass restored.

AI-Assisted: GPT-5.6 Sol + Forge
Reviewed-by: DeepSeek V4 Flash + Oracle (consistency)
Reviewed-by: GPT-5.6 Sol + Sage (correctness)