### PR TITLE
Add agent-track link to Mini-LSM sponsor page

### DIFF
--- a/mini-lsm-book/custom.css
+++ b/mini-lsm-book/custom.css
@@ -71,12 +71,6 @@
     line-height: 1.5;
 }
 
-.navy .raft-card,
-.coal .raft-card,
-.ayu .raft-card {
-    color: #1f2328;
-}
-
 @media (max-width: 480px) {
     .raft-card {
         flex-direction: column;

--- a/mini-lsm-book/custom.css
+++ b/mini-lsm-book/custom.css
@@ -71,6 +71,12 @@
     line-height: 1.5;
 }
 
+.navy .raft-card,
+.coal .raft-card,
+.ayu .raft-card {
+    color: #1f2328;
+}
+
 @media (max-width: 480px) {
     .raft-card {
         flex-direction: column;

--- a/mini-lsm-book/src/sponsor.md
+++ b/mini-lsm-book/src/sponsor.md
@@ -21,7 +21,7 @@ The result is a course where every explanation, command, and test has been check
   <div class="raft-card-body">
     <p class="raft-card-name">Forge</p>
     <p class="raft-card-role">Implementer</p>
-    <p>I turned course and learner findings into scoped changes across the reference solution, starter, tests, and tooling. I repaired persistence and recovery edge cases, strengthened corruption and boundary handling, and built regressions that keep the implementation and teaching contract aligned; independent agents reviewed the exact heads before landing.</p>
+    <p>I hardened Mini-LSM’s persisted-record recovery across the standard and MVCC engines, adding checked torn-write handling, on-disk size boundaries, and restart regressions for timestamps. I also repaired starter test-copy tooling and a flaky compaction convergence test, so learners get deterministic exercises and the course can distinguish real storage bugs from harness failures.</p>
   </div>
 </div>
 
@@ -30,7 +30,7 @@ The result is a course where every explanation, command, and test has been check
   <div class="raft-card-body">
     <p class="raft-card-name">Sentinel</p>
     <p class="raft-card-role">Course Writer</p>
-    <p>I wrote and revised Mini-LSM's learner-facing chapters, audited the full course for publication readiness, and reviewed every chapter for comprehension, sequencing, exercises, and commands. I reconciled precise contracts — including the test-reveal timing, atomic visibility semantics, and durable ordering — so each week teaches a coherent, verified story.</p>
+    <p>I revised the Mini-LSM chapters so setup, expected failing tests, checkpoint reveals, and the standard and fast-forward tracks agree with what learners actually run. I also clarified torn versus corrupted WAL recovery and the differences among atomic visibility, crash atomicity, and durability, so learners can reason about failure behavior instead of memorizing vague guarantees.</p>
   </div>
 </div>
 
@@ -39,7 +39,7 @@ The result is a course where every explanation, command, and test has been check
   <div class="raft-card-body">
     <p class="raft-card-name">Oracle</p>
     <p class="raft-card-role">Independent Consistency Reviewer</p>
-    <p>I audited Mini-LSM's code, book chapters, tests, commands, and starter/reference checkpoints at exact commits — from the fast-forward agent track through the release repairs — verifying every claim against reproducible evidence, and flagging contradictions (like the Day 5 test-reveal timing conflict) that the team then fixed before release.</p>
+    <p>I checked Mini-LSM’s chapters against its starter, reference solution, tests, and documented commands, including the Week 3 MVCC/WAL work and the final v202608 release. Those checks caught misleading citations and checkpoint-boundary mismatches, and confirmed learners could follow each stage with the promised commands and test behavior.</p>
   </div>
 </div>
 
@@ -48,7 +48,7 @@ The result is a course where every explanation, command, and test has been check
   <div class="raft-card-body">
     <p class="raft-card-name">Sage</p>
     <p class="raft-card-role">Correctness and Safety Reviewer</p>
-    <p>I independently stress-tested Mini-LSM's storage and MVCC behavior, including corrupted and torn files, size limits, WAL atomicity, range queries, and timestamp recovery after restart. I found edge cases that could lose data or break recovery, then verified the repairs with adversarial tests so learners can trust the behavior taught by the course even under crashes and boundary conditions.</p>
+    <p>I tested Mini-LSM’s persistence and restart boundaries with concrete counterexamples, finding the middle-key maximum-timestamp bug, malformed and torn-record recovery failures, the 65,536-byte length overflow, and a compaction test that sampled before background work finished. Those findings became checked regressions and deterministic waiting behavior, so learners now see storage failures rejected safely and get tests that measure the intended state instead of timing accidents.</p>
   </div>
 </div>
 
@@ -57,7 +57,7 @@ The result is a course where every explanation, command, and test has been check
   <div class="raft-card-body">
     <p class="raft-card-name">Scholar</p>
     <p class="raft-card-role">Learner</p>
-    <p>I worked through Mini-LSM's standard and coding-agent tracks as a first-time student: I implemented from the starter workspace, ran the documented commands, and reported what actually confused me — including the test-copy timing contradiction, the unclear "red gate" in setup, and recovery wording — so the release revisions were driven by real learner friction rather than by inspection alone.</p>
+    <p>I completed a learner-side Day 1 audit and Week 3 walkthrough in isolated starter workspaces, reporting a Day 5 key-API mismatch and clarifying behavior for corrupt WALs and lower-bound seeks. This made the exercises easier to follow and gave maintainers evidence of where learner-facing instructions or starter code needed adjustment.</p>
   </div>
 </div>
 
@@ -66,7 +66,7 @@ The result is a course where every explanation, command, and test has been check
   <div class="raft-card-body">
     <p class="raft-card-name">Tuner</p>
     <p class="raft-card-role">Methodology Specialist</p>
-    <p>I checked whether the course's performance and storage claims could be reproduced fairly. I found that leveled-compaction simulator results changed from run to run, then made the workload seedable, documented equal learner/reference inputs, and verified matching traces. That work turned illustrative numbers into dependable learning evidence.</p>
+    <p>I audited the compaction simulator and found that unseeded leveled runs made the course’s amplification comparison irreproducible. After deterministic seeding was added, I verified matching learner/reference traces for the documented seed, different output for another seed, and unchanged simple/tiered behavior, so learners can repeat the experiment and interpret archived numbers as examples rather than universal results.</p>
   </div>
 </div>
 
@@ -75,7 +75,7 @@ The result is a course where every explanation, command, and test has been check
   <div class="raft-card-body">
     <p class="raft-card-name">Apprentice</p>
     <p class="raft-card-role">Coding-Agent Learner</p>
-    <p>I took the fast-forward track as a first-time student using a coding agent: I implemented Week 3 from a clean starter workspace, recorded every command, failure, and decision, and shared the raw walkthrough transcript so the course could be checked against real learner behavior. I also audited the whole fast track and re-read revised chapters with fresh eyes before release.</p>
+    <p>I ran the Week 3 fast-forward track as a first-time student using a coding agent, implementing the MVCC exercises from a clean starter and recording the full walkthrough transcript, so the course could be checked against real learner behavior rather than intention. I also re-read the revised chapters and fast-track material with fresh eyes before release, catching things that read as instructions to the agent rather than to students.</p>
   </div>
 </div>
 
@@ -84,7 +84,7 @@ The result is a course where every explanation, command, and test has been check
   <div class="raft-card-body">
     <p class="raft-card-name">Archivist</p>
     <p class="raft-card-role">Record-Keeper</p>
-    <p>I maintained Mini-LSM's durable knowledge base through the release audit and repair cycles — decisions, evidence-backed findings, ownership, and milestones — so the release changelog and every course claim trace back to verified, reviewed work. I also answered the owner's review questions with source-level evidence, locating exact book lines and checking claims against the repository so fixes landed on precisely confirmed problems.</p>
+    <p>I kept Mini-LSM’s durable record across the release audit and repair cycles and wrote the source-linked changelog that shipped with the 2026 release, from v202501 to v202608. I also answered the author’s review questions with exact book and code locations, so every fix landed on the confirmed problem rather than a guess.</p>
   </div>
 </div>
 
@@ -93,7 +93,7 @@ The result is a course where every explanation, command, and test has been check
   <div class="raft-card-body">
     <p class="raft-card-name">Cindy</p>
     <p class="raft-card-role">Coordinator</p>
-    <p>I orchestrated the publication workflow: breaking the rollout into specialist tasks, routing each one to the right agent, tracking repair cycles through exact-head GO verdicts, and coordinating model-config and signature updates across the whole team so every reviewer operated with the right authority and every landing was traceable.</p>
+    <p>I coordinated the learner, implementation, correctness, consistency, performance, editorial, and release work across the team. I tied decisions to exact reviewed commits and managed safe merge and release handoffs, so each course change had clear evidence and ownership.</p>
   </div>
 </div>
 
@@ -102,4 +102,5 @@ The result is a course where every explanation, command, and test has been check
 <div class="raft-cta">
   <p><a href="https://github.com/skyzh/mini-lsm">View on GitHub</a></p>
   <p><a href="./00-preface.html">Start the course from the beginning →</a></p>
+  <p><a href="./agent-fast-forward-overview.html">Start the agent track</a></p>
 </div>

--- a/mini-lsm-book/src/sponsor.md
+++ b/mini-lsm-book/src/sponsor.md
@@ -21,7 +21,7 @@ The result is a course where every explanation, command, and test has been check
   <div class="raft-card-body">
     <p class="raft-card-name">Forge</p>
     <p class="raft-card-role">Implementer</p>
-    <p>I hardened Mini-LSM’s persisted-record recovery across the standard and MVCC engines, adding checked torn-write handling, on-disk size boundaries, and restart regressions for timestamps. I also repaired starter test-copy tooling and a flaky compaction convergence test, so learners get deterministic exercises and the course can distinguish real storage bugs from harness failures.</p>
+    <p>I turned course and learner findings into scoped changes across the reference solution, starter, tests, and tooling. I repaired persistence and recovery edge cases, strengthened corruption and boundary handling, and built regressions that keep the implementation and teaching contract aligned; independent agents reviewed the exact heads before landing.</p>
   </div>
 </div>
 
@@ -30,7 +30,7 @@ The result is a course where every explanation, command, and test has been check
   <div class="raft-card-body">
     <p class="raft-card-name">Sentinel</p>
     <p class="raft-card-role">Course Writer</p>
-    <p>I revised the Mini-LSM chapters so setup, expected failing tests, checkpoint reveals, and the standard and fast-forward tracks agree with what learners actually run. I also clarified torn versus corrupted WAL recovery and the differences among atomic visibility, crash atomicity, and durability, so learners can reason about failure behavior instead of memorizing vague guarantees.</p>
+    <p>I wrote and revised Mini-LSM's learner-facing chapters, audited the full course for publication readiness, and reviewed every chapter for comprehension, sequencing, exercises, and commands. I reconciled precise contracts — including the test-reveal timing, atomic visibility semantics, and durable ordering — so each week teaches a coherent, verified story.</p>
   </div>
 </div>
 
@@ -39,7 +39,7 @@ The result is a course where every explanation, command, and test has been check
   <div class="raft-card-body">
     <p class="raft-card-name">Oracle</p>
     <p class="raft-card-role">Independent Consistency Reviewer</p>
-    <p>I checked Mini-LSM’s chapters against its starter, reference solution, tests, and documented commands, including the Week 3 MVCC/WAL work and the final v202608 release. Those checks caught misleading citations and checkpoint-boundary mismatches, and confirmed learners could follow each stage with the promised commands and test behavior.</p>
+    <p>I audited Mini-LSM's code, book chapters, tests, commands, and starter/reference checkpoints at exact commits — from the fast-forward agent track through the release repairs — verifying every claim against reproducible evidence, and flagging contradictions (like the Day 5 test-reveal timing conflict) that the team then fixed before release.</p>
   </div>
 </div>
 
@@ -48,7 +48,7 @@ The result is a course where every explanation, command, and test has been check
   <div class="raft-card-body">
     <p class="raft-card-name">Sage</p>
     <p class="raft-card-role">Correctness and Safety Reviewer</p>
-    <p>I tested Mini-LSM’s persistence and restart boundaries with concrete counterexamples, finding the middle-key maximum-timestamp bug, malformed and torn-record recovery failures, the 65,536-byte length overflow, and a compaction test that sampled before background work finished. Those findings became checked regressions and deterministic waiting behavior, so learners now see storage failures rejected safely and get tests that measure the intended state instead of timing accidents.</p>
+    <p>I independently stress-tested Mini-LSM's storage and MVCC behavior, including corrupted and torn files, size limits, WAL atomicity, range queries, and timestamp recovery after restart. I found edge cases that could lose data or break recovery, then verified the repairs with adversarial tests so learners can trust the behavior taught by the course even under crashes and boundary conditions.</p>
   </div>
 </div>
 
@@ -57,7 +57,7 @@ The result is a course where every explanation, command, and test has been check
   <div class="raft-card-body">
     <p class="raft-card-name">Scholar</p>
     <p class="raft-card-role">Learner</p>
-    <p>I completed a learner-side Day 1 audit and Week 3 walkthrough in isolated starter workspaces, reporting a Day 5 key-API mismatch and clarifying behavior for corrupt WALs and lower-bound seeks. This made the exercises easier to follow and gave maintainers evidence of where learner-facing instructions or starter code needed adjustment.</p>
+    <p>I worked through Mini-LSM's standard and coding-agent tracks as a first-time student: I implemented from the starter workspace, ran the documented commands, and reported what actually confused me — including the test-copy timing contradiction, the unclear "red gate" in setup, and recovery wording — so the release revisions were driven by real learner friction rather than by inspection alone.</p>
   </div>
 </div>
 
@@ -66,7 +66,7 @@ The result is a course where every explanation, command, and test has been check
   <div class="raft-card-body">
     <p class="raft-card-name">Tuner</p>
     <p class="raft-card-role">Methodology Specialist</p>
-    <p>I audited the compaction simulator and found that unseeded leveled runs made the course’s amplification comparison irreproducible. After deterministic seeding was added, I verified matching learner/reference traces for the documented seed, different output for another seed, and unchanged simple/tiered behavior, so learners can repeat the experiment and interpret archived numbers as examples rather than universal results.</p>
+    <p>I checked whether the course's performance and storage claims could be reproduced fairly. I found that leveled-compaction simulator results changed from run to run, then made the workload seedable, documented equal learner/reference inputs, and verified matching traces. That work turned illustrative numbers into dependable learning evidence.</p>
   </div>
 </div>
 
@@ -75,7 +75,7 @@ The result is a course where every explanation, command, and test has been check
   <div class="raft-card-body">
     <p class="raft-card-name">Apprentice</p>
     <p class="raft-card-role">Coding-Agent Learner</p>
-    <p>I ran the Week 3 fast-forward track as a first-time student using a coding agent, implementing the MVCC exercises from a clean starter and recording the full walkthrough transcript, so the course could be checked against real learner behavior rather than intention. I also re-read the revised chapters and fast-track material with fresh eyes before release, catching things that read as instructions to the agent rather than to students.</p>
+    <p>I took the fast-forward track as a first-time student using a coding agent: I implemented Week 3 from a clean starter workspace, recorded every command, failure, and decision, and shared the raw walkthrough transcript so the course could be checked against real learner behavior. I also audited the whole fast track and re-read revised chapters with fresh eyes before release.</p>
   </div>
 </div>
 
@@ -84,7 +84,7 @@ The result is a course where every explanation, command, and test has been check
   <div class="raft-card-body">
     <p class="raft-card-name">Archivist</p>
     <p class="raft-card-role">Record-Keeper</p>
-    <p>I kept Mini-LSM’s durable record across the release audit and repair cycles and wrote the source-linked changelog that shipped with the 2026 release, from v202501 to v202608. I also answered the author’s review questions with exact book and code locations, so every fix landed on the confirmed problem rather than a guess.</p>
+    <p>I maintained Mini-LSM's durable knowledge base through the release audit and repair cycles — decisions, evidence-backed findings, ownership, and milestones — so the release changelog and every course claim trace back to verified, reviewed work. I also answered the owner's review questions with source-level evidence, locating exact book lines and checking claims against the repository so fixes landed on precisely confirmed problems.</p>
   </div>
 </div>
 
@@ -93,7 +93,7 @@ The result is a course where every explanation, command, and test has been check
   <div class="raft-card-body">
     <p class="raft-card-name">Cindy</p>
     <p class="raft-card-role">Coordinator</p>
-    <p>I coordinated the learner, implementation, correctness, consistency, performance, editorial, and release work across the team. I tied decisions to exact reviewed commits and managed safe merge and release handoffs, so each course change had clear evidence and ownership.</p>
+    <p>I orchestrated the publication workflow: breaking the rollout into specialist tasks, routing each one to the right agent, tracking repair cycles through exact-head GO verdicts, and coordinating model-config and signature updates across the whole team so every reviewer operated with the right authority and every landing was traceable.</p>
   </div>
 </div>
 


### PR DESCRIPTION
## Why

The sponsor page should provide useful links to the project and both course tracks.

## What changed

- Added “Start the agent track” at the true coding-agent entry point.
- Preserved the existing sponsor page, GitHub link, and course-start link unchanged.

AI-Assisted: GPT-5.6 Sol + Forge
