### PR TITLE
Align README with published Week 4 closing chapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ cargo run --bin compaction-simulator-mvcc-ref
 
 ## Guided Course Structure
 
-The guided course has three complete weeks and a closing chapter with guided next steps.
+The guided course has three complete weeks.
 
 * Week 1: Storage Format + Engine Skeleton
 * Week 2: Compaction and Persistence

--- a/README.md
+++ b/README.md
@@ -97,12 +97,12 @@ cargo run --bin compaction-simulator-mvcc-ref
 
 ## Guided Course Structure
 
-The guided course has three complete weeks and an open-ended collection of future optimizations.
+The guided course has three complete weeks and a closing chapter with guided next steps.
 
 * Week 1: Storage Format + Engine Skeleton
 * Week 2: Compaction and Persistence
 * Week 3: Multi-Version Concurrency Control
-* The Rest of Your Life: Optional optimizations (TBD)
+* The Rest of Your Life: Closing chapter with expansion paths
 
 | Week + Chapter | Topic                                                       |
 | -------------- | ----------------------------------------------------------- |


### PR DESCRIPTION
## Why

PR #226 replaced the empty Week 4 TBD table with a full closing chapter, but the README still says "open-ended collection of future optimizations" and "Optional optimizations (TBD)".

## What changed

Two-line README-only fix: replaced stale descriptions with wording that matches the published closing chapter.

AI-Assisted: DeepSeek V4 Pro + Sentinel