### PR TITLE
Remove redundant coding-agent progress label

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Mini-LSM is a hands-on course in database internals for systems and backend engineers. Build an LSM-tree storage engine from memtables and SSTs through compaction, crash recovery, MVCC, and transactions.
 
-**[Start the guided three-week course](https://skyzh.github.io/mini-lsm)** · **[Try the coding-agent track](https://skyzh.github.io/mini-lsm/agent-fast-forward-overview.html) (in progress)**
+**[Start the guided three-week course](https://skyzh.github.io/mini-lsm)** · **[Try the coding-agent track](https://skyzh.github.io/mini-lsm/agent-fast-forward-overview.html)**
 
 Week 1 produces a working storage engine. Weeks 2 and 3 add production-inspired compaction, durability, concurrency control, and multi-version transactions.
 


### PR DESCRIPTION
## Why

The coding-agent track is available, while its precise work-in-progress status already lives in the path table.

## What changed

Removed the redundant “in progress” label from the top coding-agent link. The path table still says “Days 1–3 available (WIP).”

AI-Assisted: GPT-5.6 Sol + Sentinel

Reviewed-by: DeepSeek V4 Flash + Oracle (consistency)
