### PR TITLE
chore: advance course crates after 0.3 publication

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -406,7 +406,7 @@ checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "mini-lsm"
-version = "0.2.1"
+version = "0.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -430,7 +430,7 @@ dependencies = [
 
 [[package]]
 name = "mini-lsm-mvcc"
-version = "0.2.1"
+version = "0.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -454,7 +454,7 @@ dependencies = [
 
 [[package]]
 name = "mini-lsm-starter"
-version = "0.2.1"
+version = "0.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -477,7 +477,7 @@ dependencies = [
 
 [[package]]
 name = "mini-lsm-xtask"
-version = "0.2.1"
+version = "0.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -406,7 +406,7 @@ checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "mini-lsm"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -430,7 +430,7 @@ dependencies = [
 
 [[package]]
 name = "mini-lsm-mvcc"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -454,7 +454,7 @@ dependencies = [
 
 [[package]]
 name = "mini-lsm-starter"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -477,7 +477,7 @@ dependencies = [
 
 [[package]]
 name = "mini-lsm-xtask"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["mini-lsm", "xtask", "mini-lsm-starter", "mini-lsm-mvcc"]
 resolver = "3"
 
 [workspace.package]
-version = "0.2.1"
+version = "0.4.0-alpha.1"
 edition = "2024"
 rust-version = "1.97.1"
 homepage = "https://github.com/skyzh/mini-lsm"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["mini-lsm", "xtask", "mini-lsm-starter", "mini-lsm-mvcc"]
 resolver = "3"
 
 [workspace.package]
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 rust-version = "1.97.1"
 homepage = "https://github.com/skyzh/mini-lsm"

--- a/mini-lsm-starter/Cargo.toml
+++ b/mini-lsm-starter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mini-lsm-starter"
-version = "0.2.1"
+version = "0.4.0-alpha.1"
 edition = "2024"
 rust-version = "1.97.1"
 publish = false

--- a/mini-lsm-starter/Cargo.toml
+++ b/mini-lsm-starter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mini-lsm-starter"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 rust-version = "1.97.1"
 publish = false


### PR DESCRIPTION
## Summary

- publish the real `mini-lsm` and `mini-lsm-mvcc` packages at 0.3.0
- publish the reserved `mini-lsm-starter` placeholder at 0.3.0 because the learner crate remains intentionally non-publishable
- advance the workspace and starter package metadata to 0.4.0-alpha.1
- refresh only the four workspace package versions in `Cargo.lock`

## Why

The three public crate names now have live, unyanked 0.3.0 releases. Keeping the repository at 0.4.0-alpha.1 distinguishes the continuing course source from the registry release while accurately marking the next line as prerelease work.

The workspace currently has no local directory dependencies, so there are no `path` dependencies that need an accompanying `version` requirement.

## Verification

- `cargo publish --dry-run --allow-dirty -p mini-lsm`
- `cargo publish --dry-run --allow-dirty -p mini-lsm-mvcc`
- `cargo publish --dry-run --allow-dirty --manifest-path mini-lsm-starter-placeholder-03/Cargo.toml`
- `cargo check --workspace --all-targets`
- `git diff --check`

This PR does not create a Git tag or GitHub release, merge itself, or deploy the course.
