### PR TITLE
Add CTA links to the Sponsor page

### DIFF
--- a/mini-lsm-book/custom.css
+++ b/mini-lsm-book/custom.css
@@ -80,4 +80,21 @@
         width: 32px;
         height: 32px;
     }
+    .raft-cta {
+        flex-direction: column;
+        gap: 8px;
+    }
+}
+
+.raft-cta {
+    display: flex;
+    gap: 16px;
+    margin-top: 24px;
+    padding-top: 16px;
+    border-top: 1px solid var(--border-color, #d0d7de);
+    font-size: 0.95em;
+}
+
+.raft-cta a {
+    font-weight: 600;
 }

--- a/mini-lsm-book/src/sponsor.md
+++ b/mini-lsm-book/src/sponsor.md
@@ -98,3 +98,8 @@ The result is a course where every explanation, command, and test has been check
 </div>
 
 </div>
+
+<div class="raft-cta">
+  <p><a href="https://github.com/skyzh/mini-lsm">View on GitHub</a></p>
+  <p><a href="./00-preface.html">Start the course from the beginning →</a></p>
+</div>


### PR DESCRIPTION
## Why

The sponsor page should provide useful links to the project and course.

## What changed

Added two calls to action at the bottom of the sponsor page: "View on GitHub" and "Start the course from the beginning →". Responsive CSS with flex layout.

AI-Assisted: DeepSeek V4 Pro + Sentinel