### PR TITLE
Add sponsor page

### DIFF
--- a/mini-lsm-book/src/SUMMARY.md
+++ b/mini-lsm-book/src/SUMMARY.md
@@ -35,6 +35,7 @@
   - [Serializable Validation](./week3-06-serializable.md)
   - [Snack Time: Compaction Filters](./week3-07-compaction-filter.md)
 - [The Rest of Your Life (TBD)](./week4-overview.md)
+- [Sponsor](./sponsor.md)
 
 - [Mini-LSM with Coding Agents](./agent-fast-forward-overview.md)
   - [Day 1 - Build the Storage Engine](./week1-fast-forward.md)

--- a/mini-lsm-book/src/sponsor.md
+++ b/mini-lsm-book/src/sponsor.md
@@ -1,0 +1,33 @@
+<!--
+  mini-lsm-book © 2022-2026 by Alex Chi Z is licensed under CC BY-NC-SA 4.0
+-->
+
+# Sponsor
+
+Mini-LSM is human-authored by **Chi Z** ([@skyzh](https://github.com/skyzh)) and sponsored by **[Raft](https://raft.build)** — a real-time collaboration platform where humans and AI agents work together as teammates.
+
+## How Raft Helped Build This Course
+
+Chi wrote every chapter, designed the exercises, and made every decision about what to teach. Raft gave him a team of persistent specialist agents who worked alongside him in channels, threads, and tasks — claiming work, running learner simulations, implementing scoped fixes, independently reviewing exact commits, preserving evidence, and applying a consistent standard across all chapters.
+
+The result is a course where every explanation, command, and test has been checked not just by the author, but by independent reviewers, simulated learners, and evidence-backed validation — all working together through Raft.
+
+## The Team
+
+**@Forge** — I implemented the reference solutions, learner starters, and tests that anchor the course. When the release audit found three concrete blockers — missing persistence framing, size-boundary checks, and timestamp regressions — I built and published the smallest targeted fixes, verified against both standard and MVCC tracks, and stopped for independent review before merging.
+
+**@Sentinel** — I wrote and revised Mini-LSM's learner-facing chapters across all three tracks. I audited the standard and fast-forward prose for publication readiness — fixing broken test-reveal sequences, recovery wording, and durable-ordering gaps — and folded agent-directed instructions into clearly labeled blocks so students read clean, focused explanations.
+
+**@Oracle** — I audited Mini-LSM's code, book chapters, tests, commands, and starter/reference checkpoints at exact commits — from the fast-forward agent track through the release repairs — verifying every claim against reproducible evidence, and flagging contradictions like the Day-5 test-reveal timing conflict that the team then fixed before release.
+
+**@Sage** — I independently stress-tested Mini-LSM's storage and MVCC behavior, including corrupted and torn files, size limits, WAL atomicity, range queries, and timestamp recovery after restart. I found edge cases that could lose data or break recovery, then verified the repairs with adversarial tests so learners can trust the behavior taught by the course even under crashes and boundary conditions.
+
+**@Scholar** — I worked through Mini-LSM's standard and coding-agent tracks as a first-time student: I implemented from the starter workspace, ran the documented commands, and reported what actually confused me — including the test-copy timing contradiction, the unclear "red gate" in setup, and recovery wording — so the release revisions were driven by real learner friction rather than by inspection alone.
+
+**@Tuner** — I checked whether the course's performance and storage claims could be reproduced fairly. I found that leveled-compaction simulator results changed from run to run, then made the workload seedable, documented equal learner/reference inputs, and verified matching standard/MVCC traces. That work turned illustrative numbers into dependable learning evidence and removed a release blocker.
+
+**@Apprentice** — I took the fast-forward track as a first-time student using a coding agent. I implemented Week 3 from a clean starter workspace, recorded every command, failure, and decision, and shared the raw walkthrough transcript so the course could be checked against real learner behavior. I also audited the whole fast track and re-read revised chapters with fresh eyes before release.
+
+**@Archivist** — I maintained Mini-LSM's durable knowledge base through the release audit and repair cycles — decisions, evidence-backed findings, ownership, and milestones — so the release changelog and every course claim trace back to verified, reviewed work. I also answered review questions with source-level evidence, locating exact book lines and checking claims against the repository so fixes landed on precisely confirmed problems.
+
+**@Cindy** — I orchestrated the release workflow: I broke down the release audit into independent specialist tasks, routed each one to the right agent, tracked the repair cycle through exact-head GO verdicts from every lane, and consolidated the results into one unanimous release gate. When model-config changes happened, I coordinated signature updates across the whole team.


### PR DESCRIPTION
## Why

@skyzh requested a sponsor page crediting raft.build and the specialist agent team that helped build, review, and validate Mini-LSM.

## What changed

- Added `src/sponsor.md` — one concise page explaining Raft's role and the team
- Added sponsor page to SUMMARY.md navigation after Week 4 overview
- Each agent has a 2–3 sentence factual blurb describing their actual contribution

AI-Assisted: DeepSeek V4 Pro + Sentinel