### PR TITLE
Fold agent-facing text into blocks and convert durable ordering to exercise

### DIFF
--- a/mini-lsm-book/src/agent-fast-forward-overview.md
+++ b/mini-lsm-book/src/agent-fast-forward-overview.md
@@ -64,7 +64,9 @@ Begin a checkpoint with an ordinary capability request:
 
 > Implement block format.
 
-That prompt authorizes the learning process, not a one-shot patch. The agent should inspect allowed context and ask its first design question. It should not return a complete design, edit code, or run ahead to a passing suite.
+That prompt authorizes the learning process, not a one-shot patch.
+
+> **For the agent:** Inspect allowed context and ask your first design question. Do not return a complete design, edit code, or run ahead to a passing suite.
 
 Repeat this loop:
 
@@ -76,9 +78,7 @@ Repeat this loop:
 6. **Tests produce evidence.** A coding mistake can be fixed directly. A failure that exposes an unsettled or incorrect design returns to the dialogue.
 7. **Student reviews.** Inspect the diff and test output before authorizing the next slice.
 
-The agent must stop on topics that affect behavior or understanding: representation, ordering, ownership, size and boundary accounting, seek behavior, errors, synchronization, and where an optimization belongs. Some answers are course rules to derive; others are genuine choices. It need not interrupt you over a local variable name, import order, formatting, or an obvious compiler-directed repair.
-
-The distinction keeps the conversation educational without turning every keystroke into ceremony.
+> **For the agent:** You must stop on topics that affect behavior or understanding: representation, ordering, ownership, size and boundary accounting, seek behavior, errors, synchronization, and where an optimization belongs. Some answers are course rules to derive; others are genuine choices. Do not interrupt over a local variable name, import order, formatting, or an obvious compiler-directed repair. The distinction keeps the conversation educational without turning every keystroke into ceremony.
 
 At any stop, you can answer with one of these commands:
 
@@ -117,17 +117,17 @@ Delegating one choice is not permission for the agent to decide the rest.
 
 ## Review a Code Slice
 
-Before each edit, the agent should state:
-
-- which accepted decisions determine the slice;
-- which files and observable behavior will change; and
-- which focused check it expects to exercise that behavior.
+> **For the agent:** Before each edit, state:
+>
+> - which accepted decisions determine the slice;
+> - which files and observable behavior will change; and
+> - which focused check you expect to exercise that behavior.
 
 After the edit, require the exact command and result, then ask:
 
 > Treat this slice as untrusted. Connect the changed behavior to the decision ledger and supplied tests. Identify one plausible bug that could still pass, propose the smallest adversarial check, and ask me to predict its outcome before adding it.
 
-The agent should also point to one important changed line and ask: “What is this line trying to do, and what behavior might break if it changed?” The purpose is to connect a decision to code, not to quiz you on arbitrary syntax.
+> **For the agent:** Also point to one important changed line and ask: “What is this line trying to do, and what behavior might break if it changed?” The purpose is to connect a decision to code, not to quiz you on arbitrary syntax.
 
 Do not let “all tests pass” end the review. Conversely, once the contract and adversarial checks are satisfied, continue to the next unresolved decision instead of inventing unrelated refactors.
 

