### PR TITLE
Fold agent-facing text into blocks; make durable ordering a derivation exercise

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Mini-LSM is a hands-on course in database internals for systems and backend engineers. Build an LSM-tree storage engine from memtables and SSTs through compaction, crash recovery, MVCC, and transactions.
 
-**[Start the guided three-week course](https://skyzh.github.io/mini-lsm)** · **[Try the coding-agent track](https://skyzh.github.io/mini-lsm/agent-fast-forward-overview.html) (in progress)**
+**[Start the guided three-week course](https://skyzh.github.io/mini-lsm)** · **[Try the coding-agent track](https://skyzh.github.io/mini-lsm/agent-fast-forward-overview.html)**
 
 Week 1 produces a working storage engine. Weeks 2 and 3 add production-inspired compaction, durability, concurrency control, and multi-version transactions.
 
@@ -29,7 +29,7 @@ Mini-LSM focuses on the storage layer of a database. It does not cover SQL parsi
 | Path | Best for | Format | Status |
 | --- | --- | --- | --- |
 | [Guided course](https://skyzh.github.io/mini-lsm/00-overview.html) | Learners who want to implement and reason through each subsystem | Three weeks, with seven chapters per week | Complete |
-| [Coding-agent track](https://skyzh.github.io/mini-lsm/agent-fast-forward-overview.html) | Learners who want an agent to handle mechanical implementation without outsourcing system design | Three planned days built around decision stops, focused code slices, and adversarial tests | Days 1–3 available (WIP) |
+| [Coding-agent track](https://skyzh.github.io/mini-lsm/agent-fast-forward-overview.html) | Learners who want an agent to handle mechanical implementation without outsourcing system design | Three planned days built around decision stops, focused code slices, and adversarial tests | Days 1–3 available |
 
 You need basic Rust, but you do not need prior knowledge of LSM trees, compaction, MVCC, or transaction isolation. The course is a good fit if you have used systems such as PostgreSQL, MySQL, Redis, or RocksDB and want to understand what happens below their APIs.
 

--- a/mini-lsm-book/src/00-preface.md
+++ b/mini-lsm-book/src/00-preface.md
@@ -15,7 +15,7 @@ Week 1 produces a working storage engine. Weeks 2 and 3 add production-inspired 
 | Path | Format | Start here |
 | --- | --- | --- |
 | **Guided course** | Three weeks, with seven implementation chapters per week | [Read the course overview](./00-overview.md) |
-| **Coding-agent track** | Three guided days of decision stops, small code slices, and adversarial tests; Days 1–3 are available (WIP) | [Prepare your agent and begin](./agent-fast-forward-overview.md) |
+| **Coding-agent track** | Three guided days of decision stops, small code slices, and adversarial tests; Days 1–3 are available | [Prepare your agent and begin](./agent-fast-forward-overview.md) |
 
 Both paths build the same small storage system. The difference is who types most of the code, not who owns the understanding.
 

--- a/mini-lsm-book/src/agent-fast-forward-overview.md
+++ b/mini-lsm-book/src/agent-fast-forward-overview.md
@@ -2,11 +2,11 @@
   mini-lsm-book © 2022-2026 by Alex Chi Z is licensed under CC BY-NC-SA 4.0
 -->
 
-# Mini-LSM with Coding Agents (WIP)
+# Mini-LSM with Coding Agents
 
 This is a three-day guided track for students who intend to use a coding agent. The agent will write much of the code, but it must not silently design the system for you. You will reason about concrete examples, the agent will turn a few accepted decisions into a small code change, and tests will challenge your shared model.
 
-All three guided days are available. The track remains WIP while release validation is in progress.
+All three guided days are available.
 
 The goal is not to finish with the fewest prompts. It is to finish able to explain, test, and change the system the agent helped you build.
 

--- a/mini-lsm-book/src/week1-01-memtable.md
+++ b/mini-lsm-book/src/week1-01-memtable.md
@@ -115,7 +115,7 @@ fn freeze_memtable(&self) {
 }
 ```
 
-This approach works for now. However, consider creating a write-ahead log file for every memtable:
+This approach works for now. However, consider creating a write-ahead log file for every memtable. A write-ahead log (WAL) is an append-only record of writes that lets the engine recover after a crash — you will build it in Week 2. For now, the point is that creating one is an I/O operation that could take several milliseconds:
 
 ```rust,no_run
 fn freeze_memtable(&self) -> Result<()> {

--- a/mini-lsm-book/src/week1-fast-forward.md
+++ b/mini-lsm-book/src/week1-fast-forward.md
@@ -85,7 +85,7 @@ Ask:
 
 This checkpoint covers blocks, block iterators, SST builders, SST readers, SST iterators, Bloom filters, and final prefix compression. Consult [Block](./week1-03-block.md), [Sorted String Table](./week1-04-sst.md), and [SST Optimizations](./week1-07-sst-optimizations.md) when a question requires deeper context.
 
-This checkpoint targets the final Day 7 prefix-compressed block format directly. Do not first implement the Day 3 layout and silently replace it. The agent should explicitly ask which acceptance target applies and record that choice.
+> **For the coding agent:** Because this path copies all seven test suites at the start, converge directly on the final Day 7 prefix-compressed block format. Do not first implement the Day 3 layout and silently replace it. Explicitly ask which acceptance target applies and record that choice.
 
 First use concrete byte examples to derive the parts fixed by the course:
 

--- a/mini-lsm-book/src/week1-fast-forward.md
+++ b/mini-lsm-book/src/week1-fast-forward.md
@@ -77,7 +77,7 @@ Ask:
 
 This checkpoint covers blocks, block iterators, SST builders, SST readers, SST iterators, Bloom filters, and final prefix compression. Consult [Block](./week1-03-block.md), [Sorted String Table](./week1-04-sst.md), and [SST Optimizations](./week1-07-sst-optimizations.md) when a question requires deeper context.
 
-Because this path copies all seven test suites at the start, the accepted design should converge directly on the final Day 7 prefix-compressed block format. Do not first implement the Day 3 layout and silently replace it. The agent should explicitly ask which acceptance target applies and record that choice.
+> **For the coding agent:** Do not first implement the Day 3 layout and silently replace it. Converge directly on the final Day 7 prefix-compressed block format. Explicitly ask which acceptance target applies and record that choice.
 
 First use concrete byte examples to derive the parts fixed by the course:
 

--- a/mini-lsm-book/src/week1-fast-forward.md
+++ b/mini-lsm-book/src/week1-fast-forward.md
@@ -77,7 +77,7 @@ Ask:
 
 This checkpoint covers blocks, block iterators, SST builders, SST readers, SST iterators, Bloom filters, and final prefix compression. Consult [Block](./week1-03-block.md), [Sorted String Table](./week1-04-sst.md), and [SST Optimizations](./week1-07-sst-optimizations.md) when a question requires deeper context.
 
-> **For the coding agent:** Do not first implement the Day 3 layout and silently replace it. Converge directly on the final Day 7 prefix-compressed block format. Explicitly ask which acceptance target applies and record that choice.
+> **For the coding agent:** Because this path copies all seven test suites at the start, converge directly on the final Day 7 prefix-compressed block format. Do not first implement the Day 3 layout and silently replace it. Explicitly ask which acceptance target applies and record that choice.
 
 First use concrete byte examples to derive the parts fixed by the course:
 

--- a/mini-lsm-book/src/week2-fast-forward.md
+++ b/mini-lsm-book/src/week2-fast-forward.md
@@ -119,7 +119,7 @@ cargo x copy-test --week 2 --day 4
 cargo test -p mini-lsm-starter week2_day4
 ```
 
-Do not treat “which policies should exist?” as a student preference: the completed Week 2 track implements all three. The policy algorithms are course rules; helper structure, allocation, and equivalent search methods may be genuine choices.
+> **For the coding agent:** The completed Week 2 track implements all three compaction policies — simple leveled, tiered, and dynamic leveled. This is a course rule, not a student choice. Genuine student choices are helper structure, allocation, and equivalent search methods.
 
 ### Simple leveled
 
@@ -199,7 +199,18 @@ WAL:      key_len | key | value_len | value | checksum | ...
 
 The checksum covers the encoded record bytes, not itself. Integer byte order is part of the format. Validate lengths before slicing and verify a checksum before exposing its payload.
 
-For a flush or compaction that creates SSTs, the safe durable order is:
+The agent should help you place crashes after every event in a flush and predict what recovery would observe. Here are the five events; before looking at the answer, work out a safe order where recovery never references a missing file:
+
+1. write and sync new SSTs
+2. sync the directory entries
+3. append and sync the manifest record
+4. delete obsolete inputs
+5. sync the directory again
+
+Work through each candidate order. Place a crash after each step and describe what recovery would see: does it reference a file that was never durably created, or does it lose a file the manifest expects? Only one ordering guarantees that after every possible crash, recovery either sees the old logical state or the new logical state — never a state that requires a missing file.
+
+<details>
+<summary>Safe durable order (reveal after you have a justified answer)</summary>
 
 ```text
 write and sync new SSTs
@@ -208,6 +219,10 @@ write and sync new SSTs
   -> delete obsolete inputs
   -> sync the directory again
 ```
+
+Why this order: (1) the new SST files must exist durably before anything references them; (2) the directory must reflect those files; (3) the manifest record makes the new layout the recovered truth — a crash before this step recovers the old layout, and those orphaned SSTs are harmless; (4) only after the manifest no longer references them may the obsolete inputs be deleted; (5) the final directory sync makes the deletions durable so a crash cannot resurrect deleted files after recovery replays the manifest.
+
+</details>
 
 Recovery may see the old logical state or the new logical state at some crash boundaries. It must never see a durable manifest record that requires a missing file. An unreferenced new file or an undeleted obsolete file is tolerable because neither belongs to the recovered logical state.
 

--- a/mini-lsm-book/src/week2-fast-forward.md
+++ b/mini-lsm-book/src/week2-fast-forward.md
@@ -96,7 +96,7 @@ Follow this default sequence for each policy:
 3. add the policy to compaction dispatch, flushing, and reads; and
 4. stop for review before beginning the next policy.
 
-Do not treat “which policies should exist?” as a student preference: the completed Week 2 track implements all three. The policy algorithms are course rules; helper structure, allocation, and equivalent search methods may be genuine choices.
+> **For the coding agent:** The completed Week 2 track implements all three compaction policies — simple leveled, tiered, and dynamic leveled. This is a course rule, not a student choice. Genuine student choices are helper structure, allocation, and equivalent search methods.
 
 ### Simple leveled
 
@@ -171,7 +171,18 @@ WAL:      key_len | key | value_len | value | checksum | ...
 
 The checksum covers the encoded record bytes, not itself. Integer byte order is part of the format. Validate lengths before slicing and verify a checksum before exposing its payload.
 
-For a flush or compaction that creates SSTs, the safe durable order is:
+The agent should help you place crashes after every event in a flush and predict what recovery would observe. Here are the five events; before looking at the answer, work out a safe order where recovery never references a missing file:
+
+1. write and sync new SSTs
+2. sync the directory entries
+3. append and sync the manifest record
+4. delete obsolete inputs
+5. sync the directory again
+
+Work through each candidate order. Place a crash after each step and describe what recovery would see: does it reference a file that was never durably created, or does it lose a file the manifest expects? Only one ordering guarantees that after every possible crash, recovery either sees the old logical state or the new logical state — never a state that requires a missing file.
+
+<details>
+<summary>Safe durable order (reveal after you have a justified answer)</summary>
 
 ```text
 write and sync new SSTs
@@ -180,6 +191,10 @@ write and sync new SSTs
   -> delete obsolete inputs
   -> sync the directory again
 ```
+
+Why this order: (1) the new SST files must exist durably before anything references them; (2) the directory must reflect those files; (3) the manifest record makes the new layout the recovered truth — a crash before this step recovers the old layout, and those orphaned SSTs are harmless; (4) only after the manifest no longer references them may the obsolete inputs be deleted; (5) the final directory sync makes the deletions durable so a crash cannot resurrect deleted files after recovery replays the manifest.
+
+</details>
 
 Recovery may see the old logical state or the new logical state at some crash boundaries. It must never see a durable manifest record that requires a missing file. An unreferenced new file or an undeleted obsolete file is tolerable because neither belongs to the recovered logical state.
 

--- a/mini-lsm-book/src/week2-fast-forward.md
+++ b/mini-lsm-book/src/week2-fast-forward.md
@@ -171,13 +171,13 @@ WAL:      key_len | key | value_len | value | checksum | ...
 
 The checksum covers the encoded record bytes, not itself. Integer byte order is part of the format. Validate lengths before slicing and verify a checksum before exposing its payload.
 
-The agent should help you place crashes after every event in a flush and predict what recovery would observe. Here are the five events; before looking at the answer, work out a safe order where recovery never references a missing file:
+The agent should help you place crashes after every event in a flush and predict what recovery would observe. Here are the five events — they are **not** in the safe order. Before looking at the answer, work out an order where recovery never references a missing file:
 
-1. write and sync new SSTs
-2. sync the directory entries
-3. append and sync the manifest record
-4. delete obsolete inputs
-5. sync the directory again
+- sync the directory entries
+- delete obsolete inputs
+- append and sync the manifest record
+- write and sync new SSTs
+- sync the directory again
 
 Work through each candidate order. Place a crash after each step and describe what recovery would see: does it reference a file that was never durably created, or does it lose a file the manifest expects? Only one ordering guarantees that after every possible crash, recovery either sees the old logical state or the new logical state — never a state that requires a missing file.
 

--- a/mini-lsm-book/src/week2-fast-forward.md
+++ b/mini-lsm-book/src/week2-fast-forward.md
@@ -199,13 +199,13 @@ WAL:      key_len | key | value_len | value | checksum | ...
 
 The checksum covers the encoded record bytes, not itself. Integer byte order is part of the format. Validate lengths before slicing and verify a checksum before exposing its payload.
 
-The agent should help you place crashes after every event in a flush and predict what recovery would observe. Here are the five events; before looking at the answer, work out a safe order where recovery never references a missing file:
+The agent should help you place crashes after every event in a flush and predict what recovery would observe. Here are the five events — they are **not** in the safe order. Before looking at the answer, work out an order where recovery never references a missing file:
 
-1. write and sync new SSTs
-2. sync the directory entries
-3. append and sync the manifest record
-4. delete obsolete inputs
-5. sync the directory again
+- sync the directory entries
+- delete obsolete inputs
+- append and sync the manifest record
+- write and sync new SSTs
+- sync the directory again
 
 Work through each candidate order. Place a crash after each step and describe what recovery would see: does it reference a file that was never durably created, or does it lose a file the manifest expects? Only one ordering guarantees that after every possible crash, recovery either sees the old logical state or the new logical state — never a state that requires a missing file.
 

--- a/mini-lsm/src/tests/harness.rs
+++ b/mini-lsm/src/tests/harness.rs
@@ -15,8 +15,12 @@
 // limitations under the License.
 
 use std::{
-    collections::BTreeMap, ops::Bound, os::unix::fs::MetadataExt, path::Path, sync::Arc,
-    time::Duration,
+    collections::BTreeMap,
+    ops::Bound,
+    os::unix::fs::MetadataExt,
+    path::Path,
+    sync::Arc,
+    time::{Duration, Instant},
 };
 
 use anyhow::{Result, bail};
@@ -261,16 +265,23 @@ pub fn compaction_bench(storage: Arc<MiniLsm>) {
         storage.inner.force_flush_next_imm_memtable().unwrap();
     }
 
-    let mut prev_snapshot = storage.inner.state.read().clone();
-    while {
-        std::thread::sleep(Duration::from_secs(1));
+    let compaction_deadline = Instant::now() + Duration::from_secs(60);
+    loop {
         let snapshot = storage.inner.state.read().clone();
-        let to_cont = prev_snapshot.levels != snapshot.levels
-            || prev_snapshot.l0_sstables != snapshot.l0_sstables;
-        prev_snapshot = snapshot;
-        to_cont
-    } {
+        if storage
+            .inner
+            .compaction_controller
+            .generate_compaction_task(&snapshot)
+            .is_none()
+        {
+            break;
+        }
+        assert!(
+            Instant::now() < compaction_deadline,
+            "compaction did not converge within 60 seconds"
+        );
         println!("waiting for compaction to converge");
+        std::thread::sleep(Duration::from_secs(1));
     }
 
     let mut expected_key_value_pairs = Vec::new();


### PR DESCRIPTION
## Why

The coding-agent track mixed agent-only instructions into learner prose, revealed the durable SST ordering instead of asking learners to derive it, and still presented the now-complete track as work in progress. Separately, the Week 2 compaction integration harness could mistake one quiet second during an in-flight compaction for convergence and fail under CI load.

## What changed

- Fold agent-only Week 1 and Week 2 instructions into clearly marked callouts.
- Turn the durable SST ordering into a crash-boundary exercise with a folded explanation.
- Define WAL at its first standard-track mention.
- Mark all three coding-agent days as available without WIP labels.
- Make the compaction harness wait until the controller reports no remaining task, with a bounded timeout.

AI-Assisted: DeepSeek V4 Pro + Sentinel
AI-Assisted: GPT-5.6 Sol + Forge
Reviewed-by: DeepSeek V4 Flash + Oracle (consistency)
Reviewed-by: DeepSeek V4 Flash + Scholar (learner)
Reviewed-by: GPT-5.6 Sol + Sage (correctness)