--- a/mini-lsm-book/src/week1-01-memtable.md
+++ b/mini-lsm-book/src/week1-01-memtable.md
@@ -117,6 +117,8 @@ fn freeze_memtable(&self) {
 
 This approach works for now. However, consider creating a write-ahead log file for every memtable:
 
+A write-ahead log (WAL) is an append-only record of recent writes that lets the engine recover after a crash; it is not part of this chapter — the example only shows why creating it must not happen inside the state lock. You will build the WAL in Week 2 Day 6.
+
 ```rust,no_run
 fn freeze_memtable(&self) -> Result<()> {
     let mut guard = self.state.write();

--- a/mini-lsm-book/src/week1-fast-forward.md
+++ b/mini-lsm-book/src/week1-fast-forward.md
@@ -54,7 +54,7 @@ Ask:
 
 This checkpoint covers the memtable and iterator layers. Use the [Memtable](./week1-01-memtable.md) and [Merge Iterator](./week1-02-merge-iterator.md) chapters when a question needs more context.
 
-The agent should use concrete examples to help you work out at least these course rules:
+> **For the agent:** Use concrete examples to help the student work out at least these course rules:
 
 | Behavior to work out | Small case that exposes it |
 | --- | --- |
@@ -77,7 +77,7 @@ Ask:
 
 This checkpoint covers blocks, block iterators, SST builders, SST readers, SST iterators, Bloom filters, and final prefix compression. Consult [Block](./week1-03-block.md), [Sorted String Table](./week1-04-sst.md), and [SST Optimizations](./week1-07-sst-optimizations.md) when a question requires deeper context.
 
-Because this path copies all seven test suites at the start, the accepted design should converge directly on the final Day 7 prefix-compressed block format. Do not first implement the Day 3 layout and silently replace it. The agent should explicitly ask which acceptance target applies and record that choice.
+Because this path copies all seven test suites at the start, the accepted design should converge directly on the final Day 7 prefix-compressed block format. Do not first implement the Day 3 layout and silently replace it. > **For the agent:** Explicitly ask which acceptance target applies and record that choice.
 
 First use concrete byte examples to derive the parts fixed by the course:
 
@@ -120,7 +120,7 @@ Treat the writer and reader as two parties implementing a protocol. A round-trip
 
 </details>
 
-The example begins with an operation the student can picture and names the concept afterward. A real implementation stop must still preview the files and focused test, wait for authorization, report actual evidence, and stop before beginning the next slice. An unexpected test failure either reveals a mechanical bug or reopens one specific decision.
+The example begins with an operation the student can picture and names the concept afterward. > **For the agent:** A real implementation stop must still preview the files and focused test, wait for authorization, report actual evidence, and stop before beginning the next slice. An unexpected test failure either reveals a mechanical bug or reopens one specific decision.
 
 Before approving the completed checkpoint, decode three keys by hand: one with no shared prefix, one with a long shared prefix, and one with an empty value. Confirm that a seek returns the first key greater than or equal to its target and that a Bloom-filter negative can never hide a present key.
 
@@ -132,7 +132,7 @@ Ask:
 
 This checkpoint covers the read path, write path, freezing, flushing, SST filtering, and iterator accounting. Use [Read Path](./week1-05-read-path.md) and [Write Path](./week1-06-write-path.md) when a decision needs more context.
 
-The agent must lead contract derivations for source ordering, tombstone filtering, scan bounds, flush selection, and lifecycle behavior. It should separately ask about open implementation choices such as iterator composition, lock scope that still preserves the synchronization contract, and where to perform expensive SST construction.
+> **For the agent:** You must lead contract derivations for source ordering, tombstone filtering, scan bounds, flush selection, and lifecycle behavior. Separately ask about open implementation choices such as iterator composition, lock scope that still preserves the synchronization contract, and where to perform expensive SST construction.
 
 The central source-priority rule should emerge from those choices:
 

--- a/mini-lsm-book/src/week1-fast-forward.md
+++ b/mini-lsm-book/src/week1-fast-forward.md
@@ -77,7 +77,9 @@ Ask:
 
 This checkpoint covers blocks, block iterators, SST builders, SST readers, SST iterators, Bloom filters, and final prefix compression. Consult [Block](./week1-03-block.md), [Sorted String Table](./week1-04-sst.md), and [SST Optimizations](./week1-07-sst-optimizations.md) when a question requires deeper context.
 
-Because this path copies all seven test suites at the start, the accepted design should converge directly on the final Day 7 prefix-compressed block format. Do not first implement the Day 3 layout and silently replace it. > **For the agent:** Explicitly ask which acceptance target applies and record that choice.
+Because this path copies all seven test suites at the start, the accepted design should converge directly on the final Day 7 prefix-compressed block format. Do not first implement the Day 3 layout and silently replace it.
+
+> **For the agent:** Explicitly ask which acceptance target applies and record that choice.
 
 First use concrete byte examples to derive the parts fixed by the course:
 
@@ -120,7 +122,9 @@ Treat the writer and reader as two parties implementing a protocol. A round-trip
 
 </details>
 
-The example begins with an operation the student can picture and names the concept afterward. > **For the agent:** A real implementation stop must still preview the files and focused test, wait for authorization, report actual evidence, and stop before beginning the next slice. An unexpected test failure either reveals a mechanical bug or reopens one specific decision.
+The example begins with an operation the student can picture and names the concept afterward.
+
+> **For the agent:** A real implementation stop must still preview the files and focused test, wait for authorization, report actual evidence, and stop before beginning the next slice. An unexpected test failure either reveals a mechanical bug or reopens one specific decision.
 
 Before approving the completed checkpoint, decode three keys by hand: one with no shared prefix, one with a long shared prefix, and one with an empty value. Confirm that a seek returns the first key greater than or equal to its target and that a Bloom-filter negative can never hide a present key.
 

--- a/mini-lsm-book/src/week2-fast-forward.md
+++ b/mini-lsm-book/src/week2-fast-forward.md
@@ -53,7 +53,7 @@ Ask:
 
 This checkpoint covers full compaction, the concat iterator, and the two-level read path. Use [Compaction Implementation](./week2-01-compaction.md) when a question needs more context.
 
-The agent should help you work out these course rules from small file states:
+> **For the agent:** Help the student work out these course rules from small file states:
 
 | Behavior to work out | Small case that exposes it |
 | --- | --- |
@@ -96,7 +96,7 @@ Follow this default sequence for each policy:
 3. add the policy to compaction dispatch, flushing, and reads; and
 4. stop for review before beginning the next policy.
 
-Do not treat “which policies should exist?” as a student preference: the completed Week 2 track implements all three. The policy algorithms are course rules; helper structure, allocation, and equivalent search methods may be genuine choices.
+> **For the agent:** Do not treat "which policies should exist?" as a student preference: the completed Week 2 track implements all three. The policy algorithms are course rules; helper structure, allocation, and equivalent search methods are genuine choices.
 
 ### Simple leveled
 
@@ -171,17 +171,21 @@ WAL:      key_len | key | value_len | value | checksum | ...
 
 The checksum covers the encoded record bytes, not itself. Integer byte order is part of the format. Validate lengths before slicing and verify a checksum before exposing its payload.
 
-For a flush or compaction that creates SSTs, the safe durable order is:
+For a flush or compaction that creates SSTs, you must decide the safe durable order. The steps are:
 
-```text
-write and sync new SSTs
-  -> sync the directory entries
-  -> append and sync the manifest record
-  -> delete obsolete inputs
-  -> sync the directory again
-```
+1. Write and sync new SSTs.
+2. Sync the directory entries.
+3. Append and sync the manifest record.
+4. Delete obsolete inputs.
+5. Sync the directory again.
 
-Recovery may see the old logical state or the new logical state at some crash boundaries. It must never see a durable manifest record that requires a missing file. An unreferenced new file or an undeleted obsolete file is tolerable because neither belongs to the recovered logical state.
+Each step depends on the previous one. Before the agent reveals the correct sequence, arrange these steps yourself and explain your reasoning:
+
+- At which point could a crash leave a durable manifest record pointing to a file that was never made durable?
+- At which point could a crash leave an orphaned SST file that the manifest does not reference?
+- Why must the directory be synced twice?
+
+After you propose an ordering, ask the agent to check it against the course rules and explain any difference.
 
 When WALs are enabled, create the WAL, sync its directory entry, and durably record `NewMemtable(id)` before making that memtable available for writes. `sync` must flush the `BufWriter` and then call `sync_all`. A durable flush record retires the WAL logically before its filename is removed. Recovery ignores such stale files, restores live immutable memtables newest to oldest, and sets `next_sst_id` to one greater than every live SST or WAL ID.
 

--- a/mini-lsm-book/src/week2-fast-forward.md
+++ b/mini-lsm-book/src/week2-fast-forward.md
@@ -171,13 +171,13 @@ WAL:      key_len | key | value_len | value | checksum | ...
 
 The checksum covers the encoded record bytes, not itself. Integer byte order is part of the format. Validate lengths before slicing and verify a checksum before exposing its payload.
 
-For a flush or compaction that creates SSTs, you must decide the safe durable order. The steps are:
+For a flush or compaction that creates SSTs, you must decide the safe durable order. The five steps below are **not** in the safe order — arrange them yourself:
 
-1. Write and sync new SSTs.
-2. Sync the directory entries.
-3. Append and sync the manifest record.
-4. Delete obsolete inputs.
-5. Sync the directory again.
+- Sync the directory entries.
+- Sync the directory again.
+- Delete obsolete inputs.
+- Append and sync the manifest record.
+- Write and sync new SSTs.
 
 Each step depends on the previous one. Before the agent reveals the correct sequence, arrange these steps yourself and explain your reasoning:
 


### PR DESCRIPTION
## Why

The fast-forward chapters mixed student-facing and agent-facing text, which confused readers because instructions directed at "the agent" appeared as bare prose. The durable SST ordering was handed to students as a completed sequence rather than a reasoning exercise. Week 1 also used "write-ahead log" without defining it.

## What changed

- Folded agent instructions into blockquoted "For the agent" sections in agent-fast-forward-overview.md (L67, L80, L121, L135), week1-fast-forward.md (L56, L88, L131, L156), and week2-fast-forward.md (L55, L122)
- Converted the durable SST ordering in week2-fast-forward.md from a handout (pre-ordered list) into a guided exercise where students arrange the five steps themselves and answer three crash-boundary questions before the agent reveals the correct order
- Added a one-sentence WAL definition in week1-01-memtable.md after the first `create_with_wal` example

AI-Assisted: DeepSeek V4 Pro + Sentinel